### PR TITLE
AwsForFluentBitAddOn: Bug Fix on Helm Chart dependency

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -163,6 +163,7 @@ export default class BlueprintConstruct {
             }),
             new blueprints.EmrEksAddOn(),
             new blueprints.AwsBatchAddOn(),
+            new blueprints.AwsForFluentBitAddOn(),
         ];
 
         // Instantiated to for helm version check.

--- a/lib/addons/aws-for-fluent-bit/index.ts
+++ b/lib/addons/aws-for-fluent-bit/index.ts
@@ -52,11 +52,6 @@ export class AwsForFluentBitAddOn extends HelmAddOn {
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
         const namespace = this.options.namespace!;
-        
-        // Create namespace
-        if (this.options.createNamespace) {
-            createNamespace(namespace, cluster, true);
-        }
 
         // Create the FluentBut service account.
         const serviceAccountName = 'aws-for-fluent-bit-sa';
@@ -64,6 +59,12 @@ export class AwsForFluentBitAddOn extends HelmAddOn {
             name: serviceAccountName,
             namespace: namespace
         });
+
+        // Create namespace
+        if (this.options.createNamespace) {
+            const ns = createNamespace(namespace, cluster, true);
+            sa.node.addDependency(ns);
+        }
 
         // Apply additional IAM policies to the service account.
         const policies = this.options.iamPolicies || [];

--- a/lib/addons/aws-for-fluent-bit/index.ts
+++ b/lib/addons/aws-for-fluent-bit/index.ts
@@ -21,7 +21,7 @@ const defaultProps: AwsForFluentBitAddOnProps = {
     name: 'fluent-bit',
     chart: 'aws-for-fluent-bit',
     release: "blueprints-addon-aws-for-fluent-bit",
-    version: '0.1.11',
+    version: '0.1.23',
     repository: 'https://aws.github.io/eks-charts',
     namespace: 'kube-system',
     values: {}
@@ -45,10 +45,7 @@ export class AwsForFluentBitAddOn extends HelmAddOn {
 
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
-
-        // Create the FluentBit namespace.
         const namespace = this.options.namespace;
-        createNamespace(this.options.namespace!, cluster, true);
 
         // Create the FluentBut service account.
         const serviceAccountName = 'aws-for-fluent-bit-sa';
@@ -71,6 +68,7 @@ export class AwsForFluentBitAddOn extends HelmAddOn {
         };
 
         const helmChart = this.addHelmChart(clusterInfo, values);
+        helmChart.node.addDependency(sa);
         return Promise.resolve(helmChart);
     }
 }

--- a/lib/addons/aws-for-fluent-bit/index.ts
+++ b/lib/addons/aws-for-fluent-bit/index.ts
@@ -12,7 +12,12 @@ export interface AwsForFluentBitAddOnProps extends HelmAddOnUserProps {
     /**
      * Iam policies for the add-on.
      */
-    iamPolicies?: PolicyStatement[]
+    iamPolicies?: PolicyStatement[],
+
+    /**
+     * Create Namespace with the provided one (will not if namespace is kube-system)
+     */
+    createNamespace?: boolean
 }
 /**
  * Default props for the add-on.
@@ -24,6 +29,7 @@ const defaultProps: AwsForFluentBitAddOnProps = {
     version: '0.1.23',
     repository: 'https://aws.github.io/eks-charts',
     namespace: 'kube-system',
+    createNamespace: false,
     values: {}
 };
 
@@ -45,7 +51,12 @@ export class AwsForFluentBitAddOn extends HelmAddOn {
 
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
-        const namespace = this.options.namespace;
+        const namespace = this.options.namespace!;
+        
+        // Create namespace
+        if (this.options.createNamespace) {
+            createNamespace(namespace, cluster, true);
+        }
 
         // Create the FluentBut service account.
         const serviceAccountName = 'aws-for-fluent-bit-sa';


### PR DESCRIPTION
*Issue #, if available:* #619

*Description of changes:*
- Added Helm Chart dependency on serviceaccount
- Removed namespace creation (default to `kube-system` which already exists)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
