### PR TITLE
minor doc updates, fixed region/account defaults, fixed aws load bala…

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -1,6 +1,6 @@
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
-import { ClusterInfo } from "../../spi";
+import { ClusterInfo, Values } from "../../spi";
 import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
 import { AwsLoadbalancerControllerIamPolicy } from "./iam-policy";
 import { registries } from "../../utils/registry-utils";
@@ -58,6 +58,15 @@ const defaultProps: AwsLoadBalancerControllerProps = {
 };
 
 
+function lookupImage(registry?: string, region?: string): Values {
+    if(registry ==  null) {
+        console.log("Unable to get ECR repository for AWS Loadbalancer Controller for region " + region) + ". Using default helm image";
+        return {};
+    }
+    
+    return { repository: registry + "amazon/aws-load-balancer-controller" };
+}
+
 export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
 
     readonly options: AwsLoadBalancerControllerProps;
@@ -77,7 +86,11 @@ export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
         AwsLoadbalancerControllerIamPolicy(cluster.stack.partition).Statement.forEach((statement) => {
             serviceAccount.addToPrincipalPolicy(iam.PolicyStatement.fromJson(statement));
         });
-        const repo = registries.get(clusterInfo.cluster.stack.region) + "amazon/aws-load-balancer-controller";
+    
+        const registry = registries.get(cluster.stack.region);
+        
+        const image = lookupImage(registry, cluster.stack.region);
+        
         const awsLoadBalancerControllerChart = this.addHelmChart(clusterInfo, {
             clusterName: cluster.clusterName,
             serviceAccount: {
@@ -91,7 +104,7 @@ export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
             createIngressClassResource: this.options.createIngressClassResource,
             ingressClass: this.options.ingressClass,
             region: clusterInfo.cluster.stack.region,
-            image: { repository: repo },
+            image,
             vpcId: clusterInfo.cluster.vpc.vpcId,
         });
 

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -69,6 +69,9 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
     env: {
         account?: string,
         region?: string
+    } = {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION
     };
 
     constructor() {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
     - Nginx: 'addons/nginx.md'
     - OPA Gatekeeper: 'addons/opa-gatekeeper.md'
     - Pixie: 'addons/pixie.md'
+    - Refay: 'addons/rafay.md'
     - Secrets Store: 'addons/secrets-store.md'
     - Snyk: 'https://github.com/snyk-partners/snyk-monitor-eks-blueprints-addon'
     - SSM Agent: 'addons/ssm-agent.md'
@@ -51,7 +52,7 @@ nav:
     - MNG Cluster Provider: 'cluster-providers/mng-cluster-provider.md'
     - Fargate Cluster Provider: 'cluster-providers/fargate-cluster-provider.md'
   - Extensibility: 'extensibility.md'
-  - API Reference: '../api'
+  - API Reference: 'api'
 markdown_extensions:
   - def_list
   - pymdownx.highlight

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -278,6 +278,21 @@ test("Building blueprint with version correctly passes k8s version to the cluste
  
 });
 
+test("Account and region are correctly initialized when not explicitly set on the blueprint", () => {
+
+    const app = new cdk.App();
+
+    const blueprint = blueprints.EksBlueprint.builder().name("region-test1")
+        .addOns(new blueprints.AwsLoadBalancerControllerAddOn);
+
+    const stack = blueprint.build(app, "region-test1");
+
+    expect(stack.getClusterInfo().cluster.stack.region).toBeDefined();
+    expect(stack.getClusterInfo().cluster.stack.account).toBeDefined();
+ 
+});
+
+
 function assertBlueprint(stack: blueprints.EksBlueprint, ...charts: string[]) {
     const template = Template.fromStack(stack);
     for (let chart of charts) {


### PR DESCRIPTION
AWS Load balancer add-on falls back to default if registry is not found
Blueprint stack builder always sets default for account and region based on CLI config.

*Issue #, if available:* coming

*Description of changes:*
AWS Load balancer add-on falls back to default if registry is not found
Blueprint stack builder always sets default for account and region based on CLI config.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
