### PR TITLE
Add Karpenter Node Instance Profile Name as a Cfn Output

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -5,9 +5,11 @@ import { ClusterInfo } from '../../spi';
 import { conflictsWith, createNamespace, createServiceAccount, dependable, setPath, } from '../../utils';
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '../helm-addon';
 import { KarpenterControllerPolicy } from './iam';
+import { CfnOutput } from 'aws-cdk-lib';
 import * as md5 from 'ts-md5';
 import * as semver from 'semver';
 import * as assert from "assert";
+import { Instance } from 'aws-cdk-lib/aws-ec2';
 
 
 /**
@@ -148,6 +150,10 @@ export class KarpenterAddOn extends HelmAddOn {
             roles: [karpenterNodeRole.roleName],
             instanceProfileName: `KarpenterNodeInstanceProfile-${instanceProfileName}`,
             path: '/'
+        });
+        new CfnOutput(clusterInfo.cluster.stack, 'Karpenter Instance Profile name', { 
+            value: karpenterInstanceProfile ? karpenterInstanceProfile.instanceProfileName! : "none",
+            description: "Karpenter add-on Instance Profile name" 
         });
 
         // Map Node Role to aws-auth

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -114,21 +114,22 @@ export class KarpenterAddOn extends HelmAddOn {
         const sgTags = this.options.securityGroupTags || {};
         const taints = this.options.taints || [];
         const amiFamily = this.options.amiFamily;
-        const version = this.options.version!;
         const ttlSecondsAfterEmpty = this.options.ttlSecondsAfterEmpty || null;
-        const weight = this.options.weight;
+        const weight = this.options.weight || null;
         
         // Weight only available with v0.16.0 and later
-        if (semver.lt(version, '0.16.0')){
-            assert(!weight, 'weight only supported on versions v0.16.0 and later.');
+        if (semver.lt(this.options.version!, '0.16.0')){
+            assert(!weight, 'The prop weight is only supported on versions v0.16.0 and later.');
         }
 
-        // Consolidation only available with v0.15.0 and later
         let consolidation;
-        if (semver.gte(version, '0.15.0')){
-            consolidation = this.options.consolidation; 
-            // You cannot set both consolidation and ttlSecondsAfterEmpty values
-            assert(( consolidation && !ttlSecondsAfterEmpty ) || ( !consolidation && ttlSecondsAfterEmpty ) , 'Consolidation and ttlSecondsAfterEmpty must be mutually exclusive.');
+        // Consolidation only available with v0.15.0 and later
+        if (semver.lt(this.options.version!, '0.15.0')){
+            assert(!this.options.consolidation, 'The prop consolidation is only supported on versions v0.15.0 and later.');
+        } else {
+            consolidation = this.options.consolidation || { enabled: false }; 
+            // You cannot enable consolidation and ttlSecondsAfterEmpty values
+            assert( !(consolidation.enabled && ttlSecondsAfterEmpty) , 'Consolidation and ttlSecondsAfterEmpty must be mutually exclusive.');
         }
 
         // Set up Node Role

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -1,0 +1,71 @@
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '../lib';
+
+describe('Unit tests for Karpenter addon', () => {
+
+    test("Stack creation fails due to conflicting add-ons", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addOns(new blueprints.VpcCniAddOn, new blueprints.KarpenterAddOn(), new blueprints.ClusterAutoScalerAddOn)
+            .teams(new blueprints.PlatformTeam({ name: 'platform' }));
+
+        expect(()=> {
+            blueprint.build(app, 'stack-with-conflicting-addons');
+        }).toThrow("Deploying stack-with-conflicting-addons failed due to conflicting add-on: KarpenterAddOn.");
+    });
+
+    test("Stack creation fails due to conflicting Karpenter prop for version under 0.16", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addOns(new blueprints.VpcCniAddOn, new blueprints.KarpenterAddOn({
+                version: "0.15.0",
+                weight: 30
+            }))
+            .teams(new blueprints.PlatformTeam({ name: 'platform' }));
+
+        expect(()=> {
+            blueprint.build(app, 'stack-with-conflicting-karpenter-props');
+        }).toThrow("The prop weight is only supported on versions v0.16.0 and later.");
+    });
+
+    test("Stack creation fails due to conflicting Karpenter prop for version under 0.15", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addOns(new blueprints.VpcCniAddOn, new blueprints.KarpenterAddOn({
+                version: "0.14.0",
+                consolidation: { enabled: true },
+            }))
+            .teams(new blueprints.PlatformTeam({ name: 'platform' }));
+
+        expect(()=> {
+            blueprint.build(app, 'stack-with-conflicting-karpenter-props');
+        }).toThrow("The prop consolidation is only supported on versions v0.15.0 and later.");
+    });
+
+    test("Stack creation fails due to conflicting Karpenter Addon Props", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addOns(new blueprints.VpcCniAddOn, new blueprints.KarpenterAddOn({
+                ttlSecondsAfterEmpty: 30,
+                consolidation: { enabled: true },
+            }))
+            .teams(new blueprints.PlatformTeam({ name: 'platform' }));
+
+        expect(()=> {
+            blueprint.build(app, 'stack-with-conflicting-karpenter-props');
+        }).toThrow("Consolidation and ttlSecondsAfterEmpty must be mutually exclusive.");
+    });
+});
+

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -38,20 +38,6 @@ describe('Unit tests for EKS Blueprint', () => {
         expect(() => blueprint.build(app, 'stack-with-missing-deps')).toThrow("Missing a dependency for AwsLoadBalancerControllerAddOn for stack-with-missing-deps");
     });
 
-    test("Stack creation fails due to conflicting add-ons", () => {
-        const app = new cdk.App();
-
-        const blueprint = blueprints.EksBlueprint.builder();
-
-        blueprint.account("123567891").region('us-west-1')
-            .addOns(new blueprints.VpcCniAddOn, new blueprints.KarpenterAddOn({version: '0.14.0'}), new blueprints.ClusterAutoScalerAddOn)
-            .teams(new blueprints.PlatformTeam({ name: 'platform' }));
-
-        expect(()=> {
-            blueprint.build(app, 'stack-with-conflicting-addons');
-        }).toThrow("Deploying stack-with-conflicting-addons failed due to conflicting add-on: KarpenterAddOn.");
-    });
-
     test("Stack creation fails due to wrong node group type for NTH addon", () => {
         const app = new cdk.App();
 


### PR DESCRIPTION
*Issue #, if available:*
#494 

*Description of changes:*
PR addresses:
- Currently, the Karpenter Add-on does not export Instance Profile in any way. This is necessary for users to add as part of provisioners. This PR will expose the name of the Instance Profile as a CloudFormation output.
- Separate Karpenter Addon suite of unit tests
- Consolidation check fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
