### PR TITLE
External DNS fixed, upgraded version for deployment

### DIFF
--- a/lib/addons/external-dns/index.ts
+++ b/lib/addons/external-dns/index.ts
@@ -23,7 +23,7 @@ const defaultProps = {
     namespace: 'external-dns',
     repository: 'https://charts.bitnami.com/bitnami',
     release: 'blueprints-addon-external-dns',
-    version: '5.1.3'
+    version: '6.5.6'
 };
 
 /**

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -1,8 +1,8 @@
+import * as assert from "assert";
+import * as cdk from 'aws-cdk-lib';
 import { AutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
 import { Cluster, KubernetesVersion, Nodegroup } from 'aws-cdk-lib/aws-eks';
-import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import * as assert from "assert";
 import { ResourceProvider } from '.';
 import { EksBlueprintProps } from '../stacks';
 
@@ -218,7 +218,7 @@ export class ClusterInfo {
      */
     public getRequiredResource<T extends cdk.IResource>(name: string): T {
         const result = this.resourceContext.get<T>(name);
-        assert(result, `Required resource ${name} is missing.`);
+        assert(result, 'Required resource ' + name + ' is missing.');
         return result!;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:* coming

*Description of changes:* increased version of the External DNS helm chart
minor debugging improvements
validated manually as e2e tests currently don't have a hosted zone to test with.
Automated testing of external DNS is covered in [this](https://github.com/aws-quickstart/cdk-eks-blueprints/blob/main/examples/blueprint-construct/index.ts) issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
