### PR TITLE
Feature/argo config management

### DIFF
--- a/lib/addons/argocd/application.ts
+++ b/lib/addons/argocd/application.ts
@@ -16,8 +16,13 @@ export class ArgoApplication {
 
         for (let key in flatValues) {
             // Avoid passing the undefined values and empty objects
-            if (flatValues[key] !== undefined && Object.keys(flatValues[key]).length != 0)
-                nameValues.push({ name: key, value: `${flatValues[key]}` });
+            if (flatValues[key] !== undefined) {
+                if (Object.getPrototypeOf(flatValues[key]) !== Object.prototype) {
+                    nameValues.push({ name: key, value: `${flatValues[key]}` });
+                } else if (Object.getPrototypeOf(flatValues[key]) === Object.prototype && Object.keys(flatValues[key]).length != 0) {
+                    nameValues.push({ name: key, value: `${flatValues[key]}` });
+                }
+            }
         }
         const repository = deployment.repository ?? this.generateDefaultRepo(deployment.name);
 

--- a/lib/addons/argocd/application.ts
+++ b/lib/addons/argocd/application.ts
@@ -3,7 +3,7 @@ import { GitOpsApplicationDeployment, GitRepositoryReference } from '../../spi';
 
 /**
  * Argo Application is a utility class that can generate an ArgoCD application
- * from generic GitOps application properties.  
+ * from generic GitOps application properties.
  */
 export class ArgoApplication {
 
@@ -60,8 +60,8 @@ export class ArgoApplication {
 
     /**
      * Creates an opinionated path.
-     * @param name 
-     * @returns 
+     * @param name
+     * @returns
      */
     generateDefaultRepo(name: string): GitRepositoryReference {
         if (this.bootstrapRepo) {

--- a/lib/addons/efs-csi-driver/index.ts
+++ b/lib/addons/efs-csi-driver/index.ts
@@ -89,6 +89,8 @@ function populateValues(helmOptions: EfsCsiDriverProps, clusterName: string,
     setPath(values, "clusterName",  clusterName);
     setPath(values, "controller.serviceAccount.create",  false);
     setPath(values, "controller.serviceAccount.name",  serviceAccountName);
+    setPath(values, "node.serviceAccount.create",  false);
+    setPath(values, "node.serviceAccount.name",  serviceAccountName);
     setPath(values, "replicaCount",  helmOptions.replicaCount);
     setPath(values, "image.repository",  repository);
 


### PR DESCRIPTION
*Description of changes:*

- Fixed the bug where the `replicaCount` for csi efs addon is not passing to ArgoCD
- Fixed the csi efs node service account so it is consistent as Terraform implementation

![image](https://user-images.githubusercontent.com/5382613/175768967-49e1c57c-0430-443f-a7ac-077ac06b9e1a.png)
note: container-insignt is not in sync due to endpoint of AMP is not provided (needs another PR to create the IRSA as well)

![image](https://user-images.githubusercontent.com/5382613/175768974-2ce09815-2db4-4532-8022-537cc1a26b69.png)
Notes:
- Karpenter is actually working, out of sync is due to the ca-bundle in the secret is not in sync. Needs to add `ignoreDifferences` to let Argo know.
- nginx is in sync.
- need another PR to add kubevious to addon repo
- need another PR to add velero to addon repo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
