### PR TITLE
Adding the missing IAM permissions for the EFS CSI driver

### DIFF
--- a/lib/addons/efs-csi-driver/iam-policy.ts
+++ b/lib/addons/efs-csi-driver/iam-policy.ts
@@ -26,7 +26,8 @@ export function getEfsDriverPolicyStatements(
     {
       "Effect": "Allow",
       "Action": [
-        "elasticfilesystem:CreateAccessPoint"
+        "elasticfilesystem:CreateAccessPoint",
+        "elasticfilesystem:TagResource",
       ],
       "Resource": "*",
       "Condition": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the missing IAM permissions for the EFS CSI driver `elasticfilesystem:TagResource`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
