### PR TITLE
karpenter fix, upgrade and prep for 1.2.0 release

### DIFF
--- a/docs/addons/karpenter.md
+++ b/docs/addons/karpenter.md
@@ -18,8 +18,6 @@ Karpenter works by:
 
 2. There is no support for utilizing both Cluster Autoscaler **and** Karpenter. Therefore, any addons list that has both will result in an error `Deploying <name of your stack> failed due to conflicting add-on: ClusterAutoscalerAddOn.`.
 
-3. The current add-on supports up to ***v0.12.1***. The latest version introduces a new CRD that is not currently supported.
-
 ## Prerequisite
 
 (If using Spot), EC2 Spot Service Linked Role should be created. See [here](https://docs.aws.amazon.com/batch/latest/userguide/spot_fleet_IAM_role.html) for more details.
@@ -197,3 +195,9 @@ or, by looking at the nodes being created:
 ```bash
 kubectl get nodes
 ```
+
+## Troubleshooting
+
+The following are common troubleshooting issues observed when implementing Karpenter:
+
+1. For Karpenter version older than `0.14.0` deployed on Fargate Profiles, `values.yaml` must be overridden, setting `dnsPolicy` to `Default`. Versions after `0.14.0` has `dnsPolicy` value set default to `Default`. This is to ensure CoreDNS is set correctly on Fargate nodes.

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -57,7 +57,7 @@ const RELEASE = 'blueprints-addon-karpenter';
 const defaultProps: HelmAddOnProps = {
     name: KARPENTER,
     namespace: KARPENTER,
-    version: '0.13.2',
+    version: '0.14.0',
     chart: KARPENTER,
     release: RELEASE,
     repository: 'https://charts.karpenter.sh',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:* 
#465 

*Description of changes:*
- Updated doc to notify users for possible issues using Fargate with Karpenter version prior to 0.14.0 and the fix.
- Upgrade default Karpenter to 0.14.0
- Prepare for Blueprints 1.2.0 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
