### PR TITLE
Fix/container insights

### DIFF
--- a/lib/addons/container-insights/index.ts
+++ b/lib/addons/container-insights/index.ts
@@ -1,7 +1,7 @@
-import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
+//import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 import merge from "ts-deepmerge";
-import { assertEC2NodeGroup } from "../..";
+//import { assertEC2NodeGroup } from "../..";
 import { ClusterInfo } from "../../spi";
 import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
 import { ValuesSchema } from "./values";
@@ -32,12 +32,12 @@ export class ContainerInsightsAddOn extends HelmAddOn {
     @conflictsWith("AdotCollectorAddOn")
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;        
-        const nodeGroups = assertEC2NodeGroup(clusterInfo, ContainerInsightsAddOn.name);
+ /*        const nodeGroups = assertEC2NodeGroup(clusterInfo, ContainerInsightsAddOn.name);
         const policy = ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy');
         
         nodeGroups.forEach(nodeGroup => {
             nodeGroup.role.addManagedPolicy(policy);
-        });
+        }); */
 
         // Create an adot-collector service account.
         const serviceAccountName = "adot-collector-sa";
@@ -57,7 +57,7 @@ export class ContainerInsightsAddOn extends HelmAddOn {
         });
 
         // Apply Managed IAM policy to the service account.
-        sa.role.addManagedPolicy(policy);
+        //sa.role.addManagedPolicy(policy);
         sa.node.addDependency(ns);
 
         let values: ValuesSchema = {

--- a/lib/addons/container-insights/index.ts
+++ b/lib/addons/container-insights/index.ts
@@ -1,7 +1,6 @@
-//import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
+import { ManagedPolicy } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 import merge from "ts-deepmerge";
-//import { assertEC2NodeGroup } from "../..";
 import { ClusterInfo } from "../../spi";
 import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
 import { ValuesSchema } from "./values";
@@ -32,13 +31,8 @@ export class ContainerInsightsAddOn extends HelmAddOn {
     @conflictsWith("AdotCollectorAddOn")
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;        
- /*        const nodeGroups = assertEC2NodeGroup(clusterInfo, ContainerInsightsAddOn.name);
         const policy = ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy');
         
-        nodeGroups.forEach(nodeGroup => {
-            nodeGroup.role.addManagedPolicy(policy);
-        }); */
-
         // Create an adot-collector service account.
         const serviceAccountName = "adot-collector-sa";
         let serviceAccountNamespace;
@@ -57,7 +51,7 @@ export class ContainerInsightsAddOn extends HelmAddOn {
         });
 
         // Apply Managed IAM policy to the service account.
-        //sa.role.addManagedPolicy(policy);
+        sa.role.addManagedPolicy(policy);
         sa.node.addDependency(ns);
 
         let values: ValuesSchema = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed assertEC2NodeGroup

### Tests:
* make run-test o/p:
```
Test Suites: 13 passed, 13 total
Tests:       59 passed, 59 total
Snapshots:   0 total
Time:        24.466 s
Ran all test suites.
```
* cdk list 
```                                                                                                                                                         
INFO Chart aws-load-balancer-controller-1.5.4 is at the latest version.
INFO Chart appmesh-controller-1.12.1 is at the latest version.
INFO Chart cert-manager-1.12.2 is at the latest version.
WARN Upgrade is needed for chart kube-state-metrics-5.8.1: latest version is 5.8.2.
INFO Chart prometheus-node-exporter-4.18.1 is at the latest version.
DEBUG Core add-on adot is at version v0.76.1-eksbuild.1
INFO Chart base-1.18.0 is at the latest version.
INFO Chart istiod-1.18.0 is at the latest version.
INFO Chart tigera-operator-v3.26.1 is at the latest version.
INFO Chart metrics-server-3.10.0 is at the latest version.
WARN Upgrade is needed for chart argo-cd-5.37.0: latest version is 5.38.1.
INFO Chart nginx-ingress-0.18.0 is at the latest version.
WARN Upgrade is needed for chart velero-3.2.0: latest version is 4.1.3.
DEBUG Core add-on vpc-cni is at version v1.13.0-eksbuild.1
DEBUG Core add-on coredns is at version v1.9.3-eksbuild.5
DEBUG Core add-on kube-proxy is at version auto
INFO Chart gatekeeper-3.12.0 is at the latest version.
No versions are found for karpenter in repository oci://public.ecr.aws/karpenter/karpenter
INFO Chart aws-node-termination-handler-0.21.0 is at the latest version.
WARN Upgrade is needed for chart kubevious-1.1.2: latest version is 1.2.1.
DEBUG Core add-on aws-ebs-csi-driver is at version v1.20.0-eksbuild.1
WARN Upgrade is needed for chart aws-efs-csi-driver-2.4.6: latest version is 2.4.7.
INFO Chart keda-2.11.1 is at the latest version.
INFO Chart aws-privateca-issuer-1.2.5 is at the latest version.
INFO Chart flux2-2.9.0 is at the latest version.
No versions are found for oci://ghcr.io/grafana-operator/helm-charts/grafana-operator in repository undefined
INFO Chart aws-for-fluent-bit-0.1.27 is at the latest version.
INFO Chart airflow-1.10.0 is at the latest version.
WARN Upgrade is needed for chart external-secrets-0.9.0: latest version is 0.9.1.
INFO Chart external-dns-1.13.0 is at the latest version.
DEBUG Core add-on adot has autoselected version v0.76.1-eksbuild.1
INFO Chart secrets-store-csi-driver-1.3.4 is at the latest version.
DEBUG Core add-on vpc-cni has autoselected version v1.13.0-eksbuild.1
DEBUG Core add-on coredns has autoselected version v1.9.3-eksbuild.5
DEBUG Core add-on kube-proxy has autoselected version v1.25.6-eksbuild.1
DEBUG Core add-on aws-ebs-csi-driver has autoselected version v1.20.0-eksbuild.1
blueprint-construct-dev
```

* cdk deploy "*" - tested with ContainerInsights Add-on enabled (disabled ADOT)
![image](https://github.com/aws-quickstart/cdk-eks-blueprints/assets/118366916/8b7a613d-998b-4bb9-af8a-ae9ef2eeff64)
![image](https://github.com/aws-quickstart/cdk-eks-blueprints/assets/118366916/1ca8e590-5396-4160-8100-05c3bf084a9a)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
