### PR TITLE
setting default kubectllayer to 1.25, requiredIdmsv2 e2e test, patch 

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -188,7 +188,8 @@ export default class BlueprintConstruct {
                             "Type": "Managed-Node-Group",
                             "LaunchTemplate": "Custom",
                             "Instance": "ONDEMAND"
-                        }
+                        },
+                        requireImdsv2: true
                     }
                 },
                 {

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -2,9 +2,11 @@
 import { KubectlV23Layer } from "@aws-cdk/lambda-layer-kubectl-v23";
 import { KubectlV24Layer } from "@aws-cdk/lambda-layer-kubectl-v24";
 import { KubectlV25Layer } from "@aws-cdk/lambda-layer-kubectl-v25";
+import { Tags } from "aws-cdk-lib";
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as eks from "aws-cdk-lib/aws-eks";
+import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
 import { IKey } from "aws-cdk-lib/aws-kms";
 import { ILayerVersion } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
@@ -13,8 +15,6 @@ import * as utils from "../utils";
 import * as constants from './constants';
 import { AutoscalingNodeGroup, ManagedNodeGroup } from "./types";
 import assert = require('assert');
-import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
-import { Tags } from "aws-cdk-lib";
 
 export function clusterBuilder() {
     return new ClusterBuilder();
@@ -288,8 +288,8 @@ export class GenericClusterProvider implements ClusterProvider {
         
         const minor = version.version.split('.')[1];
 
-        if(minor && parseInt(minor, 10) > 24) {
-            return new KubectlV24Layer(scope, "kubectllayer24"); // for all versions above 1.24 use 1.24 kubectl (unless explicitly supported in CDK)
+        if(minor && parseInt(minor, 10) > 25) {
+            return new KubectlV25Layer(scope, "kubectllayer25"); // for all versions above 1.25 use 1.25 kubectl (unless explicitly supported in CDK)
         }
         return undefined;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* release prep for 1.7.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
