### PR TITLE
Bug: Missing container image registry for add-on in ap-southeast-3 region

### DIFF
--- a/lib/utils/registry-utils.ts
+++ b/lib/utils/registry-utils.ts
@@ -7,6 +7,7 @@ export const registries = new Map([
     ["ap-south-1","602401143452.dkr.ecr.ap-south-1.amazonaws.com/"],
     ["ap-southeast-1","602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/"],
     ["ap-southeast-2","602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/"],
+    ["ap-southeast-3","296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/"],
     ["ca-central-1","602401143452.dkr.ecr.ca-central-1.amazonaws.com/"],
     ["cn-north-1","918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/"],
     ["cn-northwest-1","961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/"],


### PR DESCRIPTION
*Issue #, if available:*  #437

*Description of changes:*
Adding entry of container image registry for add-on in ap-southeast-3 region at `lib/utils/registry-utils.ts`. Changes is tested with new deployment and update by referencing locally-compiled cdk-eks-blueprints distribution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
