### PR TITLE
JupyterHubAddOn: Removing AWS Load Balancer Controller dependency issue for ClusterIP service

### DIFF
--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import { Construct } from "constructs";
 import { ClusterInfo } from '../../spi';
-import { createNamespace, dependable, setPath } from '../../utils';
+import { createNamespace, setPath } from '../../utils';
 import { AwsLoadBalancerControllerAddOn } from "../aws-loadbalancer-controller";
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '../helm-addon';
 

--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -135,7 +135,6 @@ export class JupyterHubAddOn extends HelmAddOn {
         this.options = this.props as JupyterHubAddOnProps;
     }
     
-    @dependable(AwsLoadBalancerControllerAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
         let values = this.options.values ?? {};
@@ -202,8 +201,10 @@ export class JupyterHubAddOn extends HelmAddOn {
         const ingressAnnotations = this.options.ingressAnnotations;
         const cert = this.options.certificateResourceName;
 
+        const albAddOnCheck = clusterInfo.getScheduledAddOn('AwsLoadBalancerControllerAddOn.name');
         // Use Ingress and AWS ALB
         if (serviceType == JupyterHubServiceType.ALB){
+            assert(albAddOnCheck, `Missing a dependency: ${AwsLoadBalancerControllerAddOn.name}. Please add it to your list of addons.`); 
             const presetAnnotations: any = {
                 'alb.ingress.kubernetes.io/scheme': 'internet-facing',
                 'alb.ingress.kubernetes.io/target-type': 'ip',
@@ -229,6 +230,7 @@ export class JupyterHubAddOn extends HelmAddOn {
                 setPath(values, "proxy.service", {"type": "ClusterIP"});
             // We will use NLB 
             } else {
+                assert(albAddOnCheck, `Missing a dependency: ${AwsLoadBalancerControllerAddOn.name}. Please add it to your list of addons.`); 
                 setPath(values, "proxy.service", { 
                     "annotations": {
                         "service.beta.kubernetes.io/aws-load-balancer-type": "nlb",

--- a/test/jupyterhub.test.ts
+++ b/test/jupyterhub.test.ts
@@ -49,7 +49,7 @@ describe('Unit tests for JupyterHub addon', () => {
         }).toThrow("Missing a dependency: EfsCsiDriverAddOn. Please add it to your list of addons.");
     });
 
-    test("Stack creation fails due to no AWS Load Balancer Controller add-on", () => {
+    test("Stack creation fails due to no AWS Load Balancer Controller add-on when using ALB", () => {
         const app = new cdk.App();
 
         const blueprint = blueprints.EksBlueprint.builder();
@@ -68,8 +68,31 @@ describe('Unit tests for JupyterHub addon', () => {
             .teams(new blueprints.PlatformTeam({ name: 'platform' }));
 
         expect(()=> {
-            blueprint.build(app, 'stack-with-no-efs-csi-addon');
-        }).toThrow("Missing a dependency for AwsLoadBalancerControllerAddOn for stack-with-no-efs-csi-addon");
+            blueprint.build(app, 'stack-with-no-aws-load-balancer-controller-addon');
+        }).toThrow("Missing a dependency: AwsLoadBalancerControllerAddOn. Please add it to your list of addons.");
+    });
+
+    test("Stack creation fails due to no AWS Load Balancer Controller add-on when using NLB", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .addOns(
+                new blueprints.EfsCsiDriverAddOn,
+                new blueprints.JupyterHubAddOn({
+                efsConfig: {
+                    pvcName: "efs-persist",
+                    removalPolicy: cdk.RemovalPolicy.DESTROY,
+                    capacity: '100Gi',
+                },
+                serviceType: JupyterHubServiceType.NLB,
+            }))
+            .teams(new blueprints.PlatformTeam({ name: 'platform' }));
+
+        expect(()=> {
+            blueprint.build(app, 'stack-with-no-aws-load-balancer-controller-addon');
+        }).toThrow("Missing a dependency: AwsLoadBalancerControllerAddOn. Please add it to your list of addons.");
     });
 });
 


### PR DESCRIPTION
*Issue #, if available:* #616

*Description of changes:* We are removing AWS Load Balancer Controller Add On dependency when the JupyterHub proxy service is using ClusterIP type (and therefore does not require NLB or ALB).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
