### PR TITLE
[karpenter] add support for `Provisioner` limits

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -124,6 +124,12 @@ export default class BlueprintConstruct {
                 ttlSecondsUntilExpired: 2592000,
                 weight: 20,
                 interruptionHandling: true,
+                limits: {
+                    resources: {
+                        cpu: 20,
+                        memory: "64Gi",
+                    }
+                }
             }),
             new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
             new blueprints.addons.KubeviousAddOn(),

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -90,11 +90,19 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
 
     /**
      * Limits define a set of bounds for provisioning capacity.
+     * Resource limits constrain the total size of the cluster.
+     * Limits prevent Karpenter from creating new instances once the limit is exceeded.
      */
     limits?: {
         resources?: {
           cpu?: number;
           memory?: string;
+          /**
+           * Extended resources are fully-qualified resource names outside the kubernetes.io domain.
+           * They allow cluster operators to advertise and users to consume the non-Kubernetes-built-in
+           * resources such as hardware devices GPUs, RDMAs, SR-IOVs...
+           * e.g nvidia.com/gpu, amd.com/gpu, etc...
+           */
           [k: string]: unknown;
         };
     };

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -87,6 +87,17 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
      * Only applicable for v0.19.0 and later
      */
     interruptionHandling?: boolean,
+
+    /**
+     * Limits define a set of bounds for provisioning capacity.
+     */
+    limits?: {
+        resources?: {
+          cpu?: number;
+          memory?: string;
+          [k: string]: unknown;
+        };
+    };
 }
 
 const KARPENTER = 'karpenter';
@@ -139,6 +150,7 @@ export class KarpenterAddOn extends HelmAddOn {
         const consol = this.options.consolidation || null;
         const repo = this.options.repository!;
         const interruption = this.options.interruptionHandling || false;
+        const limits = this.options.limits || null;
         
         // Various checks for version errors
         const consolidation = this.versionFeatureChecksForError(clusterInfo, version, weight, consol, repo, ttlSecondsAfterEmpty, interruption);
@@ -263,6 +275,7 @@ export class KarpenterAddOn extends HelmAddOn {
                     consolidation: consolidation,
                     requirements: this.convert(requirements),
                     taints: taints,
+                    limits: limits,
                     provider: {
                         amiFamily: amiFamily,
                         subnetSelector: subnetTags,


### PR DESCRIPTION
[karpenter] add support for `Provisioner` limits

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
