### PR TITLE
Quick fix on wrong syntax for ALB addon check

### DIFF
--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -201,7 +201,7 @@ export class JupyterHubAddOn extends HelmAddOn {
         const ingressAnnotations = this.options.ingressAnnotations;
         const cert = this.options.certificateResourceName;
 
-        const albAddOnCheck = clusterInfo.getScheduledAddOn('AwsLoadBalancerControllerAddOn.name');
+        const albAddOnCheck = clusterInfo.getScheduledAddOn(AwsLoadBalancerControllerAddOn.name);
         // Use Ingress and AWS ALB
         if (serviceType == JupyterHubServiceType.ALB){
             assert(albAddOnCheck, `Missing a dependency: ${AwsLoadBalancerControllerAddOn.name}. Please add it to your list of addons.`); 

--- a/lib/addons/jupyterhub/index.ts
+++ b/lib/addons/jupyterhub/index.ts
@@ -201,7 +201,7 @@ export class JupyterHubAddOn extends HelmAddOn {
         const ingressAnnotations = this.options.ingressAnnotations;
         const cert = this.options.certificateResourceName;
 
-        const albAddOnCheck = clusterInfo.getScheduledAddOn(AwsLoadBalancerControllerAddOn.name);
+        const albAddOnCheck = clusterInfo.getProvisionedAddOn(AwsLoadBalancerControllerAddOn.name);
         // Use Ingress and AWS ALB
         if (serviceType == JupyterHubServiceType.ALB){
             assert(albAddOnCheck, `Missing a dependency: ${AwsLoadBalancerControllerAddOn.name}. Please add it to your list of addons.`); 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This fixes the syntax error on the Load Balancer addon check for JupyterHub addon. This PR also updates release version to 1.7.2 for quick patch, as issues exist with patterns repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
