### PR TITLE
Update kubecost.md to the correct import

### DIFF
--- a/docs/addons/kubecost.md
+++ b/docs/addons/kubecost.md
@@ -16,7 +16,7 @@ $ npm install @kubecost/kubecost-eks-blueprints-addon
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
-import { KubecostAddOn } from '@kubecost/kubecost-blueprints-addon';
+import { KubecostAddOn } from '@kubecost/kubecost-eks-blueprints-addon';
 
 const app = new cdk.App();
 


### PR DESCRIPTION
when importing kubecost it's suppose to be : 
import { KubecostAddOn } from '@kubecost/kubecost-eks-blueprints-addon';

NOT import { KubecostAddOn } from '@kubecost/kubecost-blueprints-addon'; because the package that was installed was @kubecost/kubecost-eks-blueprints-addon

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
