### PR TITLE
Karpenter Addon: adding AMI Selector, refactor to use NodeTemplate

### DIFF
--- a/docs/addons/karpenter.md
+++ b/docs/addons/karpenter.md
@@ -88,8 +88,8 @@ blueprints-addon-karpenter-54fd978b89-hclmp   2/2     Running   0          99m
 
 **NOTE:**
 1. The default provisioner is created only if both the subnet tags and the security group tags are provided.
-2. Provisioner spec requirement fields are not necessary, as karpenter will dynamically choose (i.e. leaving instance-type blank will let karpenter choose approrpriate sizing).
-3. Consolidation, which is a flag that enables , is supported on versions 0.15.0 and later. It is also mutually exclusive with `ttlSecondsAfterempty`, so if you provide both properties, the addon will throw an error.
+2. Provisioner spec requirement fields are not necessary, as karpenter will dynamically choose (i.e. leaving instance-type blank will let karpenter choose appropriate sizing).
+3. Consolidation, which is a flag that enables , is supported on versions 0.15.0 and later. It is also mutually exclusive with `ttlSecondsAfterEmpty`, so if you provide both properties, the addon will throw an error.
 4. Weight, which is a property to prioritize provisioners based on weight, is supported on versions 0.16.0 and later. Addon will throw an error if weight is provided for earlier versions.
 5. Interruption Handling, which is a native way to handle interruption due to involuntary interruption events, is supported on versions 0.19.0 and later. For interruption handling in the earlier versions, Karpenter supports using AWS Node Interruption Handler (which you will need to add as an add-on and ***must be in add-on array after the Karpenter add-on*** for it to work.
 

--- a/docs/addons/karpenter.md
+++ b/docs/addons/karpenter.md
@@ -44,6 +44,9 @@ const karpenterAddonProps = {
     effect: "NoSchedule",
   }],
   amiFamily: "AL2",
+  amiSelector: {
+    "karpenter.sh/discovery/MyClusterName": '*',
+  },
   consolidation: { enabled: true },
   ttlSecondsUntilExpired: 2592000,
   weight: 20,
@@ -81,7 +84,7 @@ blueprints-addon-karpenter-54fd978b89-hclmp   2/2     Running   0          99m
 2. Creates `karpenter` namespace.
 3. Creates Kubernetes Service Account, and associate AWS IAM Role with Karpenter Controller Policy attached using [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html).
 4. Deploys Karpenter helm chart in the `karpenter` namespace, configuring cluster name and cluster endpoint on the controller by default.
-5. (Optionally) provisions a default Karpenter Provisioner CRD based on user-provided [spec.requirements](https://karpenter.sh/v0.12.1/provisioner/#specrequirements), [AMI type](https://karpenter.sh/v0.12.1/aws/provisioning/#amazon-machine-image-ami-family), taints and tags. If created, the provisioner will discover the EKS VPC subnets and security groups to launch the nodes with.
+5. (Optionally) provisions a default Karpenter Provisioner and AWSNodeTemplate CRD based on user-provided parameters such as [spec.requirements](https://karpenter.sh/docs/concepts/provisioners/#specrequirements), [AMI type](https://karpenter.sh/v0.12.1/aws/provisioning/#amazon-machine-image-ami-family),[weight](https://karpenter.sh/docs/concepts/provisioners/#specweight), [Subnet Selector](https://karpenter.sh/docs/concepts/node-templates/#specsubnetselector), and [Security Group Selector](https://karpenter.sh/docs/concepts/node-templates/#specsecuritygroupselector). If created, the provisioner will discover the EKS VPC subnets and security groups to launch the nodes with.
 
 **NOTE:**
 1. The default provisioner is created only if both the subnet tags and the security group tags are provided.

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -133,7 +133,7 @@ export default class BlueprintConstruct {
                     }
                 }
             }),
-            // new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
+            new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
             new blueprints.addons.KubeviousAddOn(),
             new blueprints.addons.EbsCsiDriverAddOn({
                 kmsKeys: [

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -119,6 +119,9 @@ export default class BlueprintConstruct {
                     value: "test",
                     effect: "NoSchedule",
                 }],
+                amiSelector: {
+                    "karpenter.sh/discovery/MyClusterName": '*',
+                },
                 consolidation: { enabled: true },
                 ttlSecondsUntilExpired: 2592000,
                 weight: 20,
@@ -130,7 +133,7 @@ export default class BlueprintConstruct {
                     }
                 }
             }),
-            new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
+            // new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
             new blueprints.addons.KubeviousAddOn(),
             new blueprints.addons.EbsCsiDriverAddOn({
                 kmsKeys: [

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -1,7 +1,7 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from "constructs";
 import merge from 'ts-deepmerge';
-import { ClusterInfo, Values } from '../../spi';
+import { ClusterInfo, Values, Taint } from '../../spi';
 import { conflictsWith, createNamespace, createServiceAccount, setPath, } from '../../utils';
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '../helm-addon';
 import { KarpenterControllerPolicy } from './iam';
@@ -22,22 +22,14 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
     /**
      * Taints for the provisioned nodes - Taints may prevent pods from scheduling if they are not tolerated by the pod.
      */
-    taints?: {
-        key: string,
-        value: string,
-        effect: "NoSchedule" | "PreferNoSchedule" | "NoExecute",
-    }[],
+    taints?: Taint[],
 
     /**
      * Provisioned nodes will have these taints, but pods do not need to tolerate these taints to be provisioned by this\
      * provisioner. These taints are expected to be temporary and some other entity (e.g. a DaemonSet) is responsible for
      * removing the taint after it has finished initializing the node.
      */
-    startupTaints?: {
-        key: string,
-        value: string,
-        effect: "NoSchedule" | "PreferNoSchedule" | "NoExecute",
-    }[],
+    startupTaints?: Taint[],
 
     /**
      * Labels applied to all nodes

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -1,7 +1,7 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from "constructs";
 import merge from 'ts-deepmerge';
-import { ClusterInfo } from '../../spi';
+import { ClusterInfo, Values } from '../../spi';
 import { conflictsWith, createNamespace, createServiceAccount, setPath, } from '../../utils';
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '../helm-addon';
 import { KarpenterControllerPolicy } from './iam';
@@ -37,21 +37,17 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
         key: string,
         value: string,
         effect: "NoSchedule" | "PreferNoSchedule" | "NoExecute",
-    },
+    }[],
 
     /**
      * Labels applied to all nodes
      */
-    labels?: {
-        [key: string]: string
-    },
+    labels?: Values,
 
     /**
      * Annotations applied to all nodes
      */
-    annotations?: {
-        [key: string]: string
-    }
+    annotations?: Values,
 
     /**
      * Requirement properties for a Provisioner (Optional) - If not provided, the add-on will
@@ -66,16 +62,12 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
     /**
      * Tags needed for subnets - Subnet tags and security group tags are required for the provisioner to be created
      */
-    subnetTags?: {
-        [key: string]: string
-    }
+    subnetTags?: Values,
 
     /**
      * Tags needed for security groups - Subnet tags and security group tags are required for the provisioner to be created
      */
-    securityGroupTags?: {
-        [key: string]: string
-    }
+    securityGroupTags?: Values,
 
     /**
      * AMI Family: If provided, Karpenter will automatically query the appropriate EKS optimized AMI via AWS Systems Manager
@@ -85,9 +77,7 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
     /**
      * AMI Selector
      */
-    amiSelector?: {
-        [key: string]: string
-    }
+    amiSelector?: Values,
 
     /**
      * Enables consolidation which attempts to reduce cluster cost by both removing un-needed nodes and down-sizing those that can't be removed.  

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -25,6 +25,15 @@ export type Values = {
 };
 
 /**
+ * Utility type for Kubernetes taints passed to Helm or GitOps applications.
+ */
+export type Taint = {
+    key: string,
+    value: string,
+    effect: "NoSchedule" | "PreferNoSchedule" | "NoExecute",
+};
+
+/**
  * Interface that includes a reference to a Git repository for reuse, without credentials
  * and other access information.
  */


### PR DESCRIPTION
*Issue #, if available:* #726

*Description of changes:*
- Adding AMI Selector for the Provisioner
- Using NodeTemplate in addition to the provisioner (needed to acommodate AMI Selector)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
