### PR TITLE
Fixed the istio-system namespace missing from dependency graph

### DIFF
--- a/lib/addons/istio-base/index.ts
+++ b/lib/addons/istio-base/index.ts
@@ -72,7 +72,7 @@ export class IstioBaseAddOn extends HelmAddOn {
         const cluster = clusterInfo.cluster;
 
         // Istio Namespace
-        createNamespace('istio-system', cluster);
+        const namespace = createNamespace('istio-system', cluster);
 
         let values: Values = {
             global: {
@@ -89,6 +89,8 @@ export class IstioBaseAddOn extends HelmAddOn {
 
         values = merge(values, this.props.values ?? {});
         const chart = this.addHelmChart(clusterInfo, values);
-        return Promise.resolve(chart);
+        chart.node.addDependency(namespace)
+
+        return Promise.resolve(namespace);
     }
 }


### PR DESCRIPTION
*Description of changes:*
The istio-system namespace resource was omitted from CF dependency graph. That is why deleting the stack caused trouble as the namespace was deleted before other resources placed there. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
