### PR TITLE
Addressing multiple EKS role name/instance name issue

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -374,18 +374,21 @@ export class KarpenterAddOn extends HelmAddOn {
             instanceProfileName: `KarpenterNodeInstanceProfile-${instanceProfileName}`,
             path: '/'
         });
+        
+        const clusterName = cluster.clusterName;
+        const clusterHash = md5.Md5.hashStr(clusterName);
 
         //Cfn output for Node Role in case of needing to add additional policies
         new CfnOutput(cluster.stack, 'Karpenter Instance Node Role', {
             value: karpenterNodeRole.roleName,
             description: "Karpenter add-on Node Role name",
-            exportName: "KarpenterNodeRoleName",
+            exportName: "KarpenterNodeRoleName"+clusterHash,
         });
         //Cfn output for Instance Profile for creating additional provisioners
         new CfnOutput(cluster.stack, 'Karpenter Instance Profile name', { 
             value: karpenterInstanceProfile ? karpenterInstanceProfile.instanceProfileName! : "none",
             description: "Karpenter add-on Instance Profile name",
-            exportName: "KarpenterInstanceProfileName", 
+            exportName: "KarpenterInstanceProfileName"+clusterHash, 
         });
 
         // Map Node Role to aws-auth


### PR DESCRIPTION
*Issue #, if available:* #587

*Description of changes:* If deploy more than 2 EKS clusters are deployed in a Stack with Karpenter addons, an "Export with name KarpenterInstanceProfileName is already exported by stack {cdk-eks-blueprints-id}" error occurs.

Minor revision to add random names appended to those role names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
