### PR TITLE
[do not merge] Create dedicated IAM role for VpcCniAddOn

### DIFF
--- a/lib/addons/vpc-cni/iam-policy.ts
+++ b/lib/addons/vpc-cni/iam-policy.ts
@@ -1,0 +1,35 @@
+import { PolicyDocument } from "aws-cdk-lib/aws-iam";
+
+export function getVpcCniDriverPolicyDocument() : PolicyDocument {
+    return PolicyDocument.fromJson({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:AssignPrivateIpAddresses",
+                    "ec2:AttachNetworkInterface",
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeInstances",
+                    "ec2:DescribeTags",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeInstanceTypes",
+                    "ec2:DetachNetworkInterface",
+                    "ec2:ModifyNetworkInterfaceAttribute",
+                    "ec2:UnassignPrivateIpAddresses"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:CreateTags"
+                ],
+                "Resource": [
+                    "arn:aws:ec2:*:*:network-interface/*"
+                ]
+            }
+        ]
+    });
+}

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -1,4 +1,5 @@
 import { CoreAddOn } from "../core-addon";
+import { getVpcCniDriverPolicyDocument } from "./iam-policy";
 
 /**
  * Implementation of VpcCni EKS add-on.
@@ -9,7 +10,8 @@ export class VpcCniAddOn extends CoreAddOn {
         super({
             addOnName: "vpc-cni",
             version: version ?? "v1.12.0-eksbuild.1",
-            saName: "vpc-cni"
+            saName: "vpc-cni",
+            policyDocumentProvider: getVpcCniDriverPolicyDocument
         });
     }
 }


### PR DESCRIPTION
Create dedicated IAM role for VpcCniAddOn with policy attached, according to recommendation from https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html

Remove the default 'AmazonEKS_CNI_Policy' from the node role used for the managed node group, since it is no longer necessary.

Fixes #434.

Local tests (`npm test`) run successfully, but a deploy on **an existing cluster built with eks-blueprints 1.5.4 fails when trying to replace the managed node group**:

```
Resources:
[~] AWS::EKS::Nodegroup EKS/Nodegroup-EKS-ng-ng EKSNodegroupEKSngng84084AE6 replace
 └─ [~] NodeRole (requires replacement)
     └─ [~] .Fn::GetAtt:
         └─ @@ -1,4 +1,4 @@
            [ ] [
            [-]   "EKSNodegroupEKSngngNodeGroupRole4B998ECE",
            [+]   "NodeGroupRoleB2FF2978",
            [ ]   "Arn"
            [ ] ]
```

Result of changeset apply:
```
3:43:54 PM | UPDATE_FAILED        | AWS::EKS::Nodegroup                   | EKSNodeg...useEKSngng84084AE6
Resource handler returned message: "NodeGroup already exists with name EKS-ng and cluster name EKS (Service: Eks, Status Code: 409, Request ID: 0486189b-6ec8-46f7
-a047-85f0323443c0)" (RequestToken: 86f57db1-4ab2-23b3-034f-bac46d98009e, HandlerErrorCode: AlreadyExists)
```

Does this block this code change from getting merged? I'm afraid it will bring errors to users' builds.
**Alternatively, one could merge only the creation of the custom role for the VPC CNI addon, and then change the [default permission policies given to the node role in CDK](https://github.com/aws/aws-cdk/blob/cb7367965608eb733f7ae03a06419bba4b21c713/packages/%40aws-cdk/aws-eks/lib/managed-nodegroup.ts#L378-389) to the minimum required as specified in the docs.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.