### PR TITLE
Fix for USERNAME and TOKEN private repo authentication. validated wit…

### DIFF
--- a/lib/addons/argocd/manifest-utils.ts
+++ b/lib/addons/argocd/manifest-utils.ts
@@ -53,9 +53,7 @@ export function createUserNameSecretRef(secretName: string): CsiSecretProps {
         jmesPath: [{ path: "url", objectAlias: "url" }, { path: "username", objectAlias: "username" }, { path: "password", objectAlias: "password" }],
         kubernetesSecret: {
             secretName: secretName,
-            labels: new Map([
-                [ "argocd.argoproj.io/secret-type", "repo-creds" ]
-            ]),
+            labels: {"argocd.argoproj.io/secret-type": "repo-creds"},
             data: [
                 { key: "url", objectName: "url" },
                 { key: "username", objectName: "username" },


### PR DESCRIPTION
Fix for USERNAME and TOKEN private repo authentication with ArgoCD
*Issue #, if available:*

*Description of changes:*
Proper label to the k8s secret was not applied when USERNAME or TOKEN authn was leveraged (GitLab, GitHub)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
