### PR TITLE
Adding backwards compatibility with v1.6.0 for KMS resource provider

### DIFF
--- a/lib/resource-providers/kms-key.ts
+++ b/lib/resource-providers/kms-key.ts
@@ -54,17 +54,20 @@ export class CreateKmsKeyProvider implements ResourceProvider<kms.IKey> {
  * Pass an aliasName to lookup an existing KMS Key.
  *
  * @param aliasName The alias name to lookup an existing KMS Key
+ * @param keyId The key id for the KMS Key
  */
 export class LookupKmsKeyProvider implements ResourceProvider<kms.IKey> {
   private readonly aliasName: string;
+  private readonly keyId?: string;
 
-  public constructor(aliasName: string) {
+  public constructor(aliasName: string, keyId?: string) {
     this.aliasName = aliasName;
+    this.keyId = keyId;
   }
 
   provide(context: ResourceContext): kms.IKey {
     const id = context.scope.node.id;
-    const keyId = `${id}-${this.aliasName}-KmsKey`;
+    const keyId = this.keyId || `${id}-${this.aliasName}-KmsKey`;
 
     return kms.Key.fromLookup(context.scope, keyId, {
       aliasName: this.aliasName,

--- a/lib/resource-providers/kms-key.ts
+++ b/lib/resource-providers/kms-key.ts
@@ -15,29 +15,24 @@ import { ResourceContext, ResourceProvider } from "../spi";
  */
 export class CreateKmsKeyProvider implements ResourceProvider<kms.IKey> {
   private readonly aliasName?: string;
-  private readonly keyId?: string;
   private readonly kmsKeyProps?: kms.KeyProps;
 
   /**
    * Configuration options for the KMS Key.
    *
    * @param aliasName The alias name for the KMS Key
-   * @param keyId The key id for the KMS Key
    * @param kmsKeyProps The key props used
    */
-  public constructor(
-    aliasName?: string,
-    keyId?: string,
-    kmsKeyProps?: kms.KeyProps
-  ) {
+  public constructor(aliasName?: string, kmsKeyProps?: kms.KeyProps) {
     this.aliasName = aliasName;
-    this.keyId = keyId;
     this.kmsKeyProps = kmsKeyProps;
   }
 
   provide(context: ResourceContext): kms.IKey {
     const id = context.scope.node.id;
-    const keyId = this.keyId || `${id}-${this.aliasName ?? "default"}-KmsKey`;
+    const keyId = !this.aliasName
+      ? `${id}-kms-key`
+      : `${id}-${this.aliasName}-KmsKey`;
     let key = undefined;
 
     key = new kms.Key(context.scope, keyId, {
@@ -54,20 +49,17 @@ export class CreateKmsKeyProvider implements ResourceProvider<kms.IKey> {
  * Pass an aliasName to lookup an existing KMS Key.
  *
  * @param aliasName The alias name to lookup an existing KMS Key
- * @param keyId The key id for the KMS Key
  */
 export class LookupKmsKeyProvider implements ResourceProvider<kms.IKey> {
   private readonly aliasName: string;
-  private readonly keyId?: string;
 
-  public constructor(aliasName: string, keyId?: string) {
+  public constructor(aliasName: string) {
     this.aliasName = aliasName;
-    this.keyId = keyId;
   }
 
   provide(context: ResourceContext): kms.IKey {
     const id = context.scope.node.id;
-    const keyId = this.keyId || `${id}-${this.aliasName}-KmsKey`;
+    const keyId = `${id}-${this.aliasName}-KmsKey`;
 
     return kms.Key.fromLookup(context.scope, keyId, {
       aliasName: this.aliasName,

--- a/lib/resource-providers/kms-key.ts
+++ b/lib/resource-providers/kms-key.ts
@@ -15,22 +15,29 @@ import { ResourceContext, ResourceProvider } from "../spi";
  */
 export class CreateKmsKeyProvider implements ResourceProvider<kms.IKey> {
   private readonly aliasName?: string;
+  private readonly keyId?: string;
   private readonly kmsKeyProps?: kms.KeyProps;
 
   /**
    * Configuration options for the KMS Key.
    *
    * @param aliasName The alias name for the KMS Key
+   * @param keyId The key id for the KMS Key
    * @param kmsKeyProps The key props used
    */
-  public constructor(aliasName?: string, kmsKeyProps?: kms.KeyProps) {
+  public constructor(
+    aliasName?: string,
+    keyId?: string,
+    kmsKeyProps?: kms.KeyProps
+  ) {
     this.aliasName = aliasName;
+    this.keyId = keyId;
     this.kmsKeyProps = kmsKeyProps;
   }
 
   provide(context: ResourceContext): kms.IKey {
     const id = context.scope.node.id;
-    const keyId = `${id}-${this.aliasName ?? "default"}-KmsKey`;
+    const keyId = this.keyId || `${id}-${this.aliasName ?? "default"}-KmsKey`;
     let key = undefined;
 
     key = new kms.Key(context.scope, keyId, {


### PR DESCRIPTION
the KMS key resource provider

*Issue #, if available:* #644

*Description of changes:*
Adding KMS keyId as an optional input parameter for the KMS provider. Users can provide the KMS key alias and keyId to use the existing key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
