### PR TITLE
Manual typescript update removed from doc due to CDK update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ cdk --version
 Create a new CDK project. We use `typescript` for this example.
 
 ```bash
-npm install typescript@~4.8.4
 cdk init app --language typescript
 ```
 
@@ -72,7 +71,6 @@ cdk bootstrap aws://<AWS_ACCOUNT_ID>/<AWS_REGION>
 Run the following command to install the `eks-blueprints` dependency in your project.
 
 ```sh
-npm install typescript@~4.8.4
 npm i @aws-quickstart/eks-blueprints
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,6 @@ Create a new CDK project. We use `typescript` for this example.
 
 ```bash
 cdk init app --language typescript
-npm install typescript@~4.8.4
 ```
 
 [Bootstrap](https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html) your environment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,6 @@ cdk --version # must produce 2.60.0
 mkdir my-blueprints
 cd my-blueprints
 cdk init app --language typescript
-npm install typescript@~4.8.4 # installs compatible version of typescript
 ```
 
 ## Configure and Deploy EKS Clusters

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -83,25 +83,25 @@ export default class BlueprintConstruct {
                 skipVersionValidation: true,
                 serviceName: AckServiceName.S3
             }),
-            new blueprints.addons.AckAddOn({
-                skipVersionValidation: true,
-                id: "ec2-ack",
-                createNamespace: false,
-                serviceName: AckServiceName.EC2
-            }),
-            new blueprints.addons.AckAddOn({
-                skipVersionValidation: true,
-                serviceName: AckServiceName.RDS,
-                id: "rds-ack",
-                name: "rds-chart",
-                chart: "rds-chart",
-                version: "v0.1.1",
-                release: "rds-chart",
-                repository: "oci://public.ecr.aws/aws-controllers-k8s/rds-chart",
-                managedPolicyName: "AmazonRDSFullAccess",
-                createNamespace: false,
-                saName: "rds-chart"
-            }),
+            // new blueprints.addons.AckAddOn({
+            //     skipVersionValidation: true,
+            //     id: "ec2-ack",
+            //     createNamespace: false,
+            //     serviceName: AckServiceName.EC2
+            // }),
+            // new blueprints.addons.AckAddOn({
+            //     skipVersionValidation: true,
+            //     serviceName: AckServiceName.RDS,
+            //     id: "rds-ack",
+            //     name: "rds-chart",
+            //     chart: "rds-chart",
+            //     version: "v0.1.1",
+            //     release: "rds-chart",
+            //     repository: "oci://public.ecr.aws/aws-controllers-k8s/rds-chart",
+            //     managedPolicyName: "AmazonRDSFullAccess",
+            //     createNamespace: false,
+            //     saName: "rds-chart"
+            // }),
             new blueprints.addons.KarpenterAddOn({
                 requirements: [
                     { key: 'node.kubernetes.io/instance-type', op: 'In', vals: ['m5.2xlarge'] },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typedoc": "^0.23.19",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.4"
     },
     "dependencies": {
         "@aws-cdk/lambda-layer-kubectl-v22": "^2.0.0",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* CDK updates for v2.54 addressed build issue due to mismatching typescript version (See [issue](https://github.com/aws/aws-cdk/issues/23126), [changelog under bug fix](https://github.com/aws/aws-cdk/releases/tag/v2.54.0)). Therefore, we no longer need to manually install typescript. CDK will include typescript with appropriate version automatically.

This PR will remove those commands in our documentations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
