### PR TITLE
Feature/Jupyterhub: Removed option to expose proxy svc using NLB

### DIFF
--- a/docs/addons/jupyterhub.md
+++ b/docs/addons/jupyterhub.md
@@ -97,17 +97,22 @@ user-scheduler-7dbd789bc4-gcb8z   1/1     Running   0          23m
 
 ## Using JupyterHub
 
-JupyterHub, by default, creates a proxy that is exposed to a `LoadBalancer` type Kubernetes service, which will integrate with AWS Load Balancer as indicated when running the following command:
+JupyterHub creates a public proxy that is exposed to a Kubernetes service:
 
 ```bash
 kubectl get svc -n jupyterhub
 NAME           TYPE           CLUSTER-IP      EXTERNAL-IP                                                               PORT(S)        AGE
 hub            ClusterIP      172.20.171.28   <none>                                                                    8081/TCP       26m
 proxy-api      ClusterIP      172.20.31.32    <none>                                                                    8001/TCP       26m
-proxy-public   LoadBalancer   172.20.14.210   xxxxxxxx-1234567890.us-west-2.elb.amazonaws.com   80:32733/TCP   26m
+proxy-public   ClusterIP   172.20.14.210   <none>                                                                       80/TCP   26m
 ```
 
-You can log into the JupyterHub portal by accessing the Load Balancer endpoint in any browser. 
+You can port-forward to expose to a localhost:
+```
+kubectl port-forward services/proxy-public -n jupyterhub 8080:80 
+```
+
+You can log into the JupyterHub portal by accessing `localhost:8080` in any browser. 
 
 ![JupyterHub Login](./../assets/images/jupyterhub-login-page.png)
 

--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -176,7 +176,7 @@ export class JupyterHubAddOn extends HelmAddOn {
         }
 
         // Ingress instead of LoadBalancer service to expose the proxy - leverages AWS ALB
-        // If not, then it will leverage AWS NLB
+        // If not, then it will not be exposed
         const enableIngress = this.options.enableIngress || false;
         const ingressHosts = this.options.ingressHosts || [];
         const ingressAnnotations = this.options.ingressAnnotations;
@@ -205,13 +205,7 @@ export class JupyterHubAddOn extends HelmAddOn {
             assert(!ingressHosts || ingressHosts.length == 0, 'Ingress Hosts CANNOT be assigned when ingress is disabled');
             assert(!ingressAnnotations, 'Ingress annotations CANNOT be assigned when ingress is disabled');
             assert(!cert, 'Cert option is only supported if ingress is enabled.');
-            setPath(values, "proxy.service", { 
-                "annotations": {
-                    "service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
-                    "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
-                    "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
-                }
-            });
+            setPath(values, "proxy.service", {"type": "ClusterIP"});
         }
 
         // Create Helm Chart


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* If the Ingress option is disabled, the proxy svc will use `ClusterIP` and not `LoadBalancer`, and therefore removing the option to expose using NLB. This will require users to expose the svc using port-forwarding to access via `localhost`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
