### PR TITLE
CDK version change to 2.76.0 from 2.72.0 per 1.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ aws --version
 Install CDK matching the current version of the Blueprints QuickStart (which can be found in package.json).
 
 ```bash
-npm install -g aws-cdk@2.72.0
+npm install -g aws-cdk@2.76.0
 ```
 
 Verify the installation.
 
 ```bash
 cdk --version
-# must output 2.72.0
+# must output 2.76.0
 ```
 
 Create a new CDK project. We use `typescript` for this example.

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,14 +44,14 @@ aws --version
 Install CDK matching the current version of the Blueprints QuickStart (which can be found in package.json).
 
 ```bash
-npm install -g aws-cdk@2.72.0
+npm install -g aws-cdk@2.76.0
 ```
 
 Verify the installation.
 
 ```bash
 cdk --version
-# must output 2.72.0
+# must output 2.76.0
 ```
 
 Create a new CDK project. We use `typescript` for this example.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,8 @@ Create a directory that represents you project (e.g. `my-blueprints`) and then c
 ```bash
 npm install -g n # may require sudo
 n stable # may require sudo 
-npm install -g aws-cdk@2.72.0 # may require sudo (Ubuntu) depending on configuration
-cdk --version # must produce 2.72.0
+npm install -g aws-cdk@2.76.0 # may require sudo (Ubuntu) depending on configuration
+cdk --version # must produce 2.76.0
 mkdir my-blueprints
 cd my-blueprints
 cdk init app --language typescript

--- a/lib/pipelines/code-pipeline.ts
+++ b/lib/pipelines/code-pipeline.ts
@@ -357,7 +357,7 @@ class CodePipeline {
               input: codePipelineSource,
               installCommands: [
                 'n stable',
-                'npm install -g aws-cdk@2.72.0',
+                'npm install -g aws-cdk@2.76.0',
                 'npm install',
               ],
               commands: ['npm run build', 'npx cdk synth']


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
With 1.7.0 release, CDK version should be documented as 2.76.0 (as was updated in `package.json`). This will revise to reflect changes in all documentations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
