### PR TITLE
Correct key-value of elasticSearch

### DIFF
--- a/docs/addons/aws-for-fluent-bit.md
+++ b/docs/addons/aws-for-fluent-bit.md
@@ -73,7 +73,7 @@ const awsForFluentBit = new blueprints.addons.AwsForFluentBitAddOn({
 	values: {
 		elasticSearch: {
 			enabled: true,
-			region: "<aws_region",
+			awsRegion: "<aws_region",
 			host: "<elastic_search_host>"
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Unfortunately the key of region is `awsRegion` instead of `region` like others
Check https://github.com/aws/eks-charts/blob/master/stable/aws-for-fluent-bit/values.yaml#L119

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
