### PR TITLE
Allow multiple ExternalDNS addons

### DIFF
--- a/lib/addons/external-dns/index.ts
+++ b/lib/addons/external-dns/index.ts
@@ -46,7 +46,7 @@ export class ExternalDnsAddOn extends HelmAddOn {
         const cluster = clusterInfo.cluster;
         const namespace = this.options.namespace ?? this.options.name;
 
-        const namespaceManifest = new KubernetesManifest(cluster.stack, 'external-dns-ns', {
+        const namespaceManifest = new KubernetesManifest(cluster.stack, `${this.props.name}-ns`, {
             cluster,
             manifest: [{
                 apiVersion: 'v1',
@@ -56,7 +56,7 @@ export class ExternalDnsAddOn extends HelmAddOn {
             overwrite: true
         });
 
-        const sa = cluster.addServiceAccount(this.props.name, { name: 'external-dns-sa', namespace });
+        const sa = cluster.addServiceAccount(this.props.name, { name: `${this.props.name}-sa`, namespace });
 
         const hostedZones = this.options.hostedZoneResources.map(e => clusterInfo.getRequiredResource<IHostedZone>(e));
 


### PR DESCRIPTION
rationale: needed to work with having both a internal and external loadbalancer: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/public-private-route53.md

*Description of changes:*

Uses the chart name to create service account and as the id for the deployment on CDK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
