### PR TITLE
Bugix/docupdates

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -51,7 +51,7 @@ const blueprint = blueprints.EksBlueprint.builder()
     .repository({
         repoUrl: 'cdk-eks-blueprints-patterns',
         credentialsSecretName: 'github-token',
-        branch: 'main'
+        targetRevision: 'main'
     })
 ```
 

--- a/lib/addons/ssm-agent/index.ts
+++ b/lib/addons/ssm-agent/index.ts
@@ -46,7 +46,7 @@ export class SSMAgentAddOn implements ClusterAddOn {
                         ],
                         initContainers: [
                             {
-                                image: "public.ecr.aws/y9z4e3w0/eks-blueprints-test/addon-ssm-agent:3.0.1390.0",
+                                image: "public.ecr.aws/y9z4e3w0/eks-ssp-test/addon-ssm-agent:3.0.1390.0",
                                 imagePullPolicy: "Always",
                                 name: "ssm-install",
                                 securityContext: {

--- a/lib/addons/ssm-agent/index.ts
+++ b/lib/addons/ssm-agent/index.ts
@@ -46,7 +46,7 @@ export class SSMAgentAddOn implements ClusterAddOn {
                         ],
                         initContainers: [
                             {
-                                image: "public.ecr.aws/y9z4e3w0/eks-ssp-test/addon-ssm-agent:3.0.1390.0",
+                                image: "public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:3.1.90.0",
                                 imagePullPolicy: "Always",
                                 name: "ssm-install",
                                 securityContext: {

--- a/lib/addons/ssm-agent/index.ts
+++ b/lib/addons/ssm-agent/index.ts
@@ -21,6 +21,7 @@ export class SSMAgentAddOn implements ClusterAddOn {
             kind: "DaemonSet",
             metadata: {
                 name: "ssm-installer",
+                namespace: "kube-system"
             },
             spec: {
                 selector: { matchLabels: appLabel },

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -132,6 +132,7 @@ export class GenericClusterProvider implements ClusterProvider {
         const clusterOptions = {...this.props, ...defaultOptions };
         // Create an EKS Cluster
         const cluster = this.internalCreateCluster(scope, id, clusterOptions);
+        cluster.node.addDependency(vpc);
 
         const nodeGroups: eks.Nodegroup[] = [];
         
@@ -213,7 +214,7 @@ export class GenericClusterProvider implements ClusterProvider {
         const desiredSize = nodeGroup.desiredSize ?? valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize);
 
         // Create a managed node group.
-        const commonNodegroupProps = {
+        const commonNodegroupProps: Partial<eks.NodegroupOptions> = {
             nodegroupName: nodeGroup.id,
             capacityType,
             instanceTypes,
@@ -222,14 +223,14 @@ export class GenericClusterProvider implements ClusterProvider {
             desiredSize
         };
 
-        let nodegroupProps: eks.NodegroupOptions;
+        let nodegroupOptions: eks.NodegroupOptions;
         if(nodeGroup.customAmi) {
             // Create launch template if custom AMI is provided.
             const lt = new ec2.LaunchTemplate(cluster, `${nodeGroup.id}-lt`, {
                 machineImage: nodeGroup.customAmi?.machineImage,
                 userData: nodeGroup.customAmi?.userData,
             });
-            nodegroupProps = {
+            nodegroupOptions = {
                 ...commonNodegroupProps,
                 launchTemplateSpec: {
                     id: lt.launchTemplateId!,
@@ -237,14 +238,13 @@ export class GenericClusterProvider implements ClusterProvider {
                 },
             };
         } else {
-            nodegroupProps = {
+            nodegroupOptions = {
                 ...commonNodegroupProps,
                 amiType,
-
                 releaseVersion,
             };
         }
 
-        return cluster.addNodegroupCapacity(nodeGroup.id + "-ng", nodegroupProps);
+        return cluster.addNodegroupCapacity(nodeGroup.id + "-ng", nodegroupOptions);
     }
 }

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -1,14 +1,14 @@
 
+import * as cdk from 'aws-cdk-lib';
+import { StackProps } from 'aws-cdk-lib';
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
-import * as cdk from 'aws-cdk-lib';
-import * as lodash from "lodash";
 import { Construct } from 'constructs';
-import { StackProps } from 'aws-cdk-lib';
+import * as lodash from "lodash";
 import { MngClusterProvider } from '../cluster-providers/mng-cluster-provider';
 import { VpcProvider } from '../resource-providers/vpc';
 import * as spi from '../spi';
-import { getAddOnNameOrId, withUsageTracking, setupClusterLogging } from '../utils';
+import { getAddOnNameOrId, setupClusterLogging, withUsageTracking } from '../utils';
 
 export class EksBlueprintProps {
 
@@ -181,7 +181,7 @@ export class EksBlueprint extends cdk.Stack {
 
         const version = blueprintProps.version ?? KubernetesVersion.V1_21;
         const clusterProvider = blueprintProps.clusterProvider ?? new MngClusterProvider({ 
-            id: `${blueprintProps.name}-ng`,
+            id: `${ blueprintProps.name ?? blueprintProps.id }-ng`,
             version
         });
 

--- a/lib/utils/secrets-manager-utils.ts
+++ b/lib/utils/secrets-manager-utils.ts
@@ -6,7 +6,7 @@ import { SecretsManager } from "aws-sdk";
  * @returns 
 */
  export async function getSecretValue(secretName: string, region: string): Promise<string> {
-    const secretManager = new SecretsManager({ region: region });
+    const secretManager = new SecretsManager({ region });
     let secretString = "";
     try {
         let response = await secretManager.getSecretValue({ SecretId: secretName }).promise();
@@ -21,6 +21,22 @@ import { SecretsManager } from "aws-sdk";
     }
     catch (error) {
         console.log(`error getting secret ${secretName}: `  + error);
+        throw error;
+    }
+}
+
+/**
+ * Throws an error if secret is undefined in the target region.
+ * @returns ARN of the secret if exists.
+ */
+export async function validateSecret(secretName: string, region: string): Promise<string> {
+    const secretManager = new SecretsManager({ region });
+    try {
+        const response = await secretManager.describeSecret({ SecretId: secretName }).promise();
+        return response.ARN!;
+    }
+    catch (error) {
+        console.log(`Secret ${secretName} is not defined: `  + error);
         throw error;
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - AWS XRay: 'addons/xray.md'
   - Cluster Providers: 
     - Overview: 'cluster-providers/index.md'
+    - Generic Cluster Provider: 'cluster-providers/generic-cluster-provider.md'
     - ASG Cluster Provider: 'cluster-providers/asg-cluster-provider.md'
     - MNG Cluster Provider: 'cluster-providers/mng-cluster-provider.md'
     - Fargate Cluster Provider: 'cluster-providers/fargate-cluster-provider.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
Nodegroup name defaults now to stackId + "-ng" as opposed to undefined-ng
Dependency between vpc and cluster as potentially an issue for non-routable service IP CIDR
SSM agent image updated to point to AWS maintained public ECR repo (based on recommendation from @askulkarni2).
SSM agent moved to kube-system (was in default) namespace.
Minor doc updates: nav pane

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
