### PR TITLE
Fixing EBS CSI Driver Addon and coreAddon Modules

### DIFF
--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -20,7 +20,7 @@ export class CoreAddOnProps {
      */
     readonly policyDocumentProvider?: (partition: string) => PolicyDocument;
     /**
-     * Service Account Name to be used with AddOn.
+     * Service Account Name to be used with AddOn
      */
     readonly saName: string;
 }

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,4 +1,4 @@
-import { CfnAddon } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo } from "../../spi";
 import { Construct } from "constructs";
@@ -19,6 +19,10 @@ export class CoreAddOnProps {
      * Policy document provider returns the policy required by the add-on to allow it to interact with AWS resources
      */
     readonly policyDocumentProvider?: (partition: string) => PolicyDocument;
+    /**
+     * Service Account Name to be used with AddOn.
+     */
+    readonly saName: string;
 }
 
 const DEFAULT_NAMESPACE = "kube-system";
@@ -38,23 +42,28 @@ export class CoreAddOn implements ClusterAddOn {
 
         // Create a service account if user provides namespace and service account
         let serviceAccountRoleArn: string | undefined = undefined;
+        let serviceAccount: ServiceAccount | undefined = undefined;
 
         if (this.coreAddOnProps?.policyDocumentProvider) {
             const policyDoc = this.coreAddOnProps.policyDocumentProvider(clusterInfo.cluster.stack.partition);
-            const serviceAccount = createServiceAccount(clusterInfo.cluster, this.coreAddOnProps.addOnName,
+            serviceAccount  = createServiceAccount(clusterInfo.cluster, this.coreAddOnProps.saName,
                 DEFAULT_NAMESPACE, policyDoc);
             serviceAccountRoleArn = serviceAccount.role.roleArn;
+
         }
-
-
-        // Instantiate the Add-on
-        return Promise.resolve(
-            new CfnAddon(clusterInfo.cluster.stack, this.coreAddOnProps.addOnName + "-addOn", {
+        const cfnaddon = new CfnAddon(clusterInfo.cluster.stack, this.coreAddOnProps.addOnName + "-addOn", {
             addonName: this.coreAddOnProps.addOnName,
             addonVersion: this.coreAddOnProps.version,
             clusterName: clusterInfo.cluster.clusterName,
             serviceAccountRoleArn: serviceAccountRoleArn,
             resolveConflicts: "OVERWRITE"
-        }));
+        });
+        
+        if (serviceAccount) {
+            cfnaddon.node.addDependency(serviceAccount);
+        }
+
+        // Instantiate the Add-on
+        return Promise.resolve(cfnaddon!);
     }
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -8,7 +8,8 @@ export class CoreDnsAddOn extends CoreAddOn {
     constructor(version?: string) {
         super({
             addOnName: "coredns",
-            version: version ?? "v1.8.4-eksbuild.1"
+            version: version ?? "v1.8.4-eksbuild.1",
+            saName: "coredns"
         });
     }
 }

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -6,7 +6,9 @@ import { getEbsDriverPolicyDocument } from "./iam-policy";
  */
 const defaultProps = {
     addOnName: 'aws-ebs-csi-driver',
-    version: 'v1.4.0-eksbuild.preview'
+    version: 'v1.4.0-eksbuild.preview',
+    saName: 'ebs-csi-controller-sa'
+    
 };
 
 /**
@@ -18,6 +20,7 @@ export class EbsCsiDriverAddOn extends CoreAddOn {
         super({
             addOnName: defaultProps.addOnName,
             version: version ?? defaultProps.version,
+            saName: defaultProps.saName,
             policyDocumentProvider: getEbsDriverPolicyDocument
         });
     }

--- a/lib/addons/kube-proxy/index.ts
+++ b/lib/addons/kube-proxy/index.ts
@@ -8,7 +8,8 @@ export class KubeProxyAddOn extends CoreAddOn {
     constructor(version?: string) {
         super({
             addOnName: "kube-proxy",
-            version: version ?? "v1.21.2-eksbuild.2"
+            version: version ?? "v1.21.2-eksbuild.2",
+            saName: "kube-proxy"
         });
     }
 }

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -8,7 +8,8 @@ export class VpcCniAddOn extends CoreAddOn {
     constructor(version?: string) {
         super({
             addOnName: "vpc-cni",
-            version: version ?? "v1.10.2-eksbuild.1"
+            version: version ?? "v1.10.2-eksbuild.1",
+            saName: "vpc-cni"
         });
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #419 

*Description of changes: 

1. Standardization of the `core-addon` module to allow service account name as additional parameter and using the same to create service account for the addon using this model. 
2. Added a dependency to `CfnAddon` to avoid race condition while deployment of the addons.
3. Fixing Issue Related to EBS CSI Driver - deployed with incorrect trust relationship in `ebs-csi-driver` Addon.
4. Adding SA Name to pass as parameter to `CoreAddon` on `coredns`, `kube-proxy` and `vpc-cni` Addons.
 Also 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice
