### PR TITLE
Add requireImdsv2 to ManagedNodeGroup's LaunchTemplateProps

### DIFF
--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -356,6 +356,7 @@ export class GenericClusterProvider implements ClusterProvider {
             const lt = new ec2.LaunchTemplate(cluster, `${nodeGroup.id}-lt`, {
                 machineImage: nodeGroup.launchTemplate?.machineImage,
                 userData: nodeGroup.launchTemplate?.userData,
+                requireImdsv2: nodeGroup.launchTemplate?.requireImdsv2,
             });
             utils.setPath(nodegroupOptions, "launchTemplateSpec", {
                 id: lt.launchTemplateId!,

--- a/lib/cluster-providers/types.ts
+++ b/lib/cluster-providers/types.ts
@@ -23,6 +23,10 @@ export interface LaunchTemplateProps {
         [key: string]: string;
     }
 
+    /**
+     * Whether IMDSv2 should be required on launched instances. (optional, default: false)
+     */
+    requireImdsv2?: boolean;
 }
 
 

--- a/test/resource-providers/resource-proxy.test.ts
+++ b/test/resource-providers/resource-proxy.test.ts
@@ -115,4 +115,29 @@ describe("ResourceProxy",() => {
         logger.debug(template.toJSON());
         expect(JSON.stringify(template.toJSON())).toContain('kmsKeyArn');
     });
+
+    test("When a stack with a managed node group is created, IMDSv2 is required if specified via the launch template", () => {
+        const app = new App();
+
+        const genericClusterProvider = new blueprints.GenericClusterProvider({
+            version: KubernetesVersion.V1_24,
+            managedNodeGroups: [{
+                id: "mng1",
+                launchTemplate: {
+                    requireImdsv2: true,
+                },
+            }],
+        });
+
+        const stack = EksBlueprint.builder()
+                                  .clusterProvider(genericClusterProvider)
+                                  .account("123456789012")
+                                  .region("us-east-1")
+                                  .build(app, "cluster");
+
+        // Then
+        const template = Template.fromStack(stack);
+        expect(JSON.stringify(template.toJSON())).toContain("\"HttpTokens\":\"required\"");
+    });
+
 });


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-quickstart/cdk-eks-blueprints/issues/643

*Description of changes:*
Add requireImdsv2 to ManagedNodeGroup's LaunchTemplateProps so that clusters using managed node groups will create ec2 instances with imdsv1 disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
