### PR TITLE
Feature/pipeline build role support

### DIFF
--- a/lib/addons/argocd/index.ts
+++ b/lib/addons/argocd/index.ts
@@ -61,7 +61,7 @@ export interface ArgoCDAddOnProps extends HelmAddOnUserProps {
  */
 const defaultProps = {
     namespace: "argocd",
-    version: '4.10.5',
+    version: '4.10.6',
     chart: "argo-cd",
     release: "blueprints-addon-argocd",
     repository: "https://argoproj.github.io/argo-helm"

--- a/lib/addons/keda/index.ts
+++ b/lib/addons/keda/index.ts
@@ -52,7 +52,7 @@ const defaultProps: HelmAddOnProps & KedaAddOnProps = {
   name: "blueprints-keda-addon",
   chart: "keda",
   namespace:"keda",
-  version: "2.8.0",
+  version: "2.8.1",
   release: "keda",
   repository:  "https://kedacore.github.io/charts",
   values: {},

--- a/lib/addons/kubevious/index.ts
+++ b/lib/addons/kubevious/index.ts
@@ -29,7 +29,7 @@ const defaultProps: HelmAddOnProps & KubeviousAddOnProps = {
     name: "blueprints-kubevious-addon",
     namespace: "kubevious",
     chart: "kubevious",
-    version: "1.0.10",
+    version: "1.0.11",
     release: "kubevious",
     repository:  "https://helm.kubevious.io",
     values: {},

--- a/lib/addons/secrets-store/index.ts
+++ b/lib/addons/secrets-store/index.ts
@@ -46,7 +46,7 @@ const defaultProps: SecretsStoreAddOnProps = {
     chart: 'secrets-store-csi-driver',
     name: 'secrets-store-csi-driver',
     namespace: 'kube-system',
-    version: '1.2.2',
+    version: '1.2.3',
     release: 'blueprints-addon-secret-store-csi-driver',
     repository: 'https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts',
     rotationPollInterval: undefined,

--- a/lib/addons/velero/index.ts
+++ b/lib/addons/velero/index.ts
@@ -19,7 +19,7 @@ export interface VeleroAddOnProps extends HelmAddOnUserProps {
  */
 const defaultProps = {
     name: 'velero',
-    version: "2.31.0",
+    version: "2.31.1",
     namespace: "velero",
     createNamespace: true,
     chart: "velero",

--- a/lib/pipelines/code-pipeline.ts
+++ b/lib/pipelines/code-pipeline.ts
@@ -148,8 +148,11 @@ export interface PipelineWave {
 /**
  * Default policy for the CodeBuild role generated. 
  * It allows look-ups, including access to AWS Secrets Manager. 
+ * Not recommended for production. For production use case, CodeBuild policies 
+ * must be restricted to particular resources. Outbound access from the build should be 
+ * controlled by ACL.
  */
-const DEFAULT_BUILD_POLICY = new PolicyStatement({
+export const DEFAULT_BUILD_POLICIES = [ new PolicyStatement({
     resources: ["*"],
     actions: [    
         "sts:AssumeRole",
@@ -157,7 +160,7 @@ const DEFAULT_BUILD_POLICY = new PolicyStatement({
         "secretsmanager:DescribeSecret",
         "cloudformation:*"
     ]
-});
+})];
 
 /**
  * Builder for CodePipeline.
@@ -189,20 +192,6 @@ export class CodePipelineBuilder implements StackBuilder {
         this.props.codeBuildPolicies = policies;
         return this;
     }
-
-    /**
-     * Enables default code build policies (opt-in method). 
-     * Allows secret lookup access to AWS Secrets Manager.
-     * Not recommended for production. In production, CodeBuild policies must be restricted to particular resources.
-     * Outbound access from the build should be controlled by ACL.
-     * @see DEFAULT_BUILD_POLICY 
-     * @returns 
-     */
-    public defaultCodeBuildPolicies() : CodePipelineBuilder {
-        this.props.codeBuildPolicies = [ DEFAULT_BUILD_POLICY ];
-        return this;
-    }
-
  
     public enableCrossAccountKeys() : CodePipelineBuilder {
         this.props.crossAccountKeys = true;

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -108,6 +108,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const pipeline = blueprints.CodePipelineStack.builder()
             .name("blueprints-pipeline-inaction")
             .owner('shapirov103')
+            .codeBuildPolicies(blueprints.DEFAULT_BUILD_POLICIES)
             .repository({
                 repoUrl: 'git@github',
                 credentialsSecretName: 'github-token',


### PR DESCRIPTION
*Issue #, if available:* #254

*Description of changes:* added support for IAM policies for CodeBuild role generated in pipelines.

Updated helm chart versions:

```
INFO  Chart argo-cd-4.10.6 is at the latest version. 
INFO  Chart appmesh-controller-1.5.1 is at the latest version. 
INFO  Chart cert-manager-1.9.1 is at the latest version. 
INFO  Chart base-1.14.3 is at the latest version. 
INFO  Chart istiod-1.14.3 is at the latest version. 
INFO  Chart tigera-operator-v3.23.3 is at the latest version. 
INFO  Chart metrics-server-3.8.2 is at the latest version. 
INFO  Chart aws-load-balancer-controller-1.4.4 is at the latest version. 
INFO  Chart nginx-ingress-0.14.0 is at the latest version. 
INFO  Chart velero-2.31.1 is at the latest version. 
INFO  Chart gatekeeper-3.9.0 is at the latest version. 
INFO  Chart karpenter-0.14.0 is at the latest version. 
INFO  Chart kubevious-1.0.11 is at the latest version. 
INFO  Chart aws-efs-csi-driver-2.2.7 is at the latest version. 
INFO  Chart keda-2.8.1 is at the latest version. 
INFO  Chart aws-privateca-issuer-1.2.2 is at the latest version. 
INFO  Chart external-dns-6.7.5 is at the latest version. 
INFO  Chart gatekeeper-3.9.0 is at the latest version. 
INFO  Chart secrets-store-csi-driver-1.2.3 is at the latest version. 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
