### PR TITLE
nginx addon fails on schema validation when certificate is specified. 

### DIFF
--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -97,8 +97,8 @@ export class NginxAddOn extends HelmAddOn {
             presetAnnotations['service.beta.kubernetes.io/aws-load-balancer-ssl-ports'] = 'https';
             const certificate = clusterInfo.getResource<ICertificate>(props.certificateResourceName);
             presetAnnotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert'] = certificate?.certificateArn;
-            setPath(values, "controller.service.httpsPort.targetPort", "http");
-            setPath(values, "controller.service.httpPort.enable", "false");
+            setPath(values, "controller.service.httpPort.enable", false);
+            setPath(values, "controller.service.httpsPort.targetPort", 80);
         }
 
         const serviceAnnotations = { ...values.controller?.service?.annotations, ...presetAnnotations };

--- a/lib/addons/nginx/index.ts
+++ b/lib/addons/nginx/index.ts
@@ -1,9 +1,11 @@
 import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { Construct } from "constructs";
+import merge from "ts-deepmerge";
 import { AwsLoadBalancerControllerAddOn } from "..";
-import { ClusterInfo } from "../../spi";
+import { ClusterInfo, Values } from "../../spi";
 import { dependable } from "../../utils";
 import { setPath } from "../../utils/object-utils";
+import * as dot from 'dot-object';
 import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
 
 
@@ -91,20 +93,24 @@ export class NginxAddOn extends HelmAddOn {
             'external-dns.alpha.kubernetes.io/hostname': props.externalDnsHostname,
         };
 
-        const values = { ...props.values ?? {} };
+        const values: Values = {};
 
         if (props.certificateResourceName) {
             presetAnnotations['service.beta.kubernetes.io/aws-load-balancer-ssl-ports'] = 'https';
             const certificate = clusterInfo.getResource<ICertificate>(props.certificateResourceName);
             presetAnnotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert'] = certificate?.certificateArn;
             setPath(values, "controller.service.httpPort.enable", false);
-            setPath(values, "controller.service.httpsPort.targetPort", 80);
+            const httpPort = dot.pick("controller.service.httpsPort.targetPort", props.values ?? {});
+            if(httpPort === undefined) {
+               setPath(values, "controller.service.httpsPort.targetPort", 80);
+            }
         }
 
         const serviceAnnotations = { ...values.controller?.service?.annotations, ...presetAnnotations };
         setPath(values, 'controller.service.annotations', serviceAnnotations);
 
-        const nginxHelmChart = this.addHelmChart(clusterInfo, values);
+        const merged = merge(values, this.props.values ?? {});
+        const nginxHelmChart = this.addHelmChart(clusterInfo, merged);
 
         return Promise.resolve(nginxHelmChart);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-quickstart/eks-blueprints",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:* #672

*Description of changes:*
Added proper types and validation including HTTPS to HTTP port redirection when terminating at the NLB level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
