### PR TITLE
Fixed karpenter interruptionQueueName

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -230,7 +230,7 @@ export class KarpenterAddOn extends HelmAddOn {
                 clusterEndpoint: endpoint,
                 clusterName: name,
                 defaultInstanceProfile: karpenterInstanceProfile.instanceProfileName,
-                interruptionQueueName: cluster.clusterName
+                interruptionQueueName: stackName
             });
         } else {
             setPath(values, "clusterEndpoint", endpoint);


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

When interruption handling is enabled for Karpenter, the SQS queue is created with `queueName` set to `stackName`, but the value passed to the helm chart has `interruptionQueueName` set to `cluster.clusterName`. This results in Karpenter complaining about being unable to find the SQS queue:

```
ERROR    controller.interruption    getting messages from queue, discovering queue url, fetching queue url, AWS.SimpleQueueService.NonExistentQueue: T
he specified queue does not exist for this wsdl version.
```

This change sets `interruptionQueueName` to `stackName`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
