### PR TITLE
Feature/adot addon

### DIFF
--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -1,0 +1,67 @@
+# AWS Distro for OpenTelemetry (ADOT) Amazon EKS Add-on
+
+Amazon EKS supports using Amazon EKS API to install and manage the [AWS Distro for OpenTelemetry (ADOT) Operator] https://aws-otel.github.io/. This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
+
+This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors.
+
+For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
+
+## Prerequisites
+- The ADOT Operator uses admission webhooks to mutate and validate the Collector Custom Resource (CR) requests. In Kubernetes, the webhook requires a TLS certificate that the API server is configured to trust. There are multiple ways for you to generate the required TLS certificate. However, the default method is to install the latest version of the cert-manager. `certificate-manager` EKS blueprints should be added before ADOT addon.
+
+## Usage
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.AdotCollectorAddOn();
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+## Validation
+
+To validate that ADOT add-on is installed properly, ensure that the ADOT kubernetes resources are running in the cluster
+
+```bash
+kubectl get all -n opentelemetry-operator-system
+
+# Output
+NAME                                                             READY   STATUS    RESTARTS   AGE
+pod/opentelemetry-operator-controller-manager-845cbd7bf7-b5s9l   2/2     Running   0          140m
+
+NAME                                                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+service/opentelemetry-operator-controller-manager-metrics-service   ClusterIP   172.20.210.200   <none>        8443/TCP   140m
+service/opentelemetry-operator-webhook-service                      ClusterIP   172.20.56.72     <none>        443/TCP    140m
+
+NAME                                                        READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/opentelemetry-operator-controller-manager   1/1     1            1           140m
+
+NAME                                                                   DESIRED   CURRENT   READY   AGE
+replicaset.apps/opentelemetry-operator-controller-manager-845cbd7bf7   1         1         1       140m
+
+
+```
+
+Additionally, the `aws cli` can be used to determine which version of the add-on is installed in the cluster
+```bash
+# Assuming cluster-name is my-cluster, below command shows the version of coredns installed. Check if it is same as the version installed via EKS add-on
+aws eks describe-addon \
+    --cluster-name my-cluster \
+    --addon-name adot \
+    --query "addon.addonVersion" \
+    --output text
+    
+# Output
+v0.51.0-eksbuild.1
+```  
+
+## Functionality
+
+Applies the ADOT Driver add-on to an Amazon EKS cluster. 

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -1,6 +1,6 @@
 # AWS Distro for OpenTelemetry (ADOT) Amazon EKS Add-on
 
-Amazon EKS supports using Amazon EKS API to install and manage the [AWS Distro for OpenTelemetry (ADOT) Operator] https://aws-otel.github.io/. This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
+Amazon EKS supports using Amazon EKS API to install and manage the [AWS Distro for OpenTelemetry] (https://aws-otel.github.io/). This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
 
 This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors.
 

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -49,7 +49,7 @@ replicaset.apps/opentelemetry-operator-controller-manager-845cbd7bf7   1        
 
 ```
 
-Additionally, the `aws cli` can be used to determine which version of the add-on is installed in the cluster
+Additionally, the `aws cli` can be used to determine which version of the add-on is installed in the cluster.
 ```bash
 # Assuming cluster-name is my-cluster, below command shows the version of coredns installed. Check if it is same as the version installed via EKS add-on
 aws eks describe-addon \

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -7,7 +7,7 @@ This driver is not automatically installed when you first create a cluster, it m
 For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
 ## Prerequisites
-- The ADOT Operator uses admission webhooks to mutate and validate the Collector Custom Resource (CR) requests. In Kubernetes, the webhook requires a TLS certificate that the API server is configured to trust. There are multiple ways for you to generate the required TLS certificate. However, the default method is to install the latest version of the cert-manager. `certificate-manager` EKS blueprints should be added before ADOT addon.
+- The ADOT Operator uses admission webhooks to mutate and validate the Collector Custom Resource (CR) requests. In Kubernetes, the webhook requires a TLS certificate that the API server is configured to trust. There are multiple ways for you to generate the required TLS certificate. However, the default method is to install the latest version of the cert-manager. You can install Certificate Manager using this [user guide] https://cert-manager.io/docs/installation/helm/ or you can use `certificate-manager` EKS blueprints addon which should be added before ADOT addon.
 
 ## Usage
 

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -7,7 +7,7 @@ This driver is not automatically installed when you first create a cluster, it m
 For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
 ## Prerequisites
-- The ADOT Operator uses admission webhooks to mutate and validate the Collector Custom Resource (CR) requests. In Kubernetes, the webhook requires a TLS certificate that the API server is configured to trust. There are multiple ways for you to generate the required TLS certificate. However, the default method is to install the latest version of the cert-manager. You can install Certificate Manager using this [user guide] https://cert-manager.io/docs/installation/helm/ or you can use `certificate-manager` EKS blueprints addon which should be added before ADOT addon.
+- The ADOT Operator uses admission webhooks to mutate and validate the Collector Custom Resource (CR) requests. In Kubernetes, the webhook requires a TLS certificate that the API server is configured to trust. There are multiple ways for you to generate the required TLS certificate. However, the default method is to install the latest version of the cert-manager. You can install Certificate Manager using this [user guide](https://cert-manager.io/docs/installation/helm/) or you can use `certificate-manager` EKS blueprints addon which should be added before ADOT addon.
 
 ## Usage
 

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -1,6 +1,6 @@
 # AWS Distro for OpenTelemetry (ADOT) Amazon EKS Add-on
 
-Amazon EKS supports using Amazon EKS API to install and manage the [AWS Distro for OpenTelemetry] (https://aws-otel.github.io/). This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
+Amazon EKS supports using Amazon EKS API to install and manage the AWS Distro for OpenTelemetry (ADOT) Operator. This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
 
 This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors.
 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -46,6 +46,7 @@ export default class BlueprintConstruct {
             // adminPasswordSecretName: "argo-admin-secret"
         });
         const addOns: Array<blueprints.ClusterAddOn> = [
+            new blueprints.addons.AdotCollectorAddOn(),
             new blueprints.addons.AppMeshAddOn(),
             new blueprints.addons.IstioBaseAddOn(),
             new blueprints.addons.IstioControlPlaneAddOn(),

--- a/lib/addons/adot/iam-policy.ts
+++ b/lib/addons/adot/iam-policy.ts
@@ -1,6 +1,6 @@
 import { PolicyDocument } from "aws-cdk-lib/aws-iam";
 
-export function getAdotCollectorPolicyDocument(partition: string) : PolicyDocument {
+export function getAdotCollectorPolicyDocument() : PolicyDocument {
     return PolicyDocument.fromJson({
             "Version": "2012-10-17",
             "Statement": [

--- a/lib/addons/adot/iam-policy.ts
+++ b/lib/addons/adot/iam-policy.ts
@@ -1,0 +1,50 @@
+import { PolicyDocument } from "aws-cdk-lib/aws-iam";
+
+export function getAdotCollectorPolicyDocument(partition: string) : PolicyDocument {
+    return PolicyDocument.fromJson({
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "aps:RemoteWrite"
+                    ],
+                    "Resource": "*"
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "cloudwatch:PutMetricData",
+                        "ec2:DescribeVolumes",
+                        "ec2:DescribeTags",
+                        "logs:PutLogEvents",
+                        "logs:DescribeLogStreams",
+                        "logs:DescribeLogGroups",
+                        "logs:CreateLogStream",
+                        "logs:CreateLogGroup"
+                    ],
+                    "Resource": "*"
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ssm:GetParameter"
+                    ],
+                    "Resource": "arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*"
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "xray:PutTraceSegments",
+                        "xray:PutTelemetryRecords",
+                        "xray:GetSamplingRules",
+                        "xray:GetSamplingTargets",
+                        "xray:GetSamplingStatisticSummaries"
+                    ],
+                    "Resource": [
+                        "*"
+                    ]
+                }
+            ]
+    });
+}

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -7,8 +7,7 @@ import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
 /**
  * Configuration options for the Adot add-on.
  */
- export interface AdotCollectorAddOnProps extends CoreAddOnProps {
-}
+ export interface AdotCollectorAddOnProps extends CoreAddOnProps 
 
 const defaultProps = {
     addOnName: 'adot',
@@ -41,7 +40,7 @@ const defaultProps = {
 
         const addOnPromise = super.deploy(clusterInfo);
         addOnPromise.then(AdotCollectorAddOn => AdotCollectorAddOn.node.addDependency(otelPermissionsStatement));
-        return addOnPromise
+        return addOnPromise;
     }
  }
 

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -1,9 +1,10 @@
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { ClusterInfo } from "../../spi";
 import { getAdotCollectorPolicyDocument } from "./iam-policy";
-import { loadYaml, readYamlDocument } from "../../utils";
+import { dependable, loadYaml, readYamlDocument } from "../../utils";
 import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
 import { Construct } from 'constructs';
+// import { CertManagerAddOn } from "../cert-manager";
 
 /**
  * Configuration options for the Adot add-on.
@@ -26,7 +27,7 @@ export class AdotCollectorAddOn extends CoreAddOn {
     constructor(props?: AdotCollectorAddOnProps) {
         super({ ...defaultProps, ...props });
     }
-
+    // @dependable(CertManagerAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct>  {
 
         const cluster = clusterInfo.cluster;

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -8,10 +8,11 @@ import { Construct } from 'constructs';
 /**
  * Configuration options for the Adot add-on.
  */
- type AdotCollectorAddOnProps = CoreAddOnProps;
+type AdotCollectorAddOnProps = CoreAddOnProps;
 
 const defaultProps = {
     addOnName: 'adot',
+    version: 'v0.51.0-eksbuild.1',
     saName: 'adot-collector',
     policyDocumentProvider: getAdotCollectorPolicyDocument,
     namespace: 'default'
@@ -20,7 +21,7 @@ const defaultProps = {
  /**
   * Implementation of Adot Collector EKS add-on.
   */
- export class AdotCollectorAddOn extends CoreAddOn {
+export class AdotCollectorAddOn extends CoreAddOn {
 
     constructor(props?: AdotCollectorAddOnProps) {
         super({ ...defaultProps, ...props });
@@ -32,26 +33,14 @@ const defaultProps = {
         // Applying ADOT Permission manifest
         const otelPermissionsDoc = readYamlDocument(__dirname + '/otel-permissions.yaml');
         const otelPermissionsManifest = otelPermissionsDoc.split("---").map(e => loadYaml(e));
-        const otelpermissionsstatement = new KubernetesManifest(cluster.stack, "adot-addon-otelPermissions", {
+        const otelPermissionsStatement = new KubernetesManifest(cluster.stack, "adot-addon-otelPermissions", {
             cluster,
             manifest: otelPermissionsManifest,
             overwrite: true
         });
 
         const addOnPromise = super.deploy(clusterInfo);
-        addOnPromise.then(AdotCollectorAddOn => AdotCollectorAddOn.node.addDependency(otelpermissionsstatement));
+        addOnPromise.then(addOn => addOn.node.addDependency(otelPermissionsStatement));
         return addOnPromise;
     }
- }
-
-
-
-
-
-
-
-
-
-
-
-
+}

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -1,0 +1,58 @@
+import { CoreAddOn, CoreAddOnProps } from "../core-addon";
+import { ClusterInfo } from "../../spi";
+import { getAdotCollectorPolicyDocument } from "./iam-policy";
+import { loadYaml, readYamlDocument } from "../../utils";
+import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
+
+/**
+ * Configuration options for the Adot add-on.
+ */
+ export interface AdotCollectorAddOnProps extends CoreAddOnProps {
+}
+
+const defaultProps = {
+    addOnName: 'adot',
+    saName: 'adot-collector',
+    policyDocumentProvider: getAdotCollectorPolicyDocument,
+    namespace: 'default'
+};
+
+ /**
+  * Implementation of Adot Collector EKS add-on.
+  */
+ export class AdotCollectorAddOn extends CoreAddOn {
+
+    constructor(props?: AdotCollectorAddOnProps) {
+        super({ ...defaultProps, ...props });
+    }
+
+    deploy(clusterInfo: ClusterInfo): any  {
+
+        const cluster = clusterInfo.cluster;
+        // Applying ADOT Permission manifest
+        const otelPermissionsDoc = readYamlDocument(__dirname + '/otel-permissions.yaml');
+        const otelPermissionsManifest = otelPermissionsDoc.split("---").map(e => loadYaml(e));
+        console.log("ADOT Manifest 1 => " +JSON.stringify(otelPermissionsManifest));
+        const otelPermissionsStatement = new KubernetesManifest(cluster.stack, "adot-addon-otelPermissions", {
+            cluster,
+            manifest: otelPermissionsManifest,
+            overwrite: true
+        });
+
+        const addOnPromise = super.deploy(clusterInfo);
+        addOnPromise.then(AdotCollectorAddOn => AdotCollectorAddOn.node.addDependency(otelPermissionsStatement));
+        return addOnPromise
+    }
+ }
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -3,11 +3,13 @@ import { ClusterInfo } from "../../spi";
 import { getAdotCollectorPolicyDocument } from "./iam-policy";
 import { loadYaml, readYamlDocument } from "../../utils";
 import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
+import { Construct } from 'constructs';
 
 /**
  * Configuration options for the Adot add-on.
  */
- export interface AdotCollectorAddOnProps extends CoreAddOnProps 
+ export interface AdotCollectorAddOnProps extends CoreAddOnProps {
+ }
 
 const defaultProps = {
     addOnName: 'adot',
@@ -25,21 +27,20 @@ const defaultProps = {
         super({ ...defaultProps, ...props });
     }
 
-    deploy(clusterInfo: ClusterInfo): any  {
+    deploy(clusterInfo: ClusterInfo): Promise<Construct>  {
 
         const cluster = clusterInfo.cluster;
         // Applying ADOT Permission manifest
         const otelPermissionsDoc = readYamlDocument(__dirname + '/otel-permissions.yaml');
         const otelPermissionsManifest = otelPermissionsDoc.split("---").map(e => loadYaml(e));
-        console.log("ADOT Manifest 1 => " +JSON.stringify(otelPermissionsManifest));
-        const otelPermissionsStatement = new KubernetesManifest(cluster.stack, "adot-addon-otelPermissions", {
+        const otelpermissionsstatement = new KubernetesManifest(cluster.stack, "adot-addon-otelPermissions", {
             cluster,
             manifest: otelPermissionsManifest,
             overwrite: true
         });
 
         const addOnPromise = super.deploy(clusterInfo);
-        addOnPromise.then(AdotCollectorAddOn => AdotCollectorAddOn.node.addDependency(otelPermissionsStatement));
+        addOnPromise.then(AdotCollectorAddOn => AdotCollectorAddOn.node.addDependency(otelpermissionsstatement));
         return addOnPromise;
     }
  }

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -4,7 +4,7 @@ import { getAdotCollectorPolicyDocument } from "./iam-policy";
 import { dependable, loadYaml, readYamlDocument } from "../../utils";
 import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
 import { Construct } from 'constructs';
-// import { CertManagerAddOn } from "../cert-manager";
+import { CertManagerAddOn } from "../cert-manager";
 
 /**
  * Configuration options for the Adot add-on.
@@ -27,7 +27,7 @@ export class AdotCollectorAddOn extends CoreAddOn {
     constructor(props?: AdotCollectorAddOnProps) {
         super({ ...defaultProps, ...props });
     }
-    // @dependable(CertManagerAddOn.name)
+    @dependable(CertManagerAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct>  {
 
         const cluster = clusterInfo.cluster;

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -8,8 +8,7 @@ import { Construct } from 'constructs';
 /**
  * Configuration options for the Adot add-on.
  */
- export interface AdotCollectorAddOnProps extends CoreAddOnProps {
- }
+ type AdotCollectorAddOnProps = CoreAddOnProps;
 
 const defaultProps = {
     addOnName: 'adot',

--- a/lib/addons/adot/otel-permissions.yaml
+++ b/lib/addons/adot/otel-permissions.yaml
@@ -1,0 +1,155 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: opentelemetry-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eks:addon-manager-otel
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["opentelemetrycollectors.opentelemetry.io","instrumentations.opentelemetry.io"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    resourceNames: ["opentelemetry-operator-system"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames: ["opentelemetry-operator-manager-role", "opentelemetry-operator-metrics-reader", "opentelemetry-operator-proxy-role"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings"]
+    resourceNames: ["opentelemetry-operator-manager-rolebinding", "opentelemetry-operator-proxy-rolebinding"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    resourceNames: ["opentelemetry-operator-mutating-webhook-configuration", "opentelemetry-operator-validating-webhook-configuration"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "list", "update"]
+  - apiGroups: ["opentelemetry.io"]
+    resources: ["opentelemetrycollectors"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["opentelemetry.io"]
+    resources: ["opentelemetrycollectors/finalizers"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["opentelemetry.io"]
+    resources: ["opentelemetrycollectors/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["opentelemetry.io"]
+    resources: ["instrumentations"]
+    verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eks:addon-manager-otel
+subjects:
+- kind: User
+  name: eks:addon-manager
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: eks:addon-manager-otel
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eks:addon-manager
+  namespace: opentelemetry-operator-system
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    resourceNames: ["opentelemetry-operator-controller-manager"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles"]
+    resourceNames: ["opentelemetry-operator-leader-election-role"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    resourceNames: ["opentelemetry-operator-leader-election-rolebinding"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["opentelemetry-operator-controller-manager-metrics-service", "opentelemetry-operator-webhook-service"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["opentelemetry-operator-controller-manager"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "issuers"]
+    resourceNames: ["opentelemetry-operator-serving-cert", "opentelemetry-operator-selfsigned-issuer"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eks:addon-manager
+  namespace: opentelemetry-operator-system
+subjects:
+- kind: User
+  name: eks:addon-manager
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: eks:addon-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -75,6 +75,5 @@ export class CoreAddOn implements ClusterAddOn {
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);
-        
     }
 }

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -48,14 +48,6 @@ export class CoreAddOn implements ClusterAddOn {
         let serviceAccountRoleArn: string | undefined = undefined;
         let serviceAccount: ServiceAccount | undefined = undefined;
         let saNamespace: string | undefined = undefined;
-        
-        let addOnprops = {
-            addonName: this.coreAddOnProps.addOnName,
-            addonVersion: "",
-            clusterName: clusterInfo.cluster.clusterName,
-            serviceAccountRoleArn: "",
-            resolveConflicts: "OVERWRITE"
-        }
 
         saNamespace = DEFAULT_NAMESPACE;
         if (this.coreAddOnProps?.namespace) {
@@ -68,10 +60,14 @@ export class CoreAddOn implements ClusterAddOn {
             serviceAccount  = createServiceAccount(clusterInfo.cluster, this.coreAddOnProps.saName,
                 saNamespace, policyDoc);
             serviceAccountRoleArn = serviceAccount.role.roleArn;
-
         }
-        if (serviceAccountRoleArn) {
-            addOnprops['serviceAccountRoleArn'] = serviceAccountRoleArn;
+
+        let addOnprops = {
+            addonName: this.coreAddOnProps.addOnName,
+            addonVersion: "",
+            clusterName: clusterInfo.cluster.clusterName,
+            serviceAccountRoleArn: serviceAccountRoleArn,
+            resolveConflicts: "OVERWRITE"
         }
 
         if (this.coreAddOnProps?.version) {

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -45,7 +45,6 @@ export class CoreAddOn implements ClusterAddOn {
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         
         let serviceAccountRoleArn: string | undefined = undefined;
-        let addonVersion: string | undefined = undefined;
         let serviceAccount: ServiceAccount | undefined = undefined;
         let saNamespace: string | undefined = undefined;
 
@@ -62,7 +61,7 @@ export class CoreAddOn implements ClusterAddOn {
             serviceAccountRoleArn = serviceAccount.role.roleArn;
         }
 
-        let addOnprops = {
+        let addOnProps = {
             addonName: this.coreAddOnProps.addOnName,
             addonVersion: this.coreAddOnProps.version,
             clusterName: clusterInfo.cluster.clusterName,
@@ -70,7 +69,7 @@ export class CoreAddOn implements ClusterAddOn {
             resolveConflicts: "OVERWRITE"
         }
 
-        const cfnAddon = new CfnAddon(clusterInfo.cluster.stack, this.coreAddOnProps.addOnName + "-addOn", addOnprops);
+        const cfnAddon = new CfnAddon(clusterInfo.cluster.stack, this.coreAddOnProps.addOnName + "-addOn", addOnProps);
         if (serviceAccount) {
             cfnAddon.node.addDependency(serviceAccount);
         }

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -4,6 +4,7 @@ import { ClusterInfo } from "../../spi";
 import { Construct } from "constructs";
 import { PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { createServiceAccount } from "../../utils";
+import { json } from "stream/consumers";
 
 export class CoreAddOnProps {
     /**
@@ -46,6 +47,7 @@ export class CoreAddOn implements ClusterAddOn {
 
         
         let serviceAccountRoleArn: string | undefined = undefined;
+        let addonVersion: string | undefined = undefined;
         let serviceAccount: ServiceAccount | undefined = undefined;
         let saNamespace: string | undefined = undefined;
 
@@ -64,14 +66,14 @@ export class CoreAddOn implements ClusterAddOn {
 
         let addOnprops = {
             addonName: this.coreAddOnProps.addOnName,
-            addonVersion: "",
+            addonVersion: this.coreAddOnProps.version,
             clusterName: clusterInfo.cluster.clusterName,
             serviceAccountRoleArn: serviceAccountRoleArn,
             resolveConflicts: "OVERWRITE"
         }
 
         if (this.coreAddOnProps?.version) {
-            addOnprops['addonVersion'] = this.coreAddOnProps.version
+            addOnprops.addonVersion = this.coreAddOnProps.version
         }
 
         const cfnaddon = new CfnAddon(clusterInfo.cluster.stack, this.coreAddOnProps.addOnName + "-addOn", addOnprops);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -75,5 +75,6 @@ export class CoreAddOn implements ClusterAddOn {
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);
+        
     }
 }

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -1,4 +1,5 @@
 
+export * from './adot';
 export * from './appmesh';
 export * from './argocd';
 export * from './aws-for-fluent-bit';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* ADOT Addon for Open Telemetry module does the following :
1. Grant permissions to Amazon EKS add-ons to install ADOT:
2. Create your service account and IAM role for ADOT Collector.
3. Install the AWS Distro for OpenTelemetry (ADOT) Operator. The ADOT Operator is a custom controller which introduces a new object type called the OpenTelemetryCollector through [CustomResourceDefinition (CRD)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/). When the ADOT Operator detects the presence of the OpenTelemetryCollector resource, then it installs the ADOT Collector.

 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
