### PR TITLE
Add Pixie to docs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,9 @@ site_name: Amazon EKS Blueprints Quick Start
 repo_name: "aws-quickstart/cdk-eks-blueprints"
 repo_url: "https://github.com/aws-quickstart/cdk-eks-blueprints"
 docs_dir: "docs"
-theme: 
+theme:
   name: material
-  features: 
+  features:
     - tabs
 nav:
   - Overview: 'index.md'
@@ -37,13 +37,14 @@ nav:
     - New Relic: 'addons/newrelic.md'
     - Nginx: 'addons/nginx.md'
     - OPA Gatekeeper: 'addons/opa-gatekeeper.md'
+    - Pixie: 'addons/pixie.md'
     - Secrets Store: 'addons/secrets-store.md'
     - Snyk: 'https://github.com/snyk-partners/snyk-monitor-eks-blueprints-addon'
     - SSM Agent: 'addons/ssm-agent.md'
     - Velero: 'addons/velero.md'
     - Vpc Cni: 'addons/vpc-cni.md'
     - AWS XRay: 'addons/xray.md'
-  - Cluster Providers: 
+  - Cluster Providers:
     - Overview: 'cluster-providers/index.md'
     - Generic Cluster Provider: 'cluster-providers/generic-cluster-provider.md'
     - ASG Cluster Provider: 'cluster-providers/asg-cluster-provider.md'
@@ -53,7 +54,7 @@ nav:
   - API Reference: '../api'
 markdown_extensions:
   - def_list
-  - pymdownx.highlight  
+  - pymdownx.highlight
   - pymdownx.superfences
   - pymdownx.tabbed
   - pymdownx.inlinehilite


### PR DESCRIPTION
Pixie is listed as an available AddOn in the [Overview](https://aws-quickstart.github.io/cdk-eks-blueprints/addons/), but is missing in the expanded AddOns navigation menu.

Signed-off-by: Hannah Troisi <htroisi@pixielabs.ai>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
