### PR TITLE
Update AWS Load Balancer Controller Addon IAM Policy to fix permission issue during ALB ingress creation

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/iam-policy.ts
+++ b/lib/addons/aws-loadbalancer-controller/iam-policy.ts
@@ -198,6 +198,28 @@ export const AwsLoadbalancerControllerIamPolicy = (partition: string) => {
             {
                 "Effect": "Allow",
                 "Action": [
+                    "elasticloadbalancing:AddTags"
+                ],
+                "Resource": [
+                    `arn:${partition}:elasticloadbalancing:*:*:targetgroup/*/*`,
+                    `arn:${partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*`,
+                    `arn:${partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*`
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "elasticloadbalancing:CreateAction": [
+                            "CreateTargetGroup",
+                            "CreateLoadBalancer"
+                        ]
+                    },
+                    "Null": {
+                        "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                    }
+                }
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
                     "elasticloadbalancing:RegisterTargets",
                     "elasticloadbalancing:DeregisterTargets"
                 ],


### PR DESCRIPTION
*Issue #, if available:* #737

*Description of changes:*
Added missing permission based on the latest AWS Load Balancer Controller IAM policy reference: https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.5.2/docs/install/iam_policy.json

Also refer to this comment: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2692#issuecomment-1426195505

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
