### PR TITLE
fixing issue for team manifest dir

### DIFF
--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -12,24 +12,15 @@ import request from 'sync-request';
  * @param namespaceManifest 
  */
 export function applyYamlFromDir(dir: string, cluster: eks.Cluster, namespaceManifest: KubernetesManifest): void {
-    fs.readdir(dir, 'utf8', (err, files) => {
-        if (files != undefined) {
-            files.forEach((file) => {
-                if (file.split('.').pop() == 'yaml') {
-                    fs.readFile(dir + file, 'utf8', (err, data) => {
-                        if (data != undefined) {
-                            let i = 0;
-                            yaml.loadAll(data, function(item) {
-                                const resources = cluster.addManifest(file.substring(0, file.length - 5) + i, <Record<string, any>[]>item);
-                                resources.node.addDependency(namespaceManifest);
-                                i++;
-                            });
-                        }
-                    });
-                }
-            });
-        } else {
-            console.log(`${dir} is empty`);
+    fs.readdirSync(dir, { encoding: 'utf8' }).forEach((file, index) => {
+        if (file.split('.').pop() == 'yaml') {
+            const data = fs.readFileSync(dir + file, 'utf8');
+            if (data != undefined) {  
+                yaml.loadAll(data, function (item) {
+                    const resources = cluster.addManifest(file.substring(0, file.length - 5) + index, <Record<string, any>[]>item);
+                    resources.node.addDependency(namespaceManifest);
+                });
+            }
         }
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "0.1.6",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:* #333 

*Description of changes:*
Fix for team manifest dir issue. Async read of dir and files resulted in synthesis finishing before the manifests got a chance to be added. (#333 )

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
