### PR TITLE
Bump ArgoCD default version to 5.37.0 (currently latest)

### DIFF
--- a/lib/addons/argocd/index.ts
+++ b/lib/addons/argocd/index.ts
@@ -26,7 +26,7 @@ export interface ArgoCDAddOnProps extends HelmAddOnUserProps {
 
     /**
     * Helm chart version to use to install.
-    * @default 3.33.5
+    * @default 5.37.0
     */
     version?: string;
 
@@ -72,7 +72,7 @@ export interface ArgoCDAddOnProps extends HelmAddOnUserProps {
  */
 const defaultProps = {
     namespace: "argocd",
-    version: '4.10.9',
+    version: '5.37.0',
     chart: "argo-cd",
     release: "blueprints-addon-argocd",
     repository: "https://argoproj.github.io/argo-helm"


### PR DESCRIPTION
Argo CD helm version is outdated.
Helm chart version 5 introduced couple of changes, and I think we should upgrade it. It was tested on the pipeline-multi-env-gitops pattern

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
