### PR TITLE
Convert all vpc-cni environment variables to string

### DIFF
--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -240,7 +240,7 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
   // clean up all undefined
   const values = result.env;
   Object.keys(values).forEach(key => values[key] === undefined ? delete values[key] : {});
-  Object.keys(values).forEach(key => values[key] = typeof values[key] == 'boolean' ?  JSON.stringify(values[key]):values[key]);
+  Object.keys(values).forEach(key => values[key] = typeof values[key] !== 'string' ?  JSON.stringify(values[key]):values[key]);
   
   return result;
 }


### PR DESCRIPTION
*Issue #, if available:* **N/A**

*Description of changes:*
All environment variable names and values must be strings in k8s pods (including the aws-node daemonset pods). See [EnvVar docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core).

Numeric values are required for the `warmPrefixTarget` property and others. However passing the value verbatim as a number causes an error:
```
ConfigurationValue provided in request is not supported: Json schema validation failed with error: [$.env.WARM_PREFIX_TARGET: integer found, string expected, $.env.WARM_ENI_TARGET: integer found, string expected]
```

**Disclaimer:**
 - I am sure about the (non)string type issue
 - I have manually  tested the type-casting expression to be correct for strings, booleans and numbers (uint)
 - However, I was unable to test the addon integrated in my actual CDK app. The copy/pasted and fixed addon class got a different id, CDK wanted to destroy the riginal vpc-cni addon and all failed with a weird incompatibility error. I suppose this is related to the copy-pasting and not the fix itself.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
