### PR TITLE
bugfix: add crossAccountKeys boolean flag for Pipelines

### DIFF
--- a/lib/pipelines/code-pipeline.ts
+++ b/lib/pipelines/code-pipeline.ts
@@ -48,6 +48,11 @@ export type PipelineProps = {
     owner: string;
 
     /**
+     * Enable/Disable allowing cross-account deployments.
+     */
+    crossAccountKeys: boolean;
+
+    /**
      * Repository for the pipeline
      */
     repository: GitHubSourceRepository;
@@ -114,7 +119,7 @@ export class CodePipelineBuilder implements StackBuilder {
 
 
     constructor() {
-        this.props = { stages: [], waves: []};
+        this.props = { crossAccountKeys: false, stages: [], waves: []};
     }
 
     public name(name: string): CodePipelineBuilder {
@@ -124,6 +129,11 @@ export class CodePipelineBuilder implements StackBuilder {
 
     public owner(owner: string) : CodePipelineBuilder {
         this.props.owner = owner;
+        return this;
+    }
+
+    public enableCrossAccountKeys() : CodePipelineBuilder {
+        this.props.crossAccountKeys = true;
         return this;
     }
 
@@ -259,7 +269,8 @@ class CodePipeline {
                 'npm install',
               ],
               commands: ['npm run build', 'npx cdk synth']
-            })
+            }),
+            crossAccountKeys: props.crossAccountKeys,
           });
     }
 }


### PR DESCRIPTION
…MS key for artifact bucket

*Issue #384

*Description of changes:
Added method to set crossAccountKeys to true. This method sets [aws-cdk-lib » pipelines » CodePipeline](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.pipelines.CodePipeline.html#crossaccountkeys) constructor property crossAccountKeys to true. otherwise it is false if not called.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
