### PR TITLE
Created custom deep clone function, refactored code, removed lodash s…

### DIFF
--- a/launch.json
+++ b/launch.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "jest",
+            "request": "launch",
+            "runtimeExecutable": "npm",
+            "runtimeArgs":[
+                "test"
+            ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "cdk-launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "runtimeArgs": [
+                "-r",
+                "./node_modules/ts-node/register/transpile-only"
+            ],
+            "args": [
+                "./node_modules/aws-cdk/bin/cdk.js",
+                "-c", "config=cicd", "synth"
+            ]
+        }
+    ]
+}

--- a/lib/addons/cluster-autoscaler/index.ts
+++ b/lib/addons/cluster-autoscaler/index.ts
@@ -35,11 +35,11 @@ const defaultProps = {
  * Version of the autoscaler, controls the image tag
  */
 const versionMap = new Map([
+    [KubernetesVersion.V1_22, "9.11.0"],
     [KubernetesVersion.V1_21, "9.10.8"],
     [KubernetesVersion.V1_20, "9.9.2"],
     [KubernetesVersion.V1_19, "9.4.0"],
     [KubernetesVersion.V1_18, "9.4.0"],
-    [KubernetesVersion.V1_17, "9.4.0"]
 ]);
 
 export class ClusterAutoScalerAddOn extends HelmAddOn {
@@ -56,7 +56,8 @@ export class ClusterAutoScalerAddOn extends HelmAddOn {
 
         if(this.options.version?.trim() === 'auto') {
             this.options.version = versionMap.get(clusterInfo.version);
-            assert(this.options.version, `Unable to auto-detect cluster autoscaler version for EKS cluster version ${clusterInfo.version}`);
+            assert(this.options.version, "Unable to auto-detect cluster autoscaler version. Applying latest. Provided EKS cluster version: " 
+                + clusterInfo.version?.version ?? clusterInfo.version);
         } 
 
         const cluster = clusterInfo.cluster;

--- a/lib/addons/helm-addon/index.ts
+++ b/lib/addons/helm-addon/index.ts
@@ -1,7 +1,7 @@
 import { Duration } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as spi from "../..";
-import * as lodash from "lodash";
+import { cloneDeep } from "../../utils";
 import { HelmChartConfiguration, KubectlProvider } from "./kubectl-provider";
 
 export type HelmAddOnProps = HelmChartConfiguration;
@@ -12,7 +12,7 @@ export abstract class HelmAddOn implements spi.ClusterAddOn {
     props: HelmAddOnProps;
 
     constructor(props: HelmAddOnProps) {
-        this.props = lodash.cloneDeep(props); // avoids polution when reusing the same props across stacks, such as values
+        this.props = cloneDeep(props); // avoids polution when reusing the same props across stacks, such as values
     }
     
     abstract deploy(clusterInfo: spi.ClusterInfo): void | Promise<Construct>;

--- a/lib/addons/secrets-store/index.ts
+++ b/lib/addons/secrets-store/index.ts
@@ -2,7 +2,7 @@ import { Construct } from "constructs";
 import { ClusterAddOn, ClusterInfo } from '../../spi';
 import { HelmAddOnUserProps } from '../helm-addon';
 import { CsiDriverProviderAws } from './csi-driver-provider-aws';
-import * as lodash from "lodash";
+import { cloneDeep } from "../../utils";
 
 /**
  * Configuration options for Secrets Store AddOn
@@ -58,7 +58,7 @@ export class SecretsStoreAddOn implements ClusterAddOn {
     private options: SecretsStoreAddOnProps;
 
     constructor(props?: SecretsStoreAddOnProps) {
-        this.options = lodash.cloneDeep({ ...defaultProps, ...props });
+        this.options = cloneDeep({ ...defaultProps, ...props });
     }
 
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -4,7 +4,7 @@ import { StackProps } from 'aws-cdk-lib';
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import { Construct } from 'constructs';
-import * as lodash from "lodash";
+import { cloneDeep } from "../utils";
 import { MngClusterProvider } from '../cluster-providers/mng-cluster-provider';
 import { VpcProvider } from '../resource-providers/vpc';
 import * as spi from '../spi';
@@ -103,7 +103,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
 
     public withBlueprintProps(props: Partial<EksBlueprintProps>): this {
         const resourceProviders = this.props.resourceProviders!;
-        this.props = { ...this.props, ...lodash.cloneDeep(props)};
+        this.props = { ...this.props, ...cloneDeep(props) };
         if(props.resourceProviders) {
             this.props.resourceProviders = new Map([...resourceProviders!.entries(), ...props.resourceProviders.entries()]);
         }

--- a/lib/utils/object-utils.ts
+++ b/lib/utils/object-utils.ts
@@ -1,3 +1,5 @@
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
 export const setPath = (obj : any, path: string, val: any) => { 
     const keys = path.split('.');
     const lastKey = keys.pop()!;
@@ -6,3 +8,19 @@ export const setPath = (obj : any, path: string, val: any) => {
         obj); 
     lastObj[lastKey] = val;
 };
+
+export function cloneDeep<T>(source: T): T {
+    return Array.isArray(source)
+    ? source.map(item => cloneDeep(item))
+    : source instanceof Date
+    ? new Date(source.getTime())
+    : source instanceof KubernetesVersion
+    ? source
+    : source && typeof source === 'object'
+          ? Object.getOwnPropertyNames(source).reduce((o, prop) => {
+             Object.defineProperty(o, prop, Object.getOwnPropertyDescriptor(source, prop)!);
+             o[prop] = cloneDeep((source as { [key: string]: any })[prop]);
+             return o;
+          }, Object.create(Object.getPrototypeOf(source)))
+    : source as T;
+  }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "dependencies": {
         "@types/assert": "^1.5.6",
         "@types/bcrypt": "^5.0.0",
-        "@types/lodash": "^4.14.180",
         "aws-cdk-lib": "2.20.0",
         "aws-sdk": "2.1069.0",
         "bcrypt": "^5.0.1",

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -256,6 +256,24 @@ test("Building blueprint with builder properly clones properties", () => {
 
 });
 
+test("Building blueprint with version correctly passes k8s version to the cluster", () => {
+
+    const app = new cdk.App();
+
+    const blueprint = blueprints.EksBlueprint.builder().name("builer-version-test1")
+        .addOns(new blueprints.ClusterAutoScalerAddOn);
+    expect(blueprint.props.addOns).toHaveLength(1);
+
+    blueprint.withBlueprintProps({
+        version: KubernetesVersion.V1_22
+    });
+
+    const stack = blueprint.build(app, "builder-version-test1");
+
+    expect(stack.getClusterInfo().version).toBeDefined();
+ 
+});
+
 function assertBlueprint(stack: blueprints.EksBlueprint, ...charts: string[]) {
     const template = Template.fromStack(stack);
     for (let chart of charts) {


### PR DESCRIPTION
…ince it did not preserve types, added unit test, added 1.22 version to cluster autoscaler.

*Issue #, if available:*

*Description of changes:*
Deep clone refactored
Cluster Autoscaler supports k8s v1.22
Unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
