### PR TITLE
Enable awsproxy extension in XRay ADOT Addon

### DIFF
--- a/lib/addons/xray-adot-addon/collector-config-xray.ytpl
+++ b/lib/addons/xray-adot-addon/collector-config-xray.ytpl
@@ -6,6 +6,10 @@ metadata:
 spec:
   mode: "{{deploymentMode}}"
   serviceAccount: adot-collector
+  ports:
+  - name: awsproxy
+    targetPort: 2000
+    port: 2000
   config: |
     receivers:
       otlp:
@@ -20,7 +24,11 @@ spec:
       awsxray:
         region: "{{awsRegion}}"
 
+    extensions:
+      awsproxy:
+
     service:
+      extensions: [awsproxy]
       pipelines:
         traces:
           receivers: [otlp]


### PR DESCRIPTION
When using the OpenTelemetry collector with the javaagent, in combination with Sampling Rules in Cloudwatch or Xray, configuration is as follows:
https://aws-otel.github.io/docs/getting-started/remote-sampling

By default, the proxy will run on port 2000.

*Issue #, if available:*

*Description of changes:*
- Enable awsproxy in adot collector. When using CloudWatch Sampling Rules, the awsproxy needs to be enabled. It handles authentication to AWS, so the containers using the javaagent don't have to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
