### PR TITLE
Fixed version mapping for cluster-autoscaler

### DIFF
--- a/lib/addons/cluster-autoscaler/index.ts
+++ b/lib/addons/cluster-autoscaler/index.ts
@@ -46,7 +46,7 @@ const versionMap: Map<KubernetesVersion, string> = new Map([
     [KubernetesVersion.V1_24, "9.25.0"],
     [KubernetesVersion.V1_23, "9.21.0"],
     [KubernetesVersion.V1_22, "9.13.1"],
-    [KubernetesVersion.V1_25, "9.13.1"],
+    [KubernetesVersion.V1_21, "9.13.1"],
     [KubernetesVersion.V1_20, "9.9.2"],
     [KubernetesVersion.V1_19, "9.4.0"],
     [KubernetesVersion.V1_18, "9.4.0"],


### PR DESCRIPTION
*Description of changes:*

The map provided two different mappings for V1.25. Fixed the typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
