### PR TITLE
Feature/xray adot addon

### DIFF
--- a/docs/addons/xray-adot-addon.md
+++ b/docs/addons/xray-adot-addon.md
@@ -2,7 +2,7 @@
 
 [AWS X-Ray](https://aws.amazon.com/xray/) helps developers analyze and debug production, distributed applications, such as those built using a microservices architecture. This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for X-Ray which receives traces from the application and sends the same to X-Ray console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
 
-This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup AMP for remote write of metrics.
+This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup X-Ray for remote write traces.
 
 For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
@@ -51,7 +51,7 @@ const blueprint = blueprints.EksBlueprint.builder()
 
 ## Validation
 
-To validate that AMP add-on is installed properly, ensure that the required kubernetes resources are running in the cluster
+To validate that X-Ray add-on is installed properly, ensure that the required kubernetes resources are running in the cluster
 
 ```bash
 kubectl get all -n default

--- a/docs/addons/xray-adot-addon.md
+++ b/docs/addons/xray-adot-addon.md
@@ -1,18 +1,18 @@
 # AWS X-Ray AWS Distro for OpenTelemetry (ADOT) Add-on
 
-[AWS X-Ray](https://aws.amazon.com/xray/) helps developers analyze and debug production, distributed applications, such as those built using a microservices architecture. This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for X-Ray which receives traces from the application and sends the same to X-Ray console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
+[AWS X-Ray](https://aws.amazon.com/xray/) helps developers analyze and debug production, distributed applications, such as those built using a microservices architecture. This add-on deploys an AWS Distro for OpenTelemetry (ADOT) Collector for X-Ray which receives traces from the application and sends the same to X-Ray console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
 
-This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup X-Ray for remote write traces.
+This add-on is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup X-Ray for remote write traces.
 
-For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
+For more information on the add-on, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
 ## Prerequisites
-- `Certificate-Manager` Blueprints Addon addon.
-- `ADOT` EKS Blueprints Addon.
+- `cert-manager` Blueprints add-on.
+- `adot` EKS Blueprints add-on.
 
 ## Usage
 
-This Addon can used with two different patterns :
+This add-on can used with two different patterns :
 
 Pattern # 1 : Simple and Easy - Using all default property values. This pattern deploys an ADOT collector in the `default` namespace with `deployment` as the mode to write traces to X-Ray console.
 
@@ -30,7 +30,7 @@ const blueprint = blueprints.EksBlueprint.builder()
   .build(app, 'my-stack-name');
 ```
 
-Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace` with `daemonset` as the mode to X-Ray console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
+Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace`, name specified in `name` with `daemonset` as the mode to X-Ray console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
 
 ```typescript
 import 'source-map-support/register';
@@ -41,7 +41,8 @@ const app = new cdk.App();
 
 const addOn = new blueprints.addons.XrayAdotAddOn({
     deploymentMode: XrayDeploymentMode.DAEMONSET,
-    namespace: 'default'
+    namespace: 'default',
+    name: 'adot-collector-xray'
 });
 
 const blueprint = blueprints.EksBlueprint.builder()

--- a/docs/addons/xray-adot-addon.md
+++ b/docs/addons/xray-adot-addon.md
@@ -1,0 +1,82 @@
+# AWS X-Ray AWS Distro for OpenTelemetry (ADOT) Add-on
+
+[AWS X-Ray](https://aws.amazon.com/xray/) helps developers analyze and debug production, distributed applications, such as those built using a microservices architecture. This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for X-Ray which receives traces from the application and sends the same to X-Ray console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
+
+This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup AMP for remote write of metrics.
+
+For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
+
+## Prerequisites
+- `Certificate-Manager` Blueprints Addon addon.
+- `ADOT` EKS Blueprints Addon.
+
+## Usage
+
+This Addon can used with two different patterns :
+
+Pattern # 1 : Simple and Easy - Using all default property values. This pattern deploys an ADOT collector in the `default` namespace with `deployment` as the mode to write traces to X-Ray console.
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.XrayAdotAddOn();
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace` with `daemonset` as the mode to X-Ray console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.XrayAdotAddOn({
+    deploymentMode: XrayDeploymentMode.DAEMONSET,
+    namespace: 'default'
+});
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+## Validation
+
+To validate that AMP add-on is installed properly, ensure that the required kubernetes resources are running in the cluster
+
+```bash
+kubectl get all -n default
+```
+
+## Output
+```bash
+NAME                                                 READY   STATUS        RESTARTS   AGE
+pod/otel-collector-xray-collector-6fc44d9bbf-xdfpg   1/1     Running       0          6m44s
+pod/traffic-generator-86f86d84cc-s78wv               0/1     Terminating   0          128m
+
+NAME                                               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
+service/kubernetes                                 ClusterIP   172.20.0.1      <none>        443/TCP             3d
+service/otel-collector-xray-collector              ClusterIP   172.20.83.240   <none>        4317/TCP,4318/TCP   6m46s
+service/otel-collector-xray-collector-headless     ClusterIP   None            <none>        4317/TCP,4318/TCP   6m46s
+service/otel-collector-xray-collector-monitoring   ClusterIP   172.20.2.85     <none>        8888/TCP            6m46s
+
+NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/otel-collector-xray-collector   1/1     1            1           6m44s
+
+NAME                                                       DESIRED   CURRENT   READY   AGE
+replicaset.apps/otel-collector-xray-collector-6fc44d9bbf   1         1         1       6m44s
+```
+ 
+
+## Functionality
+
+Applies the X-Ray ADOT add-on to an Amazon EKS cluster. 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -67,6 +67,7 @@ export default class BlueprintConstruct {
             new blueprints.addons.AdotCollectorAddOn(),
             ampAddOn,
             // new blueprints.addons.AmpAddOn(),
+            new blueprints.addons.XrayAdotAddOn(),
             new blueprints.addons.AppMeshAddOn(),
             new blueprints.addons.IstioBaseAddOn(),
             new blueprints.addons.IstioControlPlaneAddOn(),

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -27,6 +27,7 @@ export * from './ssm-agent';
 export * from './velero';
 export * from './vpc-cni';
 export * from './xray';
+export * from './xray-adot-addon';
 export * from './keda';
 export * from './kubevious';
 export * from './ebs-csi-driver';

--- a/lib/addons/xray-adot-addon/collector-config-xray.ytpl
+++ b/lib/addons/xray-adot-addon/collector-config-xray.ytpl
@@ -2,9 +2,9 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
   name: otel-collector-xray
-  namespace: {{your_namespace}}
+  namespace: "{{namespace}}"
 spec:
-  mode: {{your_deployment_method}} 
+  mode: "{{deploymentMode}}"
   serviceAccount: adot-collector
   config: |
     receivers:
@@ -18,7 +18,7 @@ spec:
 
     exporters:
       awsxray:
-        region: {{your_aws_region}}
+        region: "{{awsRegion}}"
 
     service:
       pipelines:

--- a/lib/addons/xray-adot-addon/collector-config-xray.ytpl
+++ b/lib/addons/xray-adot-addon/collector-config-xray.ytpl
@@ -1,0 +1,28 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-xray
+  namespace: {{your_namespace}}
+spec:
+  mode: {{your_deployment_method}} 
+  serviceAccount: adot-collector
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+
+    exporters:
+      awsxray:
+        region: {{your_aws_region}}
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [awsxray]

--- a/lib/addons/xray-adot-addon/index.ts
+++ b/lib/addons/xray-adot-addon/index.ts
@@ -1,0 +1,79 @@
+import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
+import { ClusterAddOn, ClusterInfo } from "../../spi";
+import { dependable, loadYaml, readYamlDocument } from "../../utils";
+import { AdotCollectorAddOn } from "../adot";
+import { Construct } from 'constructs';
+
+/**
+ * Configuration options for add-on.
+ */
+ export interface XrayAdotAddOnProps {
+    /**
+     * Modes supported : `deployment`, `daemonset`, `statefulSet`, and `sidecar`
+     * @default deployment
+     */
+    deploymentMode?: XrayDeploymentMode;
+    /**
+     * Namespace to deploy the ADOT Collector for XRay.
+     * @default default
+     */
+    namepace?: string;
+}
+
+export const enum XrayDeploymentMode {
+    DEPLOYMENT = 'deployment',
+    DAEMONSET = 'daemonset',
+    STATEFULSET = 'statefulset',
+    SIDECAR = 'sidecar'
+}
+
+/**
+ * Defaults options for the add-on
+ */
+const defaultProps = {
+    deploymentMode: XrayDeploymentMode.DEPLOYMENT,
+    namespace: 'default'
+};
+
+/**
+ * Implementation of XRAY ADOT add-on for EKS Blueprints. Installs ADOT Collector.
+ */
+export class XrayAdotAddOn implements ClusterAddOn {
+
+    readonly xrayAddOnProps: XrayAdotAddOnProps;
+
+    constructor(props?: XrayAdotAddOnProps) {
+        this.xrayAddOnProps = { ...defaultProps, ...props };
+    }
+
+    @dependable(AdotCollectorAddOn.name)
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
+        const cluster = clusterInfo.cluster;
+        let finalDeploymentMode: string;
+        let finalNamespace: string;
+        let doc: string;
+        
+        finalDeploymentMode = defaultProps.deploymentMode;
+        if (this.xrayAddOnProps.deploymentMode) {
+            finalDeploymentMode = this.xrayAddOnProps.deploymentMode;
+        }
+
+        finalNamespace = defaultProps.namespace;
+        if (this.xrayAddOnProps.namepace) {
+            finalNamespace = this.xrayAddOnProps.namepace;
+        }
+
+        // Applying manifest for configuring ADOT Collector for Xray.
+        doc = readYamlDocument(__dirname + '/collector-config-xray.ytpl');
+        const docArray = doc.replace(/{{your_aws_region}}/g, cluster.stack.region)
+        .replace(/{{your_deployment_method}}/g, finalDeploymentMode)
+        .replace(/{{your_namespace}}/g, finalNamespace);
+        const manifest = docArray.split("---").map(e => loadYaml(e));
+        const statement = new KubernetesManifest(cluster.stack, "adot-collector-xray", {
+            cluster,
+            manifest,
+            overwrite: true
+        });
+        return Promise.resolve(statement);
+    }
+}

--- a/lib/addons/xray-adot-addon/index.ts
+++ b/lib/addons/xray-adot-addon/index.ts
@@ -23,7 +23,7 @@ export interface XrayAdotAddOnProps {
      * Namespace to deploy the ADOT Collector for XRay.
      * @default default
      */
-    namepace?: string;
+    namespace?: string;
     /**
      * Name for deployment of the ADOT Collector for XRay.
      * @default 'adot-collector-xray'
@@ -69,12 +69,12 @@ export class XrayAdotAddOn implements ClusterAddOn {
         const values: Values = {
             awsRegion: cluster.stack.region,
             deploymentMode: this.xrayAddOnProps.deploymentMode,
-            namespace: this.xrayAddOnProps.namepace
+            namespace: this.xrayAddOnProps.namespace
          };
          
          const manifestDeployment: ManifestDeployment = {
             name: this.xrayAddOnProps.name!,
-            namespace: this.xrayAddOnProps.namepace!,
+            namespace: this.xrayAddOnProps.namespace!,
             manifest,
             values
         };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
             "es2018",
             "dom"
         ],
-        // "types": ["node"],
         "declaration": true,
         "strict": true,
         "noImplicitAny": true,
@@ -21,7 +20,7 @@
         "inlineSourceMap": true,
         "inlineSources": true,
         "experimentalDecorators": true,
-        // "skipLibCheck": true,
+        "skipLibCheck": true,
         "strictPropertyInitialization": false,
         "typeRoots": [
             "./node_modules/@types"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
             "es2018",
             "dom"
         ],
+        // "types": ["node"],
         "declaration": true,
         "strict": true,
         "noImplicitAny": true,
@@ -20,7 +21,7 @@
         "inlineSourceMap": true,
         "inlineSources": true,
         "experimentalDecorators": true,
-        "skipLibCheck": true,
+        // "skipLibCheck": true,
         "strictPropertyInitialization": false,
         "typeRoots": [
             "./node_modules/@types"


### PR DESCRIPTION
*Issue #, if available:* XRAY ADOT Addon.

*Description of changes:*

[AWS X-Ray](https://aws.amazon.com/xray/) helps developers analyze and debug production, distributed applications, such as those built using a microservices architecture. This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for X-Ray which receives traces from the application and sends the same to X-Ray console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
