### PR TITLE
Feature/nodegroup options 372

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ dist
 cdk.context.json
 package-lock.json
 yarn.lock
-
+docs/api
 # mkdocs artifact
 site

--- a/docs/cluster-providers/asg-cluster-provider.md
+++ b/docs/cluster-providers/asg-cluster-provider.md
@@ -43,7 +43,9 @@ Configuration can also be supplied via context variables (specify in cdk.json, c
 - `eks.default.instance-type` 
 - `eks.default.private-cluster`
 
-Configuration of the EC2 parameters through context parameters makes sense if you would like to apply default configuration to multiple clusters without the need to explicitly pass `AsgProviderClusterProps` to each cluster blueprint.
+Configuration of the EC2 parameters through context parameters makes sense if you would like to apply default configuration to multiple clusters without the need to explicitly pass `AsgClusterProviderProps` to each cluster blueprint.
+
+You can find more details on the supported configuration options in the API documentation for the [AsgClusterProviderProps](../api/interfaces/AsgClusterProviderProps.html).
 
 ## Bottlerocket ASG
 

--- a/docs/cluster-providers/fargate-cluster-provider.md
+++ b/docs/cluster-providers/fargate-cluster-provider.md
@@ -25,3 +25,5 @@ new blueprints.EksBlueprint(scope, { id: 'blueprint', [], [], clusterProvider })
 | fargateProfiles       | A map of Fargate profiles to use with the cluster.
 | vpcSubnets            | The subnets for the cluster.
 | privateCluster        | Public cluster, you will need to provide a list of subnets. There should be public and private subnets for EKS cluster to work. For more information see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html)
+
+You can find more details on the supported configuration options in the API documentation for the [FargateClusterProviderProps](../api/interfaces/FargateClusterProviderProps.html).

--- a/docs/cluster-providers/generic-cluster-provider.md
+++ b/docs/cluster-providers/generic-cluster-provider.md
@@ -2,6 +2,15 @@
 
 The `GenericClusterProvider` allows you to provision an EKS cluster which leverages one or more [EKS managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html)(MNGs), or one or more autoscaling groups[EC2 Auto Scaling groups](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) for its compute capacity. Users can also configure multiple Fargate profiles along with the EC2 based compute cpacity.
 
+# Configuration
+
+Full list of configuration options:
+
+- [Generic Cluster Provider](../api/interfaces/GenericClusterProviderProps.html)
+- [Managed Node Group](../api/interfaces/ManagedNodeGroup.html)
+- [Autoscaling Group](../api/interface/../interfaces/AutoscalingNodeGroup.html)
+- [Fargate Cluster](../api/interfaces/FargateClusterProviderProps.html)
+
 ## Usage 
 
 ```typescript
@@ -11,7 +20,8 @@ const clusterProvider = new blueprints.GenericClusterProvider({
         {
             id: "mng1",
             amiType: NodegroupAmiType.AL2_X86_64,
-            instanceTypes: [new InstanceType('m5.2xlarge')]
+            instanceTypes: [new InstanceType('m5.2xlarge')],
+            diskSize: 50
         },
         {
             id: "mng2-custom",
@@ -61,6 +71,8 @@ Default configuration for managed and autoscaling node groups can also be suppli
 - `eks.default.private-cluster`
 
 Configuration of the EC2 parameters through context parameters makes sense if you would like to apply default configuration to multiple clusters without the need to explicitly pass individual `GenericProviderClusterProps` to each cluster blueprint.
+
+You can find more details on the supported configuration options in the API documentation for the [GenericClusterProviderProps](../api/interfaces/GenericClusterProviderProps.html).
 
 ## Upgrading Control Plane
 

--- a/docs/cluster-providers/mng-cluster-provider.md
+++ b/docs/cluster-providers/mng-cluster-provider.md
@@ -48,7 +48,9 @@ Configuration can also be supplied via context variables (specify in cdk.json, c
 - `eks.default.instance-type` 
 - `eks.default.private-cluster`
 
-Configuration of the EC2 parameters through context parameters makes sense if you would like to apply default configuration to multiple clusters without the need to explicitly pass `MngProviderClusterProps` to each cluster blueprint.
+Configuration of the EC2 parameters through context parameters makes sense if you would like to apply default configuration to multiple clusters without the need to explicitly pass `MngClusterProviderProps` to each cluster blueprint.
+
+You can find more details on the supported configuration options in the API documentation for the [MngClusterProviderProps](../api/interfaces/MngClusterProviderProps.html).
 
 ## Upgrading Worker Nodes
 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -83,7 +83,8 @@ export default class BlueprintConstruct extends Construct {
                 {
                     id: "mng1",
                     amiType: NodegroupAmiType.AL2_X86_64,
-                    instanceTypes: [new InstanceType('m5.2xlarge')]
+                    instanceTypes: [new InstanceType('m5.2xlarge')],
+                    diskSize: 25
                 },
                 {
                     id: "mng2-custom",

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -1,7 +1,7 @@
+import * as cdk from 'aws-cdk-lib';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { CapacityType, KubernetesVersion, NodegroupAmiType } from 'aws-cdk-lib/aws-eks';
-import * as cdk from 'aws-cdk-lib';
 import { Construct } from "constructs";
 
 import * as blueprints from '../../lib';
@@ -84,7 +84,8 @@ export default class BlueprintConstruct extends Construct {
                     id: "mng1",
                     amiType: NodegroupAmiType.AL2_X86_64,
                     instanceTypes: [new InstanceType('m5.2xlarge')],
-                    diskSize: 25
+                    diskSize: 25,
+                    nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT }
                 },
                 {
                     id: "mng2-custom",

--- a/lib/cluster-providers/asg-cluster-provider.ts
+++ b/lib/cluster-providers/asg-cluster-provider.ts
@@ -20,10 +20,6 @@ export interface AsgClusterProviderProps extends eks.CommonClusterOptions, Autos
      */
     privateCluster?: boolean;
 
-    /**
-     * Affects both control plane and the managed node group.
-    */
-    vpcSubnets?: ec2.SubnetSelection[];
 }
 
 /**

--- a/lib/cluster-providers/asg-cluster-provider.ts
+++ b/lib/cluster-providers/asg-cluster-provider.ts
@@ -1,4 +1,3 @@
-import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as eks from "aws-cdk-lib/aws-eks";
 import { defaultOptions, GenericClusterProvider } from "./generic-cluster-provider";
 import { AutoscalingNodeGroup } from "./types";
@@ -31,13 +30,7 @@ export class AsgClusterProvider extends GenericClusterProvider {
         super({...defaultOptions, ...props, ...{
             autoscalingNodeGroups: [{
                 id: props?.id ?? props?.clusterName ?? "eks-blueprints-asg",
-                desiredSize: props?.desiredSize,
-                maxSize: props?.maxSize,
-                minSize: props?.minSize,
-                vpcSubnets: props?.vpcSubnets,
-                instanceType: props?.instanceType,
-                machineImageType: props?.machineImageType,
-                updatePolicy: props?.updatePolicy
+                ...props as Omit<AutoscalingNodeGroup, "id">
             }]
         }});
     }

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -97,7 +97,7 @@ export class ClusterBuilder {
  */
 export class GenericClusterProvider implements ClusterProvider {
 
-    constructor(private readonly props: GenericClusterProviderProps) {
+    constructor(readonly props: GenericClusterProviderProps) {
         assert(!(props.managedNodeGroups && props.managedNodeGroups.length > 0 
             && props.autoscalingNodeGroups && props.autoscalingNodeGroups.length > 0),
             "Mixing managed and autoscaling node groups is not supported. Please file a request on GitHub to add this support if needed.");
@@ -178,15 +178,17 @@ export class GenericClusterProvider implements ClusterProvider {
 
         // Create an autoscaling group
         return cluster.addAutoScalingGroupCapacity(nodeGroup.id, {
-            autoScalingGroupName: nodeGroup.autoScalingGroupName ?? nodeGroup.id,
-            machineImageType,
-            instanceType,
-            minCapacity: minSize,
-            maxCapacity: maxSize,
-            desiredCapacity: desiredSize,
-            updatePolicy,
-            vpcSubnets: nodeGroup.nodeGroupSubnets,
-            ...nodeGroup
+            ...nodeGroup, 
+            ... {
+                autoScalingGroupName: nodeGroup.autoScalingGroupName ?? nodeGroup.id,
+                machineImageType,
+                instanceType,
+                minCapacity: minSize,
+                maxCapacity: maxSize,
+                desiredCapacity: desiredSize,
+                updatePolicy,
+                vpcSubnets: nodeGroup.nodeGroupSubnets,
+            }
         });
     }
 
@@ -214,15 +216,17 @@ export class GenericClusterProvider implements ClusterProvider {
 
         // Create a managed node group.
         const nodegroupOptions: Writeable<eks.NodegroupOptions> = {
-            nodegroupName: nodeGroup.nodegroupName ?? nodeGroup.id,
-            capacityType,
-            instanceTypes,
-            minSize,
-            maxSize,
-            desiredSize,
-            releaseVersion,
-            subnets: nodeGroup.nodeGroupSubnets,
-            ...nodeGroup
+            ...nodeGroup,
+            ...{
+                nodegroupName: nodeGroup.nodegroupName ?? nodeGroup.id,
+                capacityType,
+                instanceTypes,
+                minSize,
+                maxSize,
+                desiredSize,
+                releaseVersion,
+                subnets: nodeGroup.nodeGroupSubnets
+            }
         };
 
         if(nodeGroup.customAmi) {

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -1,11 +1,9 @@
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
-import { UpdatePolicy } from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as eks from "aws-cdk-lib/aws-eks";
-import { CommonClusterOptions, FargateProfileOptions, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import { Construct } from "constructs";
 import { ClusterInfo, ClusterProvider } from "../spi";
-import { valueFromContext } from "../utils";
+import { setPath, valueFromContext, Writeable } from "../utils";
 import * as constants from './constants';
 import { AutoscalingNodeGroup, ManagedNodeGroup } from "./types";
 import assert = require('assert');
@@ -59,10 +57,10 @@ export class ClusterBuilder {
     } = {};
 
     constructor() {
-        this.props = {...this.props, ...{version: KubernetesVersion.V1_21}};
+        this.props = {...this.props, ...{version: eks.KubernetesVersion.V1_21}};
     }
 
-    withCommonOptions(options: Partial<CommonClusterOptions>): this {
+    withCommonOptions(options: Partial<eks.CommonClusterOptions>): this {
         this.props = {...this.props, ...options};
         return this;
     }
@@ -77,7 +75,7 @@ export class ClusterBuilder {
         return this;
     }
 
-    fargateProfile(name: string, options: FargateProfileOptions): this {
+    fargateProfile(name: string, options: eks.FargateProfileOptions): this {
         this.fargateProfiles[name] = options;
         return this;
     }
@@ -176,7 +174,7 @@ export class GenericClusterProvider implements ClusterProvider {
         const minSize = nodeGroup.minSize ?? valueFromContext(cluster, constants.MIN_SIZE_KEY, constants.DEFAULT_NG_MINSIZE);
         const maxSize = nodeGroup.maxSize ?? valueFromContext(cluster, constants.MAX_SIZE_KEY, constants.DEFAULT_NG_MAXSIZE);
         const desiredSize = nodeGroup.desiredSize ?? valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize);
-        const updatePolicy = nodeGroup.updatePolicy ?? UpdatePolicy.rollingUpdate();
+        const updatePolicy = nodeGroup.updatePolicy ?? autoscaling.UpdatePolicy.rollingUpdate();
 
         // Create an autoscaling group
         return cluster.addAutoScalingGroupCapacity(nodeGroup.id, {
@@ -187,6 +185,7 @@ export class GenericClusterProvider implements ClusterProvider {
             maxCapacity: maxSize,
             desiredCapacity: desiredSize,
             updatePolicy,
+            ...nodeGroup
         });
     }
 
@@ -205,7 +204,6 @@ export class GenericClusterProvider implements ClusterProvider {
      * @returns 
      */
     addManagedNodeGroup(cluster: eks.Cluster, nodeGroup: ManagedNodeGroup) : eks.Nodegroup {
-        const amiType = nodeGroup.amiType;
         const capacityType = nodeGroup.nodeGroupCapacityType;
         const releaseVersion = nodeGroup.amiReleaseVersion;
         const instanceTypes = nodeGroup.instanceTypes ?? [valueFromContext(cluster, constants.INSTANCE_TYPE_KEY, constants.DEFAULT_INSTANCE_TYPE)];
@@ -214,35 +212,30 @@ export class GenericClusterProvider implements ClusterProvider {
         const desiredSize = nodeGroup.desiredSize ?? valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize);
 
         // Create a managed node group.
-        const commonNodegroupProps: Partial<eks.NodegroupOptions> = {
-            nodegroupName: nodeGroup.id,
+        const nodegroupOptions: Writeable<eks.NodegroupOptions> = {
+            nodegroupName: nodeGroup.nodegroupName ?? nodeGroup.id,
             capacityType,
             instanceTypes,
             minSize,
             maxSize,
-            desiredSize
+            desiredSize,
+            releaseVersion,
+            subnets: nodeGroup.nodeGroupSubnets,
+            ...nodeGroup
         };
 
-        let nodegroupOptions: eks.NodegroupOptions;
         if(nodeGroup.customAmi) {
             // Create launch template if custom AMI is provided.
             const lt = new ec2.LaunchTemplate(cluster, `${nodeGroup.id}-lt`, {
                 machineImage: nodeGroup.customAmi?.machineImage,
                 userData: nodeGroup.customAmi?.userData,
             });
-            nodegroupOptions = {
-                ...commonNodegroupProps,
-                launchTemplateSpec: {
-                    id: lt.launchTemplateId!,
-                    version: lt.latestVersionNumber,
-                },
-            };
-        } else {
-            nodegroupOptions = {
-                ...commonNodegroupProps,
-                amiType,
-                releaseVersion,
-            };
+            setPath(nodegroupOptions, "launchTemplateSpec", {
+                id: lt.launchTemplateId!,
+                version: lt.latestVersionNumber,
+            });
+            delete nodegroupOptions.amiType;
+            delete nodegroupOptions.releaseVersion;
         }
 
         return cluster.addNodegroupCapacity(nodeGroup.id + "-ng", nodegroupOptions);

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -178,13 +178,14 @@ export class GenericClusterProvider implements ClusterProvider {
 
         // Create an autoscaling group
         return cluster.addAutoScalingGroupCapacity(nodeGroup.id, {
-            autoScalingGroupName: nodeGroup.id,
+            autoScalingGroupName: nodeGroup.autoScalingGroupName ?? nodeGroup.id,
             machineImageType,
             instanceType,
             minCapacity: minSize,
             maxCapacity: maxSize,
             desiredCapacity: desiredSize,
             updatePolicy,
+            vpcSubnets: nodeGroup.nodeGroupSubnets,
             ...nodeGroup
         });
     }

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -115,7 +115,7 @@ export class GenericClusterProvider implements ClusterProvider {
         const version = this.props.version;
         const privateCluster = this.props.privateCluster ?? valueFromContext(scope, constants.PRIVATE_CLUSTER, false);
         const endpointAccess = (privateCluster === true) ? eks.EndpointAccess.PRIVATE : eks.EndpointAccess.PUBLIC_AND_PRIVATE;
-        const vpcSubnets = this.props.vpcSubnets ?? (privateCluster === true) ? [{ subnetType: ec2.SubnetType.PRIVATE_WITH_NAT }] : undefined;
+        const vpcSubnets = this.props.vpcSubnets ?? (privateCluster === true ? [{ subnetType: ec2.SubnetType.PRIVATE_WITH_NAT }] : undefined);
 
         const defaultOptions = {
             vpc,

--- a/lib/cluster-providers/index.ts
+++ b/lib/cluster-providers/index.ts
@@ -2,4 +2,5 @@ export * from './asg-cluster-provider';
 export * from './fargate-cluster-provider';
 export * from "./generic-cluster-provider";
 export * from './mng-cluster-provider';
+export * from './types';
 

--- a/lib/cluster-providers/mng-cluster-provider.ts
+++ b/lib/cluster-providers/mng-cluster-provider.ts
@@ -1,4 +1,4 @@
-import { aws_autoscaling as asg, aws_ec2 as ec2, aws_eks as eks } from "aws-cdk-lib";
+import { aws_autoscaling as asg, aws_eks as eks } from "aws-cdk-lib";
 // Cluster
 import { ClusterInfo } from "..";
 import { defaultOptions, GenericClusterProvider } from "./generic-cluster-provider";
@@ -38,8 +38,8 @@ export class MngClusterProvider extends GenericClusterProvider {
     constructor(props?: MngClusterProviderProps) {
         super({...defaultOptions, ...props, ...{
             managedNodeGroups: [{
+                ...props as Omit<ManagedNodeGroup, "id">,
                 id: props?.id ?? props?.clusterName ?? "eks-blueprints-mng",
-                ...props as Omit<ManagedNodeGroup, "id">
             }]
         }});
     }

--- a/lib/cluster-providers/mng-cluster-provider.ts
+++ b/lib/cluster-providers/mng-cluster-provider.ts
@@ -39,15 +39,7 @@ export class MngClusterProvider extends GenericClusterProvider {
         super({...defaultOptions, ...props, ...{
             managedNodeGroups: [{
                 id: props?.id ?? props?.clusterName ?? "eks-blueprints-mng",
-                amiReleaseVersion: props?.amiReleaseVersion,
-                customAmi: props?.customAmi,
-                amiType: props?.amiType,
-                desiredSize: props?.desiredSize,
-                instanceTypes: props?.instanceTypes,
-                maxSize: props?.maxSize,
-                minSize: props?.minSize,
-                nodeGroupCapacityType: props?.nodeGroupCapacityType,
-                nodeGroupSubnets: props?.nodeGroupSubnets,
+                ...props as Omit<ManagedNodeGroup, "id">
             }]
         }});
     }

--- a/lib/cluster-providers/mng-cluster-provider.ts
+++ b/lib/cluster-providers/mng-cluster-provider.ts
@@ -1,6 +1,4 @@
-import { aws_autoscaling as asg } from "aws-cdk-lib";
-import { aws_ec2 as ec2 } from "aws-cdk-lib";
-import { aws_eks as eks } from "aws-cdk-lib";
+import { aws_autoscaling as asg, aws_ec2 as ec2, aws_eks as eks } from "aws-cdk-lib";
 // Cluster
 import { ClusterInfo } from "..";
 import { defaultOptions, GenericClusterProvider } from "./generic-cluster-provider";
@@ -30,10 +28,6 @@ export interface MngClusterProviderProps extends eks.CommonClusterOptions, Omit<
      */
     privateCluster?: boolean;
 
-    /**
-     * Affects both control plane and the managed node group.
-     */
-    vpcSubnets?: ec2.SubnetSelection[];
 }
 
 /**
@@ -53,7 +47,7 @@ export class MngClusterProvider extends GenericClusterProvider {
                 maxSize: props?.maxSize,
                 minSize: props?.minSize,
                 nodeGroupCapacityType: props?.nodeGroupCapacityType,
-                vpcSubnets: props?.vpcSubnets,
+                nodeGroupSubnets: props?.nodeGroupSubnets,
             }]
         }});
     }

--- a/lib/cluster-providers/types.ts
+++ b/lib/cluster-providers/types.ts
@@ -81,7 +81,7 @@ export interface ManagedNodeGroup extends Omit<eks.NodegroupOptions, "launchTemp
  * Also referred to as "self-managed" node group, implying that maintenance of the group
  * is performed by the customer (as oppposed to AWS as in case of a ManagedNodeGroup).
  */
-export interface AutoscalingNodeGroup extends Omit<AutoScalingGroupCapacityOptions, "minCapacity" | "maxCapacity" | "desiredCapacity" | "instanceType"> {
+export interface AutoscalingNodeGroup extends Omit<AutoScalingGroupCapacityOptions, "minCapacity" | "maxCapacity" | "desiredCapacity" | "instanceType" | "vpcSubnets"> {
 
     /**
      * Id of this node group. Expected to be unique in cluster scope.

--- a/lib/cluster-providers/types.ts
+++ b/lib/cluster-providers/types.ts
@@ -1,6 +1,6 @@
-import * as eks from "aws-cdk-lib/aws-eks";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import * as eks from "aws-cdk-lib/aws-eks";
+import { AutoScalingGroupCapacityOptions } from "aws-cdk-lib/aws-eks";
 
 /**
  * Configuration options for the custom AMI.
@@ -18,7 +18,7 @@ export interface CustomAmiProps {
 }
 
 
-export interface ManagedNodeGroup {
+export interface ManagedNodeGroup extends Omit<eks.NodegroupOptions, "launchTemplate" | "subnets" | "capacityType" | "releaseVersion"> {
 
     /**
      * Id of this node group. Expected to be unique in cluster scope.
@@ -70,9 +70,10 @@ export interface ManagedNodeGroup {
     nodeGroupCapacityType?: eks.CapacityType;
 
     /**
-     * Subnets are passed to the cluster configuration.
+     * Subnets for the autoscaling group where nodes (instances) will be placed.
+     * @default all private subnets
      */
-    vpcSubnets?: ec2.SubnetSelection[];
+    nodeGroupSubnets?: ec2.SubnetSelection;
 }
 
 /**
@@ -80,7 +81,7 @@ export interface ManagedNodeGroup {
  * Also referred to as "self-managed" node group, implying that maintenance of the group
  * is performed by the customer (as oppposed to AWS as in case of a ManagedNodeGroup).
  */
-export interface AutoscalingNodeGroup {
+export interface AutoscalingNodeGroup extends Omit<AutoScalingGroupCapacityOptions, "minCapacity" | "maxCapacity" | "desiredCapacity" | "instanceType"> {
 
     /**
      * Id of this node group. Expected to be unique in cluster scope.
@@ -105,25 +106,16 @@ export interface AutoscalingNodeGroup {
     desiredSize?: number;
 
     /**
-     * Instance types used for the node group.
-     * @default m5.large
+     * Instance type of the instances to start. If not specified defaults are applied in the following order:
+     * - 'eks.default.instance-type' in CDK context (e.g. ~/.cdk.json under "context" key))
+     * - M5.Large
      */
     instanceType?: ec2.InstanceType;
 
     /**
-     * Machine Image Type for the Autoscaling Group.
-     * @default eks.MachineImageType.AMAZON_LINUX_2
+     * Subnets for the autoscaling group where nodes (instances) will be placed.
+     * @default all private subnets
      */
-    machineImageType?: eks.MachineImageType;
-
-    /**
-     * Update policy for the Autoscaling Group.
-     */
-    updatePolicy?: UpdatePolicy;
-
-    /**
-     * Subnets are passed to the cluster configuration.
-     */
-    vpcSubnets?: ec2.SubnetSelection[];
+    nodeGroupSubnets?: ec2.SubnetSelection;
 
 }

--- a/lib/utils/object-utils.ts
+++ b/lib/utils/object-utils.ts
@@ -19,3 +19,5 @@ export function cloneDeep<T>(source: T): T {
         return undefined;
     });
 }
+
+export type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -2,7 +2,6 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import { KubernetesManifest } from 'aws-cdk-lib/aws-eks';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import request from 'sync-request';
 
 /**
  * Applies all manifests from a directory. Note: The manifests are not checked, 
@@ -41,7 +40,12 @@ export function loadYaml(document: string): any {
 }
 
 export function loadExternalYaml(url: string): any {
-    return yaml.loadAll(request('GET', url).getBody().toString());
+    const request = require('sync-request'); // moved away from import as it is causing open handles that prevents jest from completion
+    const response = request('GET', url, { timeout: 1000, socketTimeout: 1000 });
+    if(response.isError()) {
+        throw new Error(`Failed to retrieve ${url} status: ${response.statusCode}`);
+    }
+    return yaml.loadAll(response.getBody.toString());
 }
 
 export function serializeYaml(document: any): string {

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -43,7 +43,7 @@ export function loadYaml(document: string): any {
 export function loadExternalYaml(url: string): any {
     /* eslint-disable */
     const request = require('sync-request'); // moved away from import as it is causing open handles that prevents jest from completion
-    const response = request('GET', url, { timeout: 1000, socketTimeout: 1000 });
+    const response = request('GET', url);
     if(response.isError()) {
         throw new Error(`Failed to retrieve ${url} status: ${response.statusCode}`);
     }

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -44,10 +44,7 @@ export function loadExternalYaml(url: string): any {
     /* eslint-disable */
     const request = require('sync-request'); // moved away from import as it is causing open handles that prevents jest from completion
     const response = request('GET', url);
-    if(response.isError()) {
-        throw new Error(`Failed to retrieve ${url} status: ${response.statusCode}`);
-    }
-    return yaml.loadAll(response.getBody.toString());
+    return yaml.loadAll(response.getBody().toString());
 }
 
 export function serializeYaml(document: any): string {

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -3,6 +3,7 @@ import { KubernetesManifest } from 'aws-cdk-lib/aws-eks';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
+
 /**
  * Applies all manifests from a directory. Note: The manifests are not checked, 
  * so user must ensure the manifests have the correct namespaces. 

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -41,6 +41,7 @@ export function loadYaml(document: string): any {
 }
 
 export function loadExternalYaml(url: string): any {
+    /* eslint-disable */
     const request = require('sync-request'); // moved away from import as it is causing open handles that prevents jest from completion
     const response = request('GET', url, { timeout: 1000, socketTimeout: 1000 });
     if(response.isError()) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "jest": "^27.4.7",
         "ts-jest": "^27.1.1",
         "ts-node": "^10.4.0",
+        "typedoc": "^0.22.15",
         "typescript": "~4.5.4"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "build": "rm -rf dist && tsc",
         "watch": "tsc -w",
-        "test": "jest --verbose",
+        "test": "jest --verbose --detectOpenHandles",
         "cdk": "cdk",
         "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx"
     },

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -1,0 +1,38 @@
+
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as blueprints from '../lib';
+jest.useFakeTimers();
+test("Generic cluster provider correctly registers autoscaling node groups", async () => {
+    const app = new cdk.App();
+
+    const clusterProvider = blueprints.clusterBuilder()
+    .autoscalingGroup({
+        id: "mng1",
+        maxSize: 2,
+        instanceType: new ec2.InstanceType('m5.large')
+    })
+    .autoscalingGroup({
+        id: "mng2",
+        maxSize: 1,
+        nodeGroupSubnets: {
+           subnetType: ec2.SubnetType.PRIVATE_WITH_NAT
+        }
+    })
+    .fargateProfile("fp1", {
+        selectors: [
+            {
+                namespace: "default"
+            }
+        ]
+    }).build();
+
+    const blueprint =  await blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-1')
+        .clusterProvider(clusterProvider)
+        .addOns(new blueprints.ClusterAutoScalerAddOn)
+        .buildAsync(app, 'stack-with-resource-providers');
+    
+    expect(blueprint.getClusterInfo().autoscalingGroups).toBeDefined();
+    expect(blueprint.getClusterInfo().autoscalingGroups!.length).toBe(2);
+});

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -1,16 +1,53 @@
 
 import * as cdk from 'aws-cdk-lib';
+import { BlockDeviceVolume, EbsDeviceVolumeType } from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { SubnetType } from 'aws-cdk-lib/aws-ec2';
+import { CapacityType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import * as blueprints from '../lib';
-jest.useFakeTimers();
-test("Generic cluster provider correctly registers autoscaling node groups", async () => {
+import { AsgClusterProvider, MngClusterProvider } from '../lib';
+
+test("Generic cluster provider correctly registers managed node groups", async () => {
+    const app = new cdk.App();
+
+    const clusterProvider = blueprints.clusterBuilder()
+    .managedNodeGroup({
+        id: "mng1",
+        maxSize: 2,
+        nodeGroupCapacityType: CapacityType.SPOT
+    })
+    .managedNodeGroup({
+        id: "mng2",
+        maxSize:1
+    })
+    .fargateProfile("fp1", {
+        selectors: [
+            {
+                namespace: "default"
+            }
+        ]
+    }).build();
+
+    const blueprint =  await blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-1')
+        .clusterProvider(clusterProvider)
+        .addOns(new blueprints.ClusterAutoScalerAddOn)
+        .buildAsync(app, 'stack-with-resource-providers');
+    
+    expect(blueprint.getClusterInfo().nodeGroups).toBeDefined();
+    expect(blueprint.getClusterInfo().nodeGroups!.length).toBe(2);
+});
+
+test("Generic cluster provider correctly registers autoscaling node groups", () => {
     const app = new cdk.App();
 
     const clusterProvider = blueprints.clusterBuilder()
     .autoscalingGroup({
         id: "mng1",
         maxSize: 2,
-        instanceType: new ec2.InstanceType('m5.large')
+        instanceType: new ec2.InstanceType('m5.large'),
+        allowAllOutbound: true,
+
     })
     .autoscalingGroup({
         id: "mng2",
@@ -27,12 +64,84 @@ test("Generic cluster provider correctly registers autoscaling node groups", asy
         ]
     }).build();
 
-    const blueprint =  await blueprints.EksBlueprint.builder()
+    const blueprint =  blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-1')
         .clusterProvider(clusterProvider)
         .addOns(new blueprints.ClusterAutoScalerAddOn)
-        .buildAsync(app, 'stack-with-resource-providers');
+        .build(app, 'stack-with-resource-providers');
     
     expect(blueprint.getClusterInfo().autoscalingGroups).toBeDefined();
     expect(blueprint.getClusterInfo().autoscalingGroups!.length).toBe(2);
+});
+
+test("Mng cluster provider correctly initializes managed node group", () => {
+    const app = new cdk.App();
+
+    const clusterProvider = new MngClusterProvider({
+        version: KubernetesVersion.V1_21,
+        clusterName: "my-cluster",
+        forceUpdate:true,
+        labels: { "mylabel": "value" },
+        diskSize: 34,
+        instanceTypes: [new ec2.InstanceType('t3.micro')],
+        nodeGroupCapacityType: CapacityType.SPOT,
+        nodeGroupSubnets: {
+            subnetType: ec2.SubnetType.PRIVATE_WITH_NAT
+        }
+    });
+
+    const managedNodeGroups = clusterProvider.props.managedNodeGroups!;
+    expect(managedNodeGroups.length).toBe(1);
+    expect(managedNodeGroups[0].diskSize).toBe(34);
+    expect(managedNodeGroups[0].nodeGroupCapacityType).toBe(CapacityType.SPOT);
+    expect(managedNodeGroups[0].nodeGroupSubnets).toBeDefined();
+    expect(managedNodeGroups[0].nodeGroupSubnets!.subnetType).toBe(ec2.SubnetType.PRIVATE_WITH_NAT);
+
+
+    const blueprint =  blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-1')
+        .clusterProvider(clusterProvider)
+        .addOns(new blueprints.ClusterAutoScalerAddOn)
+        .build(app, 'stack-with-resource-providers');
+    
+    expect(blueprint.getClusterInfo().nodeGroups).toBeDefined();
+    expect(blueprint.getClusterInfo().nodeGroups!.length).toBe(1);
+});
+
+test("Asg cluster provider correctly initializes self-managed node group", () => {
+    const app = new cdk.App();
+
+    const clusterProvider = new AsgClusterProvider({
+        id: "asg1",
+        version: KubernetesVersion.V1_21,
+        clusterName: "my-cluster",
+        blockDevices: [
+            {
+                deviceName: "disk1",
+                volume: BlockDeviceVolume.ebs(34, { volumeType: EbsDeviceVolumeType.GP3 })
+            }
+        ],
+        instanceType: new ec2.InstanceType('t3.micro'),
+        spotPrice: "23",
+        nodeGroupSubnets: {
+            subnetType: ec2.SubnetType.PRIVATE_WITH_NAT
+        },
+        vpcSubnets: [ {subnetType:SubnetType.PUBLIC }]
+    });
+
+    const autoscalingNodeGroups = clusterProvider.props.autoscalingNodeGroups!;
+    expect(autoscalingNodeGroups.length).toBe(1)!;
+    expect(autoscalingNodeGroups[0].blockDevices![0].volume!.ebsDevice?.volumeSize).toBe(34)!;
+    expect(autoscalingNodeGroups[0].spotPrice).toBe("23")!;
+    expect(autoscalingNodeGroups[0].nodeGroupSubnets).toBeDefined();
+    expect(autoscalingNodeGroups[0].nodeGroupSubnets!.subnetType).toBe(ec2.SubnetType.PRIVATE_WITH_NAT);
+
+    const blueprint =  blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-1')
+        .clusterProvider(clusterProvider)
+        .addOns(new blueprints.ClusterAutoScalerAddOn)
+        .build(app, 'stack-with-resource-providers');
+    
+    expect(blueprint.getClusterInfo().autoscalingGroups).toBeDefined();
+    expect(blueprint.getClusterInfo().autoscalingGroups!.length).toBe(1);
 });

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { CapacityType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import { ManualApprovalStep } from 'aws-cdk-lib/pipelines';
 import * as blueprints from '../lib';
 import { MyVpcStack } from './test-support';

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -1,13 +1,11 @@
-import { CapacityType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { CapacityType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import { ManualApprovalStep } from 'aws-cdk-lib/pipelines';
 import * as blueprints from '../lib';
 import { MyVpcStack } from './test-support';
-import { Template } from 'aws-cdk-lib/assertions';
 
-jest.useFakeTimers();
 describe('Unit tests for EKS Blueprint', () => {
-
 
     test('Usage tracking created', () => {
         let app = new cdk.App();
@@ -192,37 +190,6 @@ test("Named resource providers are correctly registered and discovered", async (
     expect(blueprint.getClusterInfo().getResource(blueprints.GlobalResources.HostedZone)).toBeDefined();
     expect(blueprint.getClusterInfo().getResource(blueprints.GlobalResources.Certificate)).toBeDefined();
     expect(blueprint.getClusterInfo().getProvisionedAddOn('NginxAddOn')).toBeDefined();
-});
-
-test("Generic cluster provider correctly registers managed node groups", async () => {
-    const app = new cdk.App();
-
-    const clusterProvider = blueprints.clusterBuilder()
-    .managedNodeGroup({
-        id: "mng1",
-        maxSize: 2,
-        nodeGroupCapacityType: CapacityType.SPOT
-    })
-    .managedNodeGroup({
-        id: "mng2",
-        maxSize:1
-    })
-    .fargateProfile("fp1", {
-        selectors: [
-            {
-                namespace: "default"
-            }
-        ]
-    }).build();
-
-    const blueprint =  await blueprints.EksBlueprint.builder()
-        .account('123456789').region('us-west-1')
-        .clusterProvider(clusterProvider)
-        .addOns(new blueprints.ClusterAutoScalerAddOn)
-        .buildAsync(app, 'stack-with-resource-providers');
-    
-    expect(blueprint.getClusterInfo().nodeGroups).toBeDefined();
-    expect(blueprint.getClusterInfo().nodeGroups!.length).toBe(2);
 });
 
 test("Building blueprint with builder properly clones properties", () => {

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -5,7 +5,9 @@ import * as blueprints from '../lib';
 import { MyVpcStack } from './test-support';
 import { Template } from 'aws-cdk-lib/assertions';
 
+jest.useFakeTimers();
 describe('Unit tests for EKS Blueprint', () => {
+
 
     test('Usage tracking created', () => {
         let app = new cdk.App();


### PR DESCRIPTION
*Issue #, if available:* 372

*Description of changes:*
Added extended options for managed node groups and autoscaling groups. 

Options for managed node groups:

- amiReleaseVersion
- amiType
- customAmi
- desiredSize
- diskSize
- forceUpdate
- id
- instanceTypes
- labels
- launchTemplateSpec
- maxSize
- minSize
- nodeGroupCapacityType
- nodeGroupSubnets
- nodeRole
- nodegroupName
- remoteAccess
- tags
- taints

Options for autoscaling groups:

- allowAllOutbound
- associatePublicIpAddress
- autoScalingGroupName
- blockDevices
- bootstrapEnabled
- bootstrapOptions
- cooldown
- desiredSize
- groupMetrics
- healthCheck
- ignoreUnmodifiedSizeProperties
- instanceMonitoring
- instanceType
- keyName
- machineImageType
- mapRole
- maxInstanceLifetime
- maxSize
- minSize
- newInstancesProtectedFromScaleIn
- nodeGroupSubnets
- notifications
- signals
- spotInterruptHandler
- spotPrice
- terminationPolicies
- updatePolicy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
