### PR TITLE
Certificate addition for JupyterHub addon

### DIFF
--- a/docs/addons/jupyterhub.md
+++ b/docs/addons/jupyterhub.md
@@ -90,7 +90,7 @@ user-scheduler-7dbd789bc4-gcb8z   1/1     Running   0          23m
 3. (Optional) Leverage OIDC Provider as a way to manage authentication and authorization. If not provided, the default creates no user, and the user will be able to login with any arbitrary username and password. **It is highly recommended to leverage an Identity provider for any production use case.**
 4. If enabled, will front the JupyterHub UI with an Ingress using AWS Application Load Balancer. ***This requires AWS Load Balancer Controller add-on and it must be in add-on array before the JupyterHub add-on***. This will also look for any additional Ingress annotations provided by the user to be tagged.
 5. (Optional) Annotates Ingress with user-provided AWS Certificate Manager certificate name. It will be looked up and automatically tagged to be used with Ingress. It will require user to provide a DNS name and ***External DNS add-on to be added in add-on array before the JupyterHub add-on***.
-6. (Optional) Leverage a different notebook stack than the standard one provided. Jupyter team maintains a set of Docker image definition in a GitHub repository as explained [here](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html).
+6. (Optional) User can choose a different notebook stack than the standard one provided. Jupyter team maintains a set of Docker image definition in a GitHub repository as explained [here](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html).
 7. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
 
 ***Note***: For custom helm values, please consult the [official documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#). 

--- a/docs/addons/jupyterhub.md
+++ b/docs/addons/jupyterhub.md
@@ -19,10 +19,15 @@ import * as blueprints from '@aws-quickstart/eks-blueprints';
 
 const app = new cdk.App();
 
+const subdomain: string = utils.valueFromContext(scope, "dev.subzone.name", "jupyterhub.some.example.com");
+const parentDnsAccountId = scope.node.tryGetContext("parent.dns.account")!;
+const parentDomain = utils.valueFromContext(scope, "parent.hostedzone.name", "some.example.com");
+
 const jupyterHubAddOn = new blueprints.addons.JupyterHubAddOn({
-  ebsConfig: {
-    storageClass: "gp2",
-    capacity: "4Gi",
+  efsConfig:{
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+    pvcName: "efs-persist",
+    capacity: "120Gi",
   },
   oidcConfig?: {
     callbackUrl: "<Callback URL>",
@@ -35,13 +40,28 @@ const jupyterHubAddOn = new blueprints.addons.JupyterHubAddOn({
     usernameKey: "<username key>",
   },
   enableIngress?: true,
-  notebookStack: 'jupyter/datascience-notebook'
+  ingressHosts: [jupyterDNSname],
+  ingressAnnotations: {
+    'external-dns.alpha.kubernetes.io/hostname': `${jupyterDNSname}`,
+  },
+  notebookStack: 'jupyter/datascience-notebook',
+  certificateResourceName?: 'your-certificate',
 });
-
-const ebsCsiAddOn = new blueprints.addons.EbsCsiDriverAddOn();
-const addOns: Array<blueprints.ClusterAddOn> = [ ebsCsiAddOn, jupyterHubAddOn ];
+const awsAlbAddOn = new blueprints.addons.AwsLoadBalancerControllerAddOn(),
+const efsCsiAddOn = new blueprints.addons.EfsCsiDriverAddOn();
+const externalDnsAddOn = new blueprints.addons.ExternalDnsAddOn({
+  hostedZoneResources: [GlobalResources.HostedZone]
+}),
+const addOns: Array<blueprints.ClusterAddOn> = [ awsAlbAddOn, externalDnsAddOn, efsCsiAddOn, jupyterHubAddOn ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .resourceProvider(GlobalResources.HostedZone, new DelegatingHostedZoneProvider({
+    parentDomain,
+    subdomain,
+    parentDnsAccountId,
+    delegatingRoleName: 'DomainOperatorRole',
+    wildcardSubdomain: true
+  }))
   .addOns(...addOns)
   .build(app, 'my-stack-name');
 ```
@@ -68,8 +88,10 @@ user-scheduler-7dbd789bc4-gcb8z   1/1     Running   0          23m
   - Leverage EBS as persistent storage with storage type and capacity provided. If you provide this configuration, ***EBS CSI Driver add-on must be present in add-on array*** and ***must be in add-on array before the JupyterHub add-on*** for it to work, as shown in above example. Otherwise it will not work.
   - Leverage EFS as persistent storage with the name, capacity and file system removal policy provided. If you provide this configuration, ***EFS CSI Driver add-on must be present in add-on array*** and ***must be in add-on array before the JupyterHub add-on*** for it to work, as shown in above example. Otherwise it will not work.
 3. (Optional) Leverage OIDC Provider as a way to manage authentication and authorization. If not provided, the default creates no user, and the user will be able to login with any arbitrary username and password. **It is highly recommended to leverage an Identity provider for any production use case.**
-4. (Optional) Leverage a different notebook stack than the standard one provided. Jupyter team maintains a set of Docker image definition in a GitHub repository as explained [here](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html).
-4. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
+4. If enabled, will front the JupyterHub UI with an Ingress using AWS Application Load Balancer. ***This requires AWS Load Balancer Controller add-on and it must be in add-on array before the JupyterHub add-on***. This will also look for any additional Ingress annotations provided by the user to be tagged.
+5. (Optional) Annotates Ingress with user-provided AWS Certificate Manager certificate name. It will be looked up and automatically tagged to be used with Ingress. It will require user to provide a DNS name and ***External DNS add-on to be added in add-on array before the JupyterHub add-on***.
+6. (Optional) Leverage a different notebook stack than the standard one provided. Jupyter team maintains a set of Docker image definition in a GitHub repository as explained [here](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html).
+7. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
 
 ***Note***: For custom helm values, please consult the [official documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#). 
 

--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -197,14 +197,14 @@ export class JupyterHubAddOn extends HelmAddOn {
                 presetAnnotations['alb.ingress.kubernetes.io/certificate-arn'] = certificate?.certificateArn;
             } 
 
-            const annotations = { ...ingressAnnotations, ...presetAnnotations}
+            const annotations = { ...ingressAnnotations, ...presetAnnotations};
             setPath(values, "ingress.annotations", annotations);
             setPath(values, "ingress.hosts", ingressHosts);
             setPath(values, "proxy.service", {"type" : "NodePort"});
         } else {
             assert(!ingressHosts || ingressHosts.length == 0, 'Ingress Hosts CANNOT be assigned when ingress is disabled');
             assert(!ingressAnnotations, 'Ingress annotations CANNOT be assigned when ingress is disabled');
-            assert(!cert, 'You cannot provide a certificate for NLB.');
+            assert(!cert, 'Cert option is only supported if ingress is enabled.');
             setPath(values, "proxy.service", { 
                 "annotations": {
                     "service.beta.kubernetes.io/aws-load-balancer-type": "nlb",

--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -8,6 +8,7 @@ import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '../helm-addon';
 import * as cdk from 'aws-cdk-lib';
 import * as efs from 'aws-cdk-lib/aws-efs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 
 import * as semver from 'semver';
 import { EbsCsiDriverAddOn } from "../ebs-csi-driver";
@@ -78,6 +79,12 @@ export interface JupyterHubAddOnProps extends HelmAddOnUserProps {
      * https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#core-stacks
      */
     notebookStack?: string,
+
+    /**
+     * Name of the certificate {@link NamedResourceProvider} to be used for certificate look up. 
+     * @see {@link ImportCertificateProvider} and {@link CreateCertificateProvider} for examples of certificate providers.
+     */
+    certificateResourceName?: string,
 }
 
 const JUPYTERHUB = 'jupyterhub';
@@ -173,15 +180,31 @@ export class JupyterHubAddOn extends HelmAddOn {
         const enableIngress = this.options.enableIngress || false;
         const ingressHosts = this.options.ingressHosts || [];
         const ingressAnnotations = this.options.ingressAnnotations;
+        const cert = this.options.certificateResourceName;
         setPath(values, "ingress.enabled", enableIngress);
 
         if (enableIngress){
-            setPath(values, "ingress.annotations", ingressAnnotations);
+            const presetAnnotations: any = {
+                'alb.ingress.kubernetes.io/scheme': 'internet-facing',
+                'alb.ingress.kubernetes.io/target-type': 'ip',
+                'kubernetes.io/ingress.class': 'alb',
+            };
+
+            if (cert){
+                presetAnnotations['alb.ingress.kubernetes.io/ssl-redirect'] = '443';
+                presetAnnotations['alb.ingress.kubernetes.io/listen-ports'] = '[{"HTTP": 80},{"HTTPS":443}]';
+                const certificate = clusterInfo.getResource<ICertificate>(cert);
+                presetAnnotations['alb.ingress.kubernetes.io/certificate-arn'] = certificate?.certificateArn;
+            } 
+
+            const annotations = { ...ingressAnnotations, ...presetAnnotations}
+            setPath(values, "ingress.annotations", annotations);
             setPath(values, "ingress.hosts", ingressHosts);
             setPath(values, "proxy.service", {"type" : "NodePort"});
         } else {
             assert(!ingressHosts || ingressHosts.length == 0, 'Ingress Hosts CANNOT be assigned when ingress is disabled');
             assert(!ingressAnnotations, 'Ingress annotations CANNOT be assigned when ingress is disabled');
+            assert(!cert, 'You cannot provide a certificate for NLB.');
             setPath(values, "proxy.service", { 
                 "annotations": {
                     "service.beta.kubernetes.io/aws-load-balancer-type": "nlb",


### PR DESCRIPTION
*Issue #, if available:*
Currently to leverage ACM certificate for JupyterHub Ingress, user must manually annotate once the certificate is created (or read in using Lookup). This PR will ensure the addon will automatically apply the annotation using user provided certificate.

*Description of changes:*
Adds a configuration for user to be able to provide the name of an ACM certificate for annotation. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
