### PR TITLE
Task/resource references

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -64,18 +64,18 @@ export default class BlueprintConstruct {
             // adminPasswordSecretName: "argo-admin-secret"
         });
         const addOns: Array<blueprints.ClusterAddOn> = [
-            new blueprints.addons.AppMeshAddOn(),
+            // new blueprints.addons.AppMeshAddOn(),
             new blueprints.addons.CertManagerAddOn(),
             new blueprints.addons.KubeStateMetricsAddOn(),
             new blueprints.addons.PrometheusNodeExporterAddOn(),
             new blueprints.addons.AdotCollectorAddOn(),
-            new blueprints.addons.AmpAddOn(),
-            new blueprints.addons.XrayAdotAddOn(),
+           // new blueprints.addons.AmpAddOn(),
+           // new blueprints.addons.XrayAdotAddOn(),
             // new blueprints.addons.CloudWatchAdotAddOn(),
-            new blueprints.addons.IstioBaseAddOn(),
-            new blueprints.addons.IstioControlPlaneAddOn(),
-            new blueprints.addons.CalicoOperatorAddOn(),
-            new blueprints.addons.MetricsServerAddOn(),
+            // new blueprints.addons.IstioBaseAddOn(),
+            // new blueprints.addons.IstioControlPlaneAddOn(),
+            // new blueprints.addons.CalicoOperatorAddOn(),
+            // new blueprints.addons.MetricsServerAddOn(),
             new blueprints.addons.AwsLoadBalancerControllerAddOn(),
             new blueprints.addons.SecretsStoreAddOn(),
             prodBootstrapArgo,
@@ -86,17 +86,17 @@ export default class BlueprintConstruct {
                 }
             }),
             new blueprints.addons.VeleroAddOn(),
-            new blueprints.addons.VpcCniAddOn({
-                customNetworkingConfig: {
-                    subnets: [
-                        blueprints.getNamedResource("secondary-cidr-subnet-0"),
-                        blueprints.getNamedResource("secondary-cidr-subnet-1"),
-                        blueprints.getNamedResource("secondary-cidr-subnet-2"),
-                    ]   
-                },
-                awsVpcK8sCniCustomNetworkCfg: true,
-                eniConfigLabelDef: 'topology.kubernetes.io/zone'
-            }),
+            // new blueprints.addons.VpcCniAddOn({
+            //     customNetworkingConfig: {
+            //         subnets: [
+            //             blueprints.getNamedResource("secondary-cidr-subnet-0"),
+            //             blueprints.getNamedResource("secondary-cidr-subnet-1"),
+            //             blueprints.getNamedResource("secondary-cidr-subnet-2"),
+            //         ]   
+            //     },
+            //     awsVpcK8sCniCustomNetworkCfg: true,
+            //     eniConfigLabelDef: 'topology.kubernetes.io/zone'
+            // }),
             new blueprints.addons.CoreDnsAddOn(),
             new blueprints.addons.KubeProxyAddOn(),
             new blueprints.addons.OpaGatekeeperAddOn(),
@@ -106,37 +106,37 @@ export default class BlueprintConstruct {
                 skipVersionValidation: true,
                 serviceName: blueprints.AckServiceName.S3
             }),
-            new blueprints.addons.KarpenterAddOn({
-                requirements: [
-                    { key: 'node.kubernetes.io/instance-type', op: 'In', vals: ['m5.2xlarge'] },
-                    { key: 'topology.kubernetes.io/zone', op: 'NotIn', vals: ['us-west-2c']},
-                    { key: 'kubernetes.io/arch', op: 'In', vals: ['amd64','arm64']},
-                    { key: 'karpenter.sh/capacity-type', op: 'In', vals: ['spot']},
-                ],
-                subnetTags: {
-                    "Name": "blueprint-construct-dev/blueprint-construct-dev-vpc/PrivateSubnet1",
-                },
-                securityGroupTags: {
-                    "kubernetes.io/cluster/blueprint-construct-dev": "owned",
-                },
-                taints: [{
-                    key: "workload",
-                    value: "test",
-                    effect: "NoSchedule",
-                }],
-                consolidation: { enabled: true },
-                ttlSecondsUntilExpired: 2592000,
-                weight: 20,
-                interruptionHandling: true,
-                limits: {
-                    resources: {
-                        cpu: 20,
-                        memory: "64Gi",
-                    }
-                }
-            }),
-            new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
-            new blueprints.addons.KubeviousAddOn(),
+            // new blueprints.addons.KarpenterAddOn({
+            //     requirements: [
+            //         { key: 'node.kubernetes.io/instance-type', op: 'In', vals: ['m5.2xlarge'] },
+            //         { key: 'topology.kubernetes.io/zone', op: 'NotIn', vals: ['us-west-2c']},
+            //         { key: 'kubernetes.io/arch', op: 'In', vals: ['amd64','arm64']},
+            //         { key: 'karpenter.sh/capacity-type', op: 'In', vals: ['spot']},
+            //     ],
+            //     subnetTags: {
+            //         "Name": "blueprint-construct-dev/blueprint-construct-dev-vpc/PrivateSubnet1",
+            //     },
+            //     securityGroupTags: {
+            //         "kubernetes.io/cluster/blueprint-construct-dev": "owned",
+            //     },
+            //     taints: [{
+            //         key: "workload",
+            //         value: "test",
+            //         effect: "NoSchedule",
+            //     }],
+            //     consolidation: { enabled: true },
+            //     ttlSecondsUntilExpired: 2592000,
+            //     weight: 20,
+            //     interruptionHandling: true,
+            //     limits: {
+            //         resources: {
+            //             cpu: 20,
+            //             memory: "64Gi",
+            //         }
+            //     }
+            // }),
+          //  new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
+            //new blueprints.addons.KubeviousAddOn(),
             new blueprints.addons.EbsCsiDriverAddOn({
                 kmsKeys: [
                   blueprints.getResource( context => new kms.Key(context.scope, "ebs-csi-driver-key", { alias: "ebs-csi-driver-key"})),
@@ -150,19 +150,19 @@ export default class BlueprintConstruct {
                 securityContextRunAsUser: 1001,
                 irsaRoles: ["CloudWatchFullAccess", "AmazonSQSFullAccess"]
             }),
-            new blueprints.addons.AWSPrivateCAIssuerAddon(),
-            new blueprints.addons.JupyterHubAddOn({
-                efsConfig: {
-                    pvcName: "efs-persist",
-                    removalPolicy: cdk.RemovalPolicy.DESTROY,
-                    capacity: '10Gi',
-                },
-                serviceType: blueprints.JupyterHubServiceType.CLUSTERIP,
-                notebookStack: 'jupyter/datascience-notebook',
-                values: { prePuller: { hook: { enabled: false }}}
-            }),
-            new blueprints.EmrEksAddOn(),
-            new blueprints.AwsBatchAddOn(),
+            // new blueprints.addons.AWSPrivateCAIssuerAddon(),
+            // new blueprints.addons.JupyterHubAddOn({
+            //     efsConfig: {
+            //         pvcName: "efs-persist",
+            //         removalPolicy: cdk.RemovalPolicy.DESTROY,
+            //         capacity: '10Gi',
+            //     },
+            //     serviceType: blueprints.JupyterHubServiceType.CLUSTERIP,
+            //     notebookStack: 'jupyter/datascience-notebook',
+            //     values: { prePuller: { hook: { enabled: false }}}
+            // }),
+            // new blueprints.EmrEksAddOn(),
+            // new blueprints.AwsBatchAddOn(),
         ];
 
         // Instantiated to for helm version check.
@@ -171,7 +171,7 @@ export default class BlueprintConstruct {
         });
         new blueprints.ExternalsSecretsAddOn();
        
-        const blueprintID = 'blueprint-construct-dev';
+        const blueprintID = 'shapirov-blueprint';
 
         const userData = ec2.UserData.forLinux();
         userData.addCommands(`/etc/eks/bootstrap.sh ${blueprintID}`); 
@@ -191,24 +191,24 @@ export default class BlueprintConstruct {
                     maxSize: 3, 
                     nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }
                 },
-                {
-                    id: "mng2-customami",
-                    instanceTypes: [new ec2.InstanceType('t3.large')],
-                    nodeGroupCapacityType: CapacityType.SPOT,
-                    desiredSize: 0,
-                    minSize: 0,
-                    customAmi: {
-                        machineImage: ec2.MachineImage.genericLinux({
-                            'us-east-1': 'ami-08e520f5673ee0894',
-                            'us-west-2': 'ami-0403ff342ceb30967',
-                            'us-east-2': 'ami-07109d69738d6e1ee',
-                            'us-west-1': 'ami-07bda4b61dc470985',
-                            'us-gov-west-1': 'ami-0e9ebbf0d3f263e9b',
-                            'us-gov-east-1':'ami-033eb9bc6daf8bfb1'
-                        }),
-                        userData: userData,
-                    }
-                }
+                // {
+                //     id: "mng2-customami",
+                //     instanceTypes: [new ec2.InstanceType('t3.large')],
+                //     nodeGroupCapacityType: CapacityType.SPOT,
+                //     desiredSize: 0,
+                //     minSize: 0,
+                //     customAmi: {
+                //         machineImage: ec2.MachineImage.genericLinux({
+                //             'us-east-1': 'ami-08e520f5673ee0894',
+                //             'us-west-2': 'ami-0403ff342ceb30967',
+                //             'us-east-2': 'ami-07109d69738d6e1ee',
+                //             'us-west-1': 'ami-07bda4b61dc470985',
+                //             'us-gov-west-1': 'ami-0e9ebbf0d3f263e9b',
+                //             'us-gov-east-1':'ami-033eb9bc6daf8bfb1'
+                //         }),
+                //         userData: userData,
+                //     }
+                // }
             ]
         });
 
@@ -259,9 +259,9 @@ export default class BlueprintConstruct {
 
         blueprints.EksBlueprint.builder()
             .addOns(...addOns)
-            .resourceProvider(blueprints.GlobalResources.Vpc, new VpcProvider(undefined,"100.64.0.0/16", ["100.64.0.0/24","100.64.1.0/24","100.64.2.0/24"]))
+            .resourceProvider(blueprints.GlobalResources.Vpc, new VpcProvider("vpc-06795ec62eb45cf89"))
             .clusterProvider(clusterProvider)
-            .teams(...teams, new blueprints.EmrEksTeam(dataTeam), new blueprints.BatchEksTeam(batchTeam))
+            //.teams(...teams, new blueprints.EmrEksTeam(dataTeam), new blueprints.BatchEksTeam(batchTeam))
             .enableControlPlaneLogTypes(blueprints.ControlPlaneLogType.API)
             .build(scope, blueprintID, props);
     }

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -25,9 +25,8 @@ export default class BlueprintConstruct {
 
         blueprints.HelmAddOn.validateHelmVersions = true;
         blueprints.HelmAddOn.failOnVersionValidation = false;
-        //0: silly, 1: trace, 2: debug, 3: info, 4: warn, 5: error, 6: fatal
-        logger.settings.minLevel =  3;
-        userLog.settings.minLevel = 2;
+        logger.settings.minLevel =  3; // info
+        userLog.settings.minLevel = 2; // debug
 
         // TODO: fix IAM user provisioning for admin user
         // Setup platform team.
@@ -65,18 +64,18 @@ export default class BlueprintConstruct {
             // adminPasswordSecretName: "argo-admin-secret"
         });
         const addOns: Array<blueprints.ClusterAddOn> = [
-            // new blueprints.addons.AppMeshAddOn(),
+            new blueprints.addons.AppMeshAddOn(),
             new blueprints.addons.CertManagerAddOn(),
             new blueprints.addons.KubeStateMetricsAddOn(),
             new blueprints.addons.PrometheusNodeExporterAddOn(),
             new blueprints.addons.AdotCollectorAddOn(),
-           // new blueprints.addons.AmpAddOn(),
-           // new blueprints.addons.XrayAdotAddOn(),
+            new blueprints.addons.AmpAddOn(),
+            new blueprints.addons.XrayAdotAddOn(),
             // new blueprints.addons.CloudWatchAdotAddOn(),
-            // new blueprints.addons.IstioBaseAddOn(),
-            // new blueprints.addons.IstioControlPlaneAddOn(),
-            // new blueprints.addons.CalicoOperatorAddOn(),
-            // new blueprints.addons.MetricsServerAddOn(),
+            new blueprints.addons.IstioBaseAddOn(),
+            new blueprints.addons.IstioControlPlaneAddOn(),
+            new blueprints.addons.CalicoOperatorAddOn(),
+            new blueprints.addons.MetricsServerAddOn(),
             new blueprints.addons.AwsLoadBalancerControllerAddOn(),
             new blueprints.addons.SecretsStoreAddOn(),
             prodBootstrapArgo,
@@ -87,17 +86,17 @@ export default class BlueprintConstruct {
                 }
             }),
             new blueprints.addons.VeleroAddOn(),
-            // new blueprints.addons.VpcCniAddOn({
-            //     customNetworkingConfig: {
-            //         subnets: [
-            //             blueprints.getNamedResource("secondary-cidr-subnet-0"),
-            //             blueprints.getNamedResource("secondary-cidr-subnet-1"),
-            //             blueprints.getNamedResource("secondary-cidr-subnet-2"),
-            //         ]   
-            //     },
-            //     awsVpcK8sCniCustomNetworkCfg: true,
-            //     eniConfigLabelDef: 'topology.kubernetes.io/zone'
-            // }),
+            new blueprints.addons.VpcCniAddOn({
+                customNetworkingConfig: {
+                    subnets: [
+                        blueprints.getNamedResource("secondary-cidr-subnet-0"),
+                        blueprints.getNamedResource("secondary-cidr-subnet-1"),
+                        blueprints.getNamedResource("secondary-cidr-subnet-2"),
+                    ]   
+                },
+                awsVpcK8sCniCustomNetworkCfg: true,
+                eniConfigLabelDef: 'topology.kubernetes.io/zone'
+            }),
             new blueprints.addons.CoreDnsAddOn(),
             new blueprints.addons.KubeProxyAddOn(),
             new blueprints.addons.OpaGatekeeperAddOn(),
@@ -107,37 +106,37 @@ export default class BlueprintConstruct {
                 skipVersionValidation: true,
                 serviceName: blueprints.AckServiceName.S3
             }),
-            // new blueprints.addons.KarpenterAddOn({
-            //     requirements: [
-            //         { key: 'node.kubernetes.io/instance-type', op: 'In', vals: ['m5.2xlarge'] },
-            //         { key: 'topology.kubernetes.io/zone', op: 'NotIn', vals: ['us-west-2c']},
-            //         { key: 'kubernetes.io/arch', op: 'In', vals: ['amd64','arm64']},
-            //         { key: 'karpenter.sh/capacity-type', op: 'In', vals: ['spot']},
-            //     ],
-            //     subnetTags: {
-            //         "Name": "blueprint-construct-dev/blueprint-construct-dev-vpc/PrivateSubnet1",
-            //     },
-            //     securityGroupTags: {
-            //         "kubernetes.io/cluster/blueprint-construct-dev": "owned",
-            //     },
-            //     taints: [{
-            //         key: "workload",
-            //         value: "test",
-            //         effect: "NoSchedule",
-            //     }],
-            //     consolidation: { enabled: true },
-            //     ttlSecondsUntilExpired: 2592000,
-            //     weight: 20,
-            //     interruptionHandling: true,
-            //     limits: {
-            //         resources: {
-            //             cpu: 20,
-            //             memory: "64Gi",
-            //         }
-            //     }
-            // }),
-          //  new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
-            //new blueprints.addons.KubeviousAddOn(),
+            new blueprints.addons.KarpenterAddOn({
+                requirements: [
+                    { key: 'node.kubernetes.io/instance-type', op: 'In', vals: ['m5.2xlarge'] },
+                    { key: 'topology.kubernetes.io/zone', op: 'NotIn', vals: ['us-west-2c']},
+                    { key: 'kubernetes.io/arch', op: 'In', vals: ['amd64','arm64']},
+                    { key: 'karpenter.sh/capacity-type', op: 'In', vals: ['spot']},
+                ],
+                subnetTags: {
+                    "Name": "blueprint-construct-dev/blueprint-construct-dev-vpc/PrivateSubnet1",
+                },
+                securityGroupTags: {
+                    "kubernetes.io/cluster/blueprint-construct-dev": "owned",
+                },
+                taints: [{
+                    key: "workload",
+                    value: "test",
+                    effect: "NoSchedule",
+                }],
+                consolidation: { enabled: true },
+                ttlSecondsUntilExpired: 2592000,
+                weight: 20,
+                interruptionHandling: true,
+                limits: {
+                    resources: {
+                        cpu: 20,
+                        memory: "64Gi",
+                    }
+                }
+            }),
+            new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
+            new blueprints.addons.KubeviousAddOn(),
             new blueprints.addons.EbsCsiDriverAddOn({
                 kmsKeys: [
                   blueprints.getResource( context => new kms.Key(context.scope, "ebs-csi-driver-key", { alias: "ebs-csi-driver-key"})),
@@ -151,19 +150,19 @@ export default class BlueprintConstruct {
                 securityContextRunAsUser: 1001,
                 irsaRoles: ["CloudWatchFullAccess", "AmazonSQSFullAccess"]
             }),
-            // new blueprints.addons.AWSPrivateCAIssuerAddon(),
-            // new blueprints.addons.JupyterHubAddOn({
-            //     efsConfig: {
-            //         pvcName: "efs-persist",
-            //         removalPolicy: cdk.RemovalPolicy.DESTROY,
-            //         capacity: '10Gi',
-            //     },
-            //     serviceType: blueprints.JupyterHubServiceType.CLUSTERIP,
-            //     notebookStack: 'jupyter/datascience-notebook',
-            //     values: { prePuller: { hook: { enabled: false }}}
-            // }),
-            // new blueprints.EmrEksAddOn(),
-            // new blueprints.AwsBatchAddOn(),
+            new blueprints.addons.AWSPrivateCAIssuerAddon(),
+            new blueprints.addons.JupyterHubAddOn({
+                efsConfig: {
+                    pvcName: "efs-persist",
+                    removalPolicy: cdk.RemovalPolicy.DESTROY,
+                    capacity: '10Gi',
+                },
+                serviceType: blueprints.JupyterHubServiceType.CLUSTERIP,
+                notebookStack: 'jupyter/datascience-notebook',
+                values: { prePuller: { hook: { enabled: false }}}
+            }),
+            new blueprints.EmrEksAddOn(),
+            new blueprints.AwsBatchAddOn(),
         ];
 
         // Instantiated to for helm version check.
@@ -172,7 +171,7 @@ export default class BlueprintConstruct {
         });
         new blueprints.ExternalsSecretsAddOn();
        
-        const blueprintID = 'shapirov-blueprint';
+        const blueprintID = 'blueprint-construct-dev';
 
         const userData = ec2.UserData.forLinux();
         userData.addCommands(`/etc/eks/bootstrap.sh ${blueprintID}`); 
@@ -192,24 +191,24 @@ export default class BlueprintConstruct {
                     maxSize: 3, 
                     nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }
                 },
-                // {
-                //     id: "mng2-customami",
-                //     instanceTypes: [new ec2.InstanceType('t3.large')],
-                //     nodeGroupCapacityType: CapacityType.SPOT,
-                //     desiredSize: 0,
-                //     minSize: 0,
-                //     customAmi: {
-                //         machineImage: ec2.MachineImage.genericLinux({
-                //             'us-east-1': 'ami-08e520f5673ee0894',
-                //             'us-west-2': 'ami-0403ff342ceb30967',
-                //             'us-east-2': 'ami-07109d69738d6e1ee',
-                //             'us-west-1': 'ami-07bda4b61dc470985',
-                //             'us-gov-west-1': 'ami-0e9ebbf0d3f263e9b',
-                //             'us-gov-east-1':'ami-033eb9bc6daf8bfb1'
-                //         }),
-                //         userData: userData,
-                //     }
-                // }
+                {
+                    id: "mng2-customami",
+                    instanceTypes: [new ec2.InstanceType('t3.large')],
+                    nodeGroupCapacityType: CapacityType.SPOT,
+                    desiredSize: 0,
+                    minSize: 0,
+                    customAmi: {
+                        machineImage: ec2.MachineImage.genericLinux({
+                            'us-east-1': 'ami-08e520f5673ee0894',
+                            'us-west-2': 'ami-0403ff342ceb30967',
+                            'us-east-2': 'ami-07109d69738d6e1ee',
+                            'us-west-1': 'ami-07bda4b61dc470985',
+                            'us-gov-west-1': 'ami-0e9ebbf0d3f263e9b',
+                            'us-gov-east-1':'ami-033eb9bc6daf8bfb1'
+                        }),
+                        userData: userData,
+                    }
+                }
             ]
         });
 
@@ -260,9 +259,9 @@ export default class BlueprintConstruct {
 
         blueprints.EksBlueprint.builder()
             .addOns(...addOns)
-            .resourceProvider(blueprints.GlobalResources.Vpc, new VpcProvider("vpc-06795ec62eb45cf89"))
+            .resourceProvider(blueprints.GlobalResources.Vpc, new VpcProvider(undefined,"100.64.0.0/16", ["100.64.0.0/24","100.64.1.0/24","100.64.2.0/24"]))
             .clusterProvider(clusterProvider)
-            //.teams(...teams, new blueprints.EmrEksTeam(dataTeam), new blueprints.BatchEksTeam(batchTeam))
+            .teams(...teams, new blueprints.EmrEksTeam(dataTeam), new blueprints.BatchEksTeam(batchTeam))
             .enableControlPlaneLogTypes(blueprints.ControlPlaneLogType.API)
             .build(scope, blueprintID, props);
     }

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -25,6 +25,7 @@ export default class BlueprintConstruct {
 
         blueprints.HelmAddOn.validateHelmVersions = true;
         blueprints.HelmAddOn.failOnVersionValidation = false;
+        //0: silly, 1: trace, 2: debug, 3: info, 4: warn, 5: error, 6: fatal
         logger.settings.minLevel =  3;
         userLog.settings.minLevel = 2;
 

--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -1,0 +1,52 @@
+import * as cdk from 'aws-cdk-lib';
+import * as bp from '../lib';
+import * as bcrypt from 'bcrypt';
+
+const app = new cdk.App();
+
+const base = bp.EksBlueprint.builder()
+    .account(process.env.CDK_DEFAULT_ACCOUNT)
+    .region(process.env.CDK_DEFAULT_REGION)
+    .resourceProvider(bp.GlobalResources.Vpc, new bp.VpcProvider("default")); // saving time on VPC creation
+
+
+const builder = base.clone;
+
+builder()
+    .clusterProvider(new bp.FargateClusterProvider())
+    .build(app, "fargate-blueprint");
+
+builder()
+    .clusterProvider(new bp.MngClusterProvider())
+    .build(app, "mng-blueprint");
+
+
+const argoBootstrap = new bp.addons.ArgoCDAddOn({
+    bootstrapRepo: {
+         repoUrl: 'https://github.com/aws-samples/eks-blueprints-add-ons.git',
+         path: 'chart',
+         targetRevision: "eks-blueprints-cdk",
+    },
+    workloadApplications: [
+        {
+            name: "micro-services",
+            namespace: "argocd",
+            repository: {
+                repoUrl: 'https://github.com/aws-samples/eks-blueprints-workloads.git',
+                path: 'envs/dev',
+                targetRevision: "main",
+            },
+            values: {
+                domain: ""
+            }
+        }
+    ],
+    values: {
+        configs: {
+             secret: {
+                 argocdServerAdminPassword: bcrypt.hash("argopwd1", 10) 
+             }
+         }
+     }
+});
+

--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -1,6 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as bp from '../lib';
 import * as bcrypt from 'bcrypt';
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
 const app = new cdk.App();
 
@@ -10,43 +12,55 @@ const base = bp.EksBlueprint.builder()
     .resourceProvider(bp.GlobalResources.Vpc, new bp.VpcProvider("default")); // saving time on VPC creation
 
 
-const builder = base.clone;
+const builder = () => base.clone();
+
+const publicCluster = {
+    version: KubernetesVersion.V1_24, 
+    vpcSubnets: [{ subnetType: ec2.SubnetType.PUBLIC }]
+};
 
 builder()
     .clusterProvider(new bp.FargateClusterProvider())
     .build(app, "fargate-blueprint");
 
 builder()
-    .clusterProvider(new bp.MngClusterProvider())
+    .clusterProvider(new bp.MngClusterProvider(publicCluster))
     .build(app, "mng-blueprint");
 
+builder()
+    .clusterProvider(new bp.MngClusterProvider(publicCluster))
+    .addOns(buildArgoBootstrap())
+    .build(app, 'argo-blueprint');
 
-const argoBootstrap = new bp.addons.ArgoCDAddOn({
-    bootstrapRepo: {
-         repoUrl: 'https://github.com/aws-samples/eks-blueprints-add-ons.git',
-         path: 'chart',
-         targetRevision: "eks-blueprints-cdk",
-    },
-    workloadApplications: [
-        {
-            name: "micro-services",
-            namespace: "argocd",
-            repository: {
-                repoUrl: 'https://github.com/aws-samples/eks-blueprints-workloads.git',
-                path: 'envs/dev',
-                targetRevision: "main",
-            },
-            values: {
-                domain: ""
+
+function buildArgoBootstrap() {
+    return new bp.addons.ArgoCDAddOn({
+        bootstrapRepo: {
+            repoUrl: 'https://github.com/aws-samples/eks-blueprints-add-ons.git',
+            path: 'chart',
+            targetRevision: "eks-blueprints-cdk",
+        },
+        workloadApplications: [
+            {
+                name: "micro-services",
+                namespace: "argocd",
+                repository: {
+                    repoUrl: 'https://github.com/aws-samples/eks-blueprints-workloads.git',
+                    path: 'envs/dev',
+                    targetRevision: "main",
+                },
+                values: {
+                    domain: ""
+                }
+            }
+        ],
+        values: {
+            configs: {
+                secret: {
+                    argocdServerAdminPassword: bcrypt.hash("argopwd1", 10)
+                }
             }
         }
-    ],
-    values: {
-        configs: {
-             secret: {
-                 argocdServerAdminPassword: bcrypt.hash("argopwd1", 10) 
-             }
-         }
-     }
-});
+    });
+}
 

--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -20,7 +20,7 @@ const publicCluster = {
 };
 
 builder()
-    .clusterProvider(new bp.FargateClusterProvider())
+    .clusterProvider(new bp.FargateClusterProvider(publicCluster))
     .build(app, "fargate-blueprint");
 
 builder()
@@ -30,7 +30,7 @@ builder()
 builder()
     .clusterProvider(new bp.MngClusterProvider(publicCluster))
     .addOns(buildArgoBootstrap())
-    .build(app, 'argo-blueprint');
+    .build(app, 'argo-blueprint1');
 
 
 function buildArgoBootstrap() {

--- a/lib/cluster-providers/fargate-cluster-provider.ts
+++ b/lib/cluster-providers/fargate-cluster-provider.ts
@@ -16,7 +16,7 @@ export interface FargateClusterProviderProps extends eks.CommonClusterOptions {
     /**
      * The Fargate for the cluster.
      */
-    fargateProfiles: Map<string, eks.FargateProfileOptions>,
+    fargateProfiles?: Map<string, eks.FargateProfileOptions>,
 
     /**
      * Subnets are passed to the cluster configuration.

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -367,7 +367,7 @@ export class GenericClusterProvider implements ClusterProvider {
         const result = cluster.addNodegroupCapacity(nodeGroup.id + "-ng", nodegroupOptions);
 
         if(nodeGroup.enableSsmPermissions) {
-            result.role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'))
+            result.role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
         }
 
         return result;

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -4,9 +4,7 @@ import { KubectlV23Layer } from "@aws-cdk/lambda-layer-kubectl-v23";
 import { KubectlV24Layer } from "@aws-cdk/lambda-layer-kubectl-v24";
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { IVpc } from "aws-cdk-lib/aws-ec2";
 import * as eks from "aws-cdk-lib/aws-eks";
-import { FargateProfile } from "aws-cdk-lib/aws-eks";
 import { IKey } from "aws-cdk-lib/aws-kms";
 import { ILayerVersion } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
@@ -15,6 +13,7 @@ import * as utils from "../utils";
 import * as constants from './constants';
 import { AutoscalingNodeGroup, ManagedNodeGroup } from "./types";
 import assert = require('assert');
+import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
 
 export function clusterBuilder() {
     return new ClusterBuilder();
@@ -200,7 +199,7 @@ export class GenericClusterProvider implements ClusterProvider {
     /**
      * @override
      */
-    createCluster(scope: Construct, vpc: IVpc, secretsEncryptionKey: IKey | undefined): ClusterInfo {
+    createCluster(scope: Construct, vpc: ec2.IVpc, secretsEncryptionKey: IKey | undefined): ClusterInfo {
         const id = scope.node.id;
 
         // Props for the cluster.
@@ -244,7 +243,7 @@ export class GenericClusterProvider implements ClusterProvider {
         });
 
         const fargateProfiles = Object.entries(this.props.fargateProfiles ?? {});
-        const fargateConstructs : FargateProfile[] = [];
+        const fargateConstructs : eks.FargateProfile[] = [];
         fargateProfiles?.forEach(([key, options]) => fargateConstructs.push(this.addFargateProfile(cluster, key, options)));
 
         return new ClusterInfo(cluster, version, nodeGroups, autoscalingGroups, fargateConstructs);
@@ -318,7 +317,7 @@ export class GenericClusterProvider implements ClusterProvider {
     /**
      * Adds a fargate profile to the cluster
      */
-    addFargateProfile(cluster: eks.Cluster, name: string, profileOptions: eks.FargateProfileOptions): FargateProfile {
+    addFargateProfile(cluster: eks.Cluster, name: string, profileOptions: eks.FargateProfileOptions): eks.FargateProfile {
         return cluster.addFargateProfile(name, profileOptions);
     }
 
@@ -365,7 +364,13 @@ export class GenericClusterProvider implements ClusterProvider {
             delete nodegroupOptions.releaseVersion;
         }
 
-        return cluster.addNodegroupCapacity(nodeGroup.id + "-ng", nodegroupOptions);
+        const result = cluster.addNodegroupCapacity(nodeGroup.id + "-ng", nodegroupOptions);
+
+        if(nodeGroup.enableSsmPermissions) {
+            result.role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'))
+        }
+
+        return result;
     }
 
     private validateInput(props: GenericClusterProviderProps) {

--- a/lib/cluster-providers/types.ts
+++ b/lib/cluster-providers/types.ts
@@ -74,6 +74,11 @@ export interface ManagedNodeGroup extends Omit<eks.NodegroupOptions, "launchTemp
      * @default all private subnets
      */
     nodeGroupSubnets?: ec2.SubnetSelection;
+
+    /**
+     * If set to true will add AmazonSSMManagedInstanceCore to the node role.
+     */
+    enableSsmPermissions?: boolean;
 }
 
 /**

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -187,7 +187,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
     }
 
     public clone(region?: string, account?: string): BlueprintBuilder {
-        return new BlueprintBuilder().withBlueprintProps({ ...this.props })
+        return new BlueprintBuilder().withBlueprintProps(this.props)
             .account(account ?? this.env.account).region(region ?? this.env.region);
     }
 

--- a/lib/utils/proxy-utils.ts
+++ b/lib/utils/proxy-utils.ts
@@ -35,7 +35,7 @@ export class DummyProxy<T extends object> implements ProxyHandler<T> {
 
         return new Proxy({} as any, new DummyProxy((arg) => {
             return (this.source(arg) as any)[key];
-        }));; 
+        }));
     }
 }
 

--- a/lib/utils/proxy-utils.ts
+++ b/lib/utils/proxy-utils.ts
@@ -34,7 +34,7 @@ export class DummyProxy<T extends object> implements ProxyHandler<T> {
         }
 
         return new Proxy({} as any, new DummyProxy((arg) => {
-            return (this.source(arg) as any).key;
+            return (this.source(arg) as any)[key];
         }));; 
     }
 }

--- a/lib/utils/proxy-utils.ts
+++ b/lib/utils/proxy-utils.ts
@@ -33,7 +33,9 @@ export class DummyProxy<T extends object> implements ProxyHandler<T> {
             return this.source;
         }
 
-        return undefined; 
+        return new Proxy({} as any, new DummyProxy((arg) => {
+            return (this.source(arg) as any).key;
+        }));; 
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "watch": "tsc -w",
         "test": "jest --verbose false --detectOpenHandles",
         "cdk": "cdk",
+        "examples": "cdk --app \"npx ts-node examples/examples.ts\"",
         "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx"
     },
     "devDependencies": {

--- a/test/resource-providers/resource-proxy.test.ts
+++ b/test/resource-providers/resource-proxy.test.ts
@@ -2,12 +2,15 @@ import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
-import { Role } from "aws-cdk-lib/aws-iam";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { Key } from "aws-cdk-lib/aws-kms";
 import * as nutil from 'node:util/types';
 import * as blueprints from "../../lib";
 import { AppMeshAddOn, EksBlueprint, GlobalResources, KmsKeyProvider } from "../../lib";
-import { cloneDeep } from "../../lib/utils";
+import { cloneDeep, logger } from "../../lib/utils";
+
+
+beforeAll(() => logger.settings.minLevel = 2); // debug
 
 describe("ResourceProxy",() => {
 
@@ -87,10 +90,12 @@ describe("ResourceProxy",() => {
         expect(nutil.isProxy(clusterProvider.props.securityGroup)).toBeTruthy();
     });
 
-    test("When a stack is created with kms key, derefereced expression for keyArn can be passed to add-ons", () => {
+    test("When a stack is created with kms key, dereferenced expression for keyArn can be passed to add-ons", () => {
         const app = new App();
         
         const kmsKey: Key = blueprints.getNamedResource(GlobalResources.KmsKey);
+
+        const someRole: Role = blueprints.getResource( context => new Role(context.scope, "some-role", { assumedBy: new ServicePrincipal("sns.amazon.com")}));
         
         const builder = EksBlueprint.builder()
             .resourceProvider(GlobalResources.KmsKey, new KmsKeyProvider())
@@ -98,7 +103,8 @@ describe("ResourceProxy",() => {
             .region("us-east-1")
             .addOns(new AppMeshAddOn( {
                 values: {
-                    kmsKeyArn: kmsKey.keyArn
+                    kmsKeyArn: kmsKey.keyArn,
+                    someRole: someRole.roleArn 
                 }
             }));
 
@@ -106,6 +112,7 @@ describe("ResourceProxy",() => {
         const template = Template.fromStack(stack1);
         
         // Then
+        logger.debug(template.toJSON());
         expect(JSON.stringify(template.toJSON())).toContain('kmsKeyArn');
     });
 });


### PR DESCRIPTION
*Issue #, if available:* #618

*Description of changes:* Customers can use properties from resource proxies obtained with `getResource` and `getNamedResource` to pass to add-on and teams. Enables passing roles, domain, certs, kms keys down to the GitOps repo (as one of the use cases).

## Example:

```typescript
const app = new App();
const kmsKey: Key = blueprints.getNamedResource(GlobalResources.KmsKey);
const someRole: Role = blueprints.getResource( context => new Role(context.scope, "some-role", { assumedBy: new ServicePrincipal("sns.amazon.com")}));
      
const builder = EksBlueprint.builder()
  .resourceProvider(GlobalResources.KmsKey, new KmsKeyProvider())
  .account("123456789012")
  .region("us-east-1")
  .addOns(new MyAddOn({
     values: {
         kmsKeyArn: kmsKey.keyArn,
         someRole: someRole.roleArn 
      }
   }))
  .build(app, "resource-deref-cluster");

```

## Example clusters (test/demo)

Added examples clusters, including examples of argocd bootstraping. Those can be run with 

```
$ npm run examples list # similar to CDK list with examples target

Output:

argo-blueprint
fargate-blueprint
mng-blueprint

$ npm run examples deploy <your-example-name> # similar to CDK deploy 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
