### PR TITLE
Feature/cw adot addon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ lint:
 build:
 	rm -rf dist && $(TSC)
 	$(COPY) lib/**/*.yaml dist/ -u 1
+	$(COPY) lib/**/*.ytpl dist/ -u 1
 
 compile:
 	$(TSC)
 	$(COPY) lib/**/*.yaml dist/ -u 1
+	$(COPY) lib/**/*.ytpl dist/ -u 1
 
 list:
 	$(DEPS)

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -2,9 +2,9 @@
 
 Amazon EKS supports using Amazon EKS API to install and manage the AWS Distro for OpenTelemetry (ADOT) Operator. This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
 
-This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors.
+This add-on is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors.
 
-For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
+For more information on the add-on, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
 ## Prerequisites
 - The ADOT Operator uses admission webhooks to mutate and validate the Collector Custom Resource (CR) requests. In Kubernetes, the webhook requires a TLS certificate that the API server is configured to trust. There are multiple ways for you to generate the required TLS certificate. However, the default method is to install the latest version of the cert-manager. You can install Certificate Manager using this [user guide](https://cert-manager.io/docs/installation/helm/) or you can use `certificate-manager` EKS blueprints addon which should be added before ADOT addon.
@@ -12,7 +12,6 @@ For more information on the driver, please review the [user guide](https://docs.
 ## Usage
 
 ```typescript
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
 
@@ -64,4 +63,4 @@ v0.51.0-eksbuild.1
 
 ## Functionality
 
-Applies the ADOT Driver add-on to an Amazon EKS cluster. 
+Applies the ADOT add-on to an Amazon EKS cluster. 

--- a/docs/addons/cloudwatch-adot-addon.md
+++ b/docs/addons/cloudwatch-adot-addon.md
@@ -1,18 +1,18 @@
 # AWS CloudWatch AWS Distro for OpenTelemetry (ADOT) Add-on
 
-[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) collects monitoring and operational data in the form of logs, metrics, and events. You get a unified view of operational health and gain complete visibility of your AWS resources, applications, and services running on AWS and on-premises.  This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for CloudWatch which receives metrics and logs from the application and sends the same to CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) collects monitoring and operational data in the form of logs, metrics, and events. You get a unified view of operational health and gain complete visibility of your AWS resources, applications, and services running on AWS and on-premises.  This add-on deploys an AWS Distro for OpenTelemetry (ADOT) Collector for CloudWatch which receives metrics and logs from the application and sends the same to CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
 
 This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup CloudWatch for remote write metrics.
 
 For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
 ## Prerequisites
-- `Certificate-Manager` Blueprints Addon addon.
-- `ADOT` EKS Blueprints Addon.
+- `cert-manager` Blueprints add-on.
+- `adot` EKS Blueprints add-on.
 
 ## Usage
 
-This Addon can used with two different patterns :
+This add-on can used with two different patterns :
 
 Pattern # 1 : Simple and Easy - Using all default property values. This pattern deploys an ADOT collector with `deployment` as the mode to write traces to CloudWatch console.
 
@@ -30,7 +30,7 @@ const blueprint = blueprints.EksBlueprint.builder()
   .build(app, 'my-stack-name');
 ```
 
-Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace` with `daemonset` as the mode to CloudWatch console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
+Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace`, name specified in `name` with `daemonset` as the mode to CloudWatch console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
 
 ```typescript
 import 'source-map-support/register';
@@ -41,7 +41,8 @@ const app = new cdk.App();
 
 const addOn = new blueprints.addons.CloudWatchAdotAddOn({
     deploymentMode: cloudWatchDeploymentMode.DEPLOYMENT,
-    namepace: 'default'
+    namepace: 'default',
+    name: 'adot-collector-cloudwatch'
 });
 
 const blueprint = blueprints.EksBlueprint.builder()

--- a/docs/addons/cloudwatch-adot-addon.md
+++ b/docs/addons/cloudwatch-adot-addon.md
@@ -1,0 +1,79 @@
+# AWS CloudWatch AWS Distro for OpenTelemetry (ADOT) Add-on
+
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) collects monitoring and operational data in the form of logs, metrics, and events. You get a unified view of operational health and gain complete visibility of your AWS resources, applications, and services running on AWS and on-premises.  This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for CloudWatch which receives metrics and logs from the application and sends the same to CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
+
+This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup CloudWatch for remote write metrics.
+
+For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
+
+## Prerequisites
+- `Certificate-Manager` Blueprints Addon addon.
+- `ADOT` EKS Blueprints Addon.
+
+## Usage
+
+This Addon can used with two different patterns :
+
+Pattern # 1 : Simple and Easy - Using all default property values. This pattern deploys an ADOT collector with `deployment` as the mode to write traces to CloudWatch console.
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.CloudWatchAdotAddOn();
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace` with `daemonset` as the mode to CloudWatch console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.CloudWatchAdotAddOn({
+    deploymentMode: cloudWatchDeploymentMode.DEPLOYMENT,
+    namepace: 'default'
+});
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+## Validation
+
+To validate that CloudWatch add-on is installed properly, ensure that the required kubernetes resources are running in the cluster
+
+```bash
+kubectl get all -n default
+```
+
+## Output
+```bash
+NAME                                                       READY   STATUS    RESTARTS   AGE
+pod/otel-collector-cloudwatch-collector-7565f958c6-r485f   1/1     Running   0          2m41s
+
+NAME                                                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+service/kubernetes                                       ClusterIP   172.20.0.1       <none>        443/TCP    18h
+service/otel-collector-cloudwatch-collector-monitoring   ClusterIP   172.20.254.103   <none>        8888/TCP   2m43s
+
+NAME                                                  READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/otel-collector-cloudwatch-collector   1/1     1            1           2m42s
+
+NAME                                                             DESIRED   CURRENT   READY   AGE
+replicaset.apps/otel-collector-cloudwatch-collector-7565f958c6   1         1         1       2m42s
+```
+ 
+
+## Functionality
+
+Applies the CloudWatch ADOT add-on to an Amazon EKS cluster. 

--- a/docs/addons/cloudwatch-adot-addon.md
+++ b/docs/addons/cloudwatch-adot-addon.md
@@ -2,9 +2,9 @@
 
 [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) collects monitoring and operational data in the form of logs, metrics, and events. You get a unified view of operational health and gain complete visibility of your AWS resources, applications, and services running on AWS and on-premises.  This add-on deploys an AWS Distro for OpenTelemetry (ADOT) Collector for CloudWatch which receives metrics and logs from the application and sends the same to CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.
 
-This driver is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup CloudWatch for remote write metrics.
+This add-on is not automatically installed when you first create a cluster, it must be added to the cluster in order to setup CloudWatch for remote write metrics.
 
-For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
+For more information on the add-on, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
 ## Prerequisites
 - `cert-manager` Blueprints add-on.
@@ -17,7 +17,6 @@ This add-on can used with two different patterns :
 Pattern # 1 : Simple and Easy - Using all default property values. This pattern deploys an ADOT collector with `deployment` as the mode to write traces to CloudWatch console.
 
 ```typescript
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
 
@@ -30,10 +29,9 @@ const blueprint = blueprints.EksBlueprint.builder()
   .build(app, 'my-stack-name');
 ```
 
-Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace`, name specified in `name` with `daemonset` as the mode to CloudWatch console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
+Pattern # 2 : Overriding property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace`, name specified in `name` with `daemonset` as the mode to CloudWatch console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
 
 ```typescript
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
 

--- a/docs/addons/xray-adot-addon.md
+++ b/docs/addons/xray-adot-addon.md
@@ -17,7 +17,6 @@ This add-on can used with two different patterns :
 Pattern # 1 : Simple and Easy - Using all default property values. This pattern deploys an ADOT collector in the `default` namespace with `deployment` as the mode to write traces to X-Ray console.
 
 ```typescript
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
 
@@ -33,7 +32,6 @@ const blueprint = blueprints.EksBlueprint.builder()
 Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace`, name specified in `name` with `daemonset` as the mode to X-Ray console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
 
 ```typescript
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -68,6 +68,7 @@ export default class BlueprintConstruct {
             ampAddOn,
             // new blueprints.addons.AmpAddOn(),
             new blueprints.addons.XrayAdotAddOn(),
+            new blueprints.addons.CloudWatchAdotAddOn(),
             new blueprints.addons.AppMeshAddOn(),
             new blueprints.addons.IstioBaseAddOn(),
             new blueprints.addons.IstioControlPlaneAddOn(),

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -51,6 +51,7 @@ export default class BlueprintConstruct {
             new blueprints.addons.AdotCollectorAddOn(),
             new blueprints.addons.AmpAddOn(),
             new blueprints.addons.XrayAdotAddOn(),
+            new blueprints.addons.CloudWatchAdotAddOn(),
             new blueprints.addons.IstioBaseAddOn(),
             new blueprints.addons.IstioControlPlaneAddOn(),
             new blueprints.addons.CalicoOperatorAddOn(),
@@ -93,7 +94,6 @@ export default class BlueprintConstruct {
                 securityContextRunAsUser: 1001,
                 irsaRoles: ["CloudWatchFullAccess", "AmazonSQSFullAccess"]
             }),
-            new blueprints.addons.CertManagerAddOn(),
         ];
 
         // Instantiated to for helm version check.

--- a/lib/addons/amp/index.ts
+++ b/lib/addons/amp/index.ts
@@ -145,14 +145,14 @@ export class AmpAddOn implements ClusterAddOn {
             awsRegion,
             deploymentMode,
             namespace
-         }
+         };
          
          const manifestDeployment: ManifestDeployment = {
             name,
             namespace,
             manifest,
             values
-        }
+        };
 
         const kubectlProvider = new KubectlProvider(clusterInfo);
         const statement = kubectlProvider.addManifest(manifestDeployment);

--- a/lib/addons/amp/index.ts
+++ b/lib/addons/amp/index.ts
@@ -34,7 +34,7 @@ import { CfnTag } from "aws-cdk-lib/core";
      * Namespace to deploy the ADOT Collector for AMP.
      * @default default
      */
-     namepace?: string;
+     namespace?: string;
 }
 
 export const enum DeploymentMode {
@@ -115,8 +115,8 @@ export class AmpAddOn implements ClusterAddOn {
 
 
         finalNamespace = defaultProps.namespace;
-        if (this.ampAddOnProps.namepace) {
-            finalNamespace = this.ampAddOnProps.namepace;
+        if (this.ampAddOnProps.namespace) {
+            finalNamespace = this.ampAddOnProps.namespace;
         }
 
         // Applying manifest for configuring ADOT Collector for Amp.

--- a/lib/addons/amp/index.ts
+++ b/lib/addons/amp/index.ts
@@ -124,7 +124,7 @@ export class AmpAddOn implements ClusterAddOn {
             deploymentMode = this.ampAddOnProps.deploymentMode;
         }
 
-        name = defaultProps.namespace;
+        name = defaultProps.name;
         namespace = defaultProps.namespace;
         awsRegion = cluster.stack.region;
         if (this.ampAddOnProps.namepace) {

--- a/lib/addons/cloudwatch-adot-addon/collector-config-cloudwatch.ytpl
+++ b/lib/addons/cloudwatch-adot-addon/collector-config-cloudwatch.ytpl
@@ -1,0 +1,400 @@
+#
+# OpenTelemetry Collector configuration
+# Metrics pipeline with Prometheus Receiver and Amazon CloudWatch EMF Exporter sending metrics to Amazon CloudWatch
+# 
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-cloudwatch
+  namespace: {{your_namespace}}
+spec:
+  mode: {{your_deployment_method}}
+  serviceAccount: adot-collector
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8888'
+  env:
+    - name: CLUSTER_NAME
+      value: {{your_cluster_name}}
+  config: |
+    receivers:
+      #
+      # Scrape configuration for the Prometheus Receiver
+      # This is the same configuration used when Prometheus is installed using the community Helm chart
+      # 
+      prometheus:
+        config:
+          global:
+            scrape_interval: 15s
+            scrape_timeout: 10s
+
+          scrape_configs:
+          - job_name: kubernetes-apiservers
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: default;kubernetes;https
+              source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+
+          - job_name: kubernetes-nodes
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: node
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - replacement: kubernetes.default.svc:443
+              target_label: __address__
+            - regex: (.+)
+              replacement: /api/v1/nodes/$$1/proxy/metrics
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: __metrics_path__
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+
+          - job_name: kubernetes-nodes-cadvisor
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: node
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - replacement: kubernetes.default.svc:443
+              target_label: __address__
+            - regex: (.+)
+              replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: __metrics_path__
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+
+          - job_name: kubernetes-service-endpoints
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+              replacement: __param_$$1
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: kubernetes_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_service_name
+              target_label: kubernetes_name
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+
+          - job_name: kubernetes-service-endpoints-slow
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+              replacement: __param_$$1
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: kubernetes_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_service_name
+              target_label: kubernetes_name
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            scrape_interval: 5m
+            scrape_timeout: 30s
+            
+          - job_name: prometheus-pushgateway
+            kubernetes_sd_configs:
+            - role: service
+            relabel_configs:
+            - action: keep
+              regex: pushgateway
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_probe
+
+          - job_name: kubernetes-services
+            kubernetes_sd_configs:
+            - role: service
+            metrics_path: /probe
+            params:
+              module:
+              - http_2xx
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_probe
+            - source_labels:
+              - __address__
+              target_label: __param_target
+            - replacement: blackbox
+              target_label: __address__
+            - source_labels:
+              - __param_target
+              target_label: instance
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels:
+              - __meta_kubernetes_namespace
+              target_label: kubernetes_namespace
+            - source_labels:
+              - __meta_kubernetes_service_name
+              target_label: kubernetes_name
+
+          - job_name: kubernetes-pods
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+              replacement: __param_$$1
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: kubernetes_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: kubernetes_pod_name
+            - action: drop
+              regex: Pending|Succeeded|Failed|Completed
+              source_labels:
+              - __meta_kubernetes_pod_phase
+              
+          - job_name: kubernetes-pods-slow
+            scrape_interval: 5m
+            scrape_timeout: 30s          
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+              replacement: __param_$1
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+            - action: drop
+              regex: Pending|Succeeded|Failed|Completed
+              source_labels:
+              - __meta_kubernetes_pod_phase              
+                                                            
+    processors:
+      batch/metrics:
+        timeout: 60s
+      #
+      # Processor to transform the names of existing labels and/or add new labels to the metrics identified
+      #   
+      metricstransform/labelling:
+        transforms:
+          - include: .*
+            match_type: regexp
+            action: update
+            operations:
+              - action: add_label
+                new_label: EKS_Cluster
+                new_value: ${CLUSTER_NAME}
+              - action: update_label
+                label: kubernetes_pod_name
+                new_label: EKS_PodName
+              - action: update_label
+                label: kubernetes_namespace
+                new_label: EKS_Namespace               
+
+    exporters:
+      #
+      # AWS EMF exporter that sends metrics data as performance log events to Amazon CloudWatch
+      # Only the metrics that were filtered out by the processors get to this stage of the pipeline
+      # Under the metric_declarations field, add one or more sets of Amazon CloudWatch dimensions
+      # Each dimension must alredy exist as a label on the Prometheus metric
+      # For each set of dimensions, add a list of metrics under the metric_name_selectors field
+      # Metrics names may be listed explicitly or using regular expressions
+      # A default list of metrics has been provided
+      # Data from performance log events will be aggregated by Amazon CloudWatch using these dimensions to create an Amazon CloudWatch custom metric
+      #    
+      awsemf:
+        region: "{{your_aws_region}}"
+        namespace: ContainerInsights/Prometheus
+        log_group_name: '/aws/containerinsights/${CLUSTER_NAME}/prometheus'
+        resource_to_telemetry_conversion:
+          enabled: true
+        dimension_rollup_option: NoDimensionRollup
+        parse_json_encoded_attr_values: [Sources, kubernetes]
+        metric_declarations:
+          - dimensions: [[EKS_Cluster, EKS_Namespace, EKS_PodName]]
+            metric_name_selectors:
+              - apiserver_request_.*
+              - container_memory_.*
+              - container_threads
+              - otelcol_process_.*
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [batch/metrics,metricstransform/labelling]
+          exporters: [awsemf]         
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-prometheus-role
+  namespace: {{your_namespace}}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-prometheus-role-binding
+  namespace: {{your_namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-prometheus-role
+subjects:
+  - kind: ServiceAccount
+    name: adot-collector
+    namespace: {{your_namespace}}

--- a/lib/addons/cloudwatch-adot-addon/index.ts
+++ b/lib/addons/cloudwatch-adot-addon/index.ts
@@ -1,0 +1,80 @@
+import { KubernetesManifest } from "aws-cdk-lib/aws-eks";
+import { ClusterAddOn, ClusterInfo } from "../../spi";
+import { dependable, loadYaml, readYamlDocument } from "../../utils";
+import { AdotCollectorAddOn } from "../adot";
+import { Construct } from 'constructs';
+
+/**
+ * Configuration options for add-on.
+ */
+ export interface CloudWatchAdotAddOnProps {
+    /**
+     * Modes supported : `deployment`, `daemonset`, `statefulSet`, and `sidecar`
+     * @default deployment
+     */
+    deploymentMode?: cloudWatchDeploymentMode;
+    /**
+     * Namespace to deploy the ADOT Collector for CloudWatch.
+     * @default default
+     */
+    namepace?: string;
+}
+
+export const enum cloudWatchDeploymentMode {
+    DEPLOYMENT = 'deployment',
+    DAEMONSET = 'daemonset',
+    STATEFULSET = 'statefulset',
+    SIDECAR = 'sidecar'
+}
+
+/**
+ * Defaults options for the add-on
+ */
+const defaultProps = {
+    deploymentMode: cloudWatchDeploymentMode.DEPLOYMENT,
+    namespace: 'default'
+};
+
+/**
+ * Implementation of CloudWatch ADOT add-on for EKS Blueprints. Installs ADOT Collector.
+ */
+export class CloudWatchAdotAddOn implements ClusterAddOn {
+
+    readonly cloudWatchAddOnProps: CloudWatchAdotAddOnProps;
+
+    constructor(props?: CloudWatchAdotAddOnProps) {
+        this.cloudWatchAddOnProps = { ...defaultProps, ...props };
+    }
+
+    @dependable(AdotCollectorAddOn.name)
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
+        const cluster = clusterInfo.cluster;
+        let finalDeploymentMode: string;
+        let finalNamespace: string;
+        let doc: string;
+        
+        finalDeploymentMode = defaultProps.deploymentMode;
+        if (this.cloudWatchAddOnProps.deploymentMode) {
+            finalDeploymentMode = this.cloudWatchAddOnProps.deploymentMode;
+        }
+
+        finalNamespace = defaultProps.namespace;
+        if (this.cloudWatchAddOnProps.namepace) {
+            finalNamespace = this.cloudWatchAddOnProps.namepace;
+        }
+
+        // Applying manifest for configuring ADOT Collector for CloudWatch.
+        doc = readYamlDocument(__dirname + '/collector-config-cloudwatch.ytpl');
+        const docArray = doc.replace(/{{your_aws_region}}/g, cluster.stack.region)
+        .replace(/{{your_deployment_method}}/g, finalDeploymentMode)
+        .replace(/{{your_namespace}}/g, finalNamespace)
+        .replace(/{{your_cluster_name}}/g, clusterInfo.cluster.clusterName);
+        const manifest = docArray.split("---").map(e => loadYaml(e));
+        const statement = new KubernetesManifest(cluster.stack, "adot-collector-cloudwatch", {
+            cluster,
+            manifest,
+            overwrite: true
+        });
+        return Promise.resolve(statement);
+    }
+}

--- a/lib/addons/cloudwatch-adot-addon/index.ts
+++ b/lib/addons/cloudwatch-adot-addon/index.ts
@@ -39,6 +39,7 @@ export const enum cloudWatchDeploymentMode {
  */
 const defaultProps = {
     deploymentMode: cloudWatchDeploymentMode.DEPLOYMENT,
+    name: 'adot-collector-cloudwatch',
     namespace: 'default'
 };
 
@@ -68,7 +69,7 @@ export class CloudWatchAdotAddOn implements ClusterAddOn {
             deploymentMode = this.cloudWatchAddOnProps.deploymentMode;
         }
 
-        name = defaultProps.namespace;
+        name = defaultProps.name;
         namespace = defaultProps.namespace;
         awsRegion = cluster.stack.region;
         clusterName = cluster.clusterName;

--- a/lib/addons/cloudwatch-adot-addon/index.ts
+++ b/lib/addons/cloudwatch-adot-addon/index.ts
@@ -5,7 +5,7 @@ import { Construct } from 'constructs';
 import { KubectlProvider, ManifestDeployment } from "../helm-addon/kubectl-provider";
 
 /**
- * This CloudWatch ADOT add-on deploys an AWS Distro for OpenTelemetry (ADOT) Collector for 
+ * This CloudWatch ADOT Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for 
  * CloudWatch which receives metrics and logs from the application and sends the same to 
  * CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar 
  * depending on your deployment strategy.
@@ -75,8 +75,8 @@ export class CloudWatchAdotAddOn implements ClusterAddOn {
          };
          
          const manifestDeployment: ManifestDeployment = {
-            name: this.cloudWatchAddOnProps.namepace!,
-            namespace: this.cloudWatchAddOnProps.name!,
+            name: this.cloudWatchAddOnProps.name!,
+            namespace: this.cloudWatchAddOnProps.namepace!,
             manifest,
             values
         };

--- a/lib/addons/cloudwatch-adot-addon/index.ts
+++ b/lib/addons/cloudwatch-adot-addon/index.ts
@@ -54,6 +54,7 @@ const defaultProps = {
 export class CloudWatchAdotAddOn implements ClusterAddOn {
 
     readonly cloudWatchAddOnProps: CloudWatchAdotAddOnProps;
+
     constructor(props?: CloudWatchAdotAddOnProps) {
         this.cloudWatchAddOnProps = { ...defaultProps, ...props };
     }
@@ -61,11 +62,9 @@ export class CloudWatchAdotAddOn implements ClusterAddOn {
     @dependable(AdotCollectorAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
-        let doc: string;
 
         // Applying manifest for configuring ADOT Collector for CloudWatch.
-        doc = readYamlDocument(__dirname +'/collector-config-cloudwatch.ytpl');
-
+        const doc = readYamlDocument(__dirname +'/collector-config-cloudwatch.ytpl');
         const manifest = doc.split("---").map(e => loadYaml(e));
         const values: Values = {
             awsRegion: cluster.stack.region,

--- a/lib/addons/cloudwatch-adot-addon/index.ts
+++ b/lib/addons/cloudwatch-adot-addon/index.ts
@@ -24,7 +24,7 @@ export interface CloudWatchAdotAddOnProps {
      * Namespace to deploy the ADOT Collector for CloudWatch.
      * @default default
      */
-    namepace?: string;
+    namespace?: string;
     /**
      * Name to deploy the ADOT Collector for CloudWatch.
      * @default 'adot-collector-cloudwatch'
@@ -70,13 +70,13 @@ export class CloudWatchAdotAddOn implements ClusterAddOn {
         const values: Values = {
             awsRegion: cluster.stack.region,
             deploymentMode: this.cloudWatchAddOnProps.deploymentMode,
-            namespace: this.cloudWatchAddOnProps.namepace,
+            namespace: this.cloudWatchAddOnProps.namespace,
             clusterName: cluster.clusterName
          };
          
          const manifestDeployment: ManifestDeployment = {
             name: this.cloudWatchAddOnProps.name!,
-            namespace: this.cloudWatchAddOnProps.namepace!,
+            namespace: this.cloudWatchAddOnProps.namespace!,
             manifest,
             values
         };

--- a/lib/addons/cloudwatch-adot-addon/index.ts
+++ b/lib/addons/cloudwatch-adot-addon/index.ts
@@ -5,7 +5,7 @@ import { Construct } from 'constructs';
 import { KubectlProvider, ManifestDeployment } from "../helm-addon/kubectl-provider";
 
 /**
- * This CloudWatch ADOT Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for 
+ * This CloudWatch ADOT add-on deploys an AWS Distro for OpenTelemetry (ADOT) Collector for 
  * CloudWatch which receives metrics and logs from the application and sends the same to 
  * CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar 
  * depending on your deployment strategy.
@@ -25,6 +25,11 @@ export interface CloudWatchAdotAddOnProps {
      * @default default
      */
     namepace?: string;
+    /**
+     * Name to deploy the ADOT Collector for CloudWatch.
+     * @default 'adot-collector-cloudwatch'
+     */
+     name?: string;
 }
 
 export const enum cloudWatchDeploymentMode {
@@ -39,8 +44,8 @@ export const enum cloudWatchDeploymentMode {
  */
 const defaultProps = {
     deploymentMode: cloudWatchDeploymentMode.DEPLOYMENT,
-    name: 'adot-collector-cloudwatch',
-    namespace: 'default'
+    namespace: 'default',
+    name: 'adot-collector-cloudwatch'
 };
 
 /**
@@ -49,7 +54,6 @@ const defaultProps = {
 export class CloudWatchAdotAddOn implements ClusterAddOn {
 
     readonly cloudWatchAddOnProps: CloudWatchAdotAddOnProps;
-
     constructor(props?: CloudWatchAdotAddOnProps) {
         this.cloudWatchAddOnProps = { ...defaultProps, ...props };
     }
@@ -57,40 +61,22 @@ export class CloudWatchAdotAddOn implements ClusterAddOn {
     @dependable(AdotCollectorAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
-        let awsRegion: string;
-        let deploymentMode: string;
-        let name: string;
-        let namespace: string;
-        let clusterName: string;
         let doc: string;
-
-        deploymentMode = defaultProps.deploymentMode;
-        if (this.cloudWatchAddOnProps.deploymentMode) {
-            deploymentMode = this.cloudWatchAddOnProps.deploymentMode;
-        }
-
-        name = defaultProps.name;
-        namespace = defaultProps.namespace;
-        awsRegion = cluster.stack.region;
-        clusterName = cluster.clusterName;
-        if (this.cloudWatchAddOnProps.namepace) {
-            namespace = this.cloudWatchAddOnProps.namepace;
-        }
 
         // Applying manifest for configuring ADOT Collector for CloudWatch.
         doc = readYamlDocument(__dirname +'/collector-config-cloudwatch.ytpl');
 
         const manifest = doc.split("---").map(e => loadYaml(e));
         const values: Values = {
-            awsRegion,
-            deploymentMode,
-            namespace,
-            clusterName
+            awsRegion: cluster.stack.region,
+            deploymentMode: this.cloudWatchAddOnProps.deploymentMode,
+            namespace: this.cloudWatchAddOnProps.namepace,
+            clusterName: cluster.clusterName
          };
          
          const manifestDeployment: ManifestDeployment = {
-            name,
-            namespace,
+            name: this.cloudWatchAddOnProps.namepace!,
+            namespace: this.cloudWatchAddOnProps.name!,
             manifest,
             values
         };

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -8,11 +8,8 @@ export * from './aws-loadbalancer-controller';
 export * from './aws-node-termination-handler';
 export * from './calico';
 export * from './calico-operator';
-<<<<<<< HEAD
 export * from './cloudwatch-adot-addon';
-=======
 export * from './cert-manager';
->>>>>>> upstream/main
 export * from './cluster-autoscaler';
 export * from './container-insights';
 export * from './coredns';

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -8,6 +8,7 @@ export * from './aws-loadbalancer-controller';
 export * from './aws-node-termination-handler';
 export * from './calico';
 export * from './calico-operator';
+export * from './cloudwatch-adot-addon';
 export * from './cluster-autoscaler';
 export * from './container-insights';
 export * from './coredns';


### PR DESCRIPTION
*Issue #, if available:* AWS CloudWatch AWS Distro for OpenTelemetry (ADOT) Add-on

*Description of changes:*
[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) collects monitoring and operational data in the form of logs, metrics, and events. You get a unified view of operational health and gain complete visibility of your AWS resources, applications, and services running on AWS and on-premises.  This Addon deploys an AWS Distro for OpenTelemetry (ADOT) Collector for CloudWatch which receives metrics and logs from the application and sends the same to CloudWatch console. You can change the mode to Daemonset, StatefulSet, and Sidecar depending on your deployment strategy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
