### PR TITLE
Adding create Namespace support for Metrics-Server addon

### DIFF
--- a/docs/addons/metrics-server.md
+++ b/docs/addons/metrics-server.md
@@ -34,6 +34,7 @@ blueprints-addon-metrics-server                               1/1     1         
 
 1. Deploys the metrics-server helm chart in `kube-system` namespace by default.
 2. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
+3. Supports `createNamespace` configuration to deploy the addon to a customized namespace.
 
 ## Testing with Kubernetes Dashboard
 

--- a/lib/addons/kube-state-metrics/index.ts
+++ b/lib/addons/kube-state-metrics/index.ts
@@ -45,20 +45,14 @@ export class KubeStateMetricsAddOn extends HelmAddOn {
     const cluster = clusterInfo.cluster;
     let values: Values = populateValues(this.options);
     values = merge(values, this.props.values ?? {});
-
-    if( this.options.createNamespace == true){
-      // Let CDK Create the Namespace
-      const namespace = createNamespace(this.options.namespace! , cluster);
-      const chart = this.addHelmChart(clusterInfo, values);
-      chart.node.addDependency(namespace);
-      return Promise.resolve(chart);
-
-    } else {
-      //Namespace is already created
-      const chart = this.addHelmChart(clusterInfo, values);
-      return Promise.resolve(chart);
+    const chart = this.addHelmChart(clusterInfo, values);
+    if (this.options.createNamespace == true) {
+        // Let CDK Create the Namespace
+        const namespace = createNamespace(this.options.namespace!, cluster);
+        const chart = this.addHelmChart(clusterInfo, values);
+        chart.node.addDependency(namespace);
     }
-    
+    return Promise.resolve(chart);
   }
 }
 

--- a/lib/addons/kube-state-metrics/index.ts
+++ b/lib/addons/kube-state-metrics/index.ts
@@ -49,7 +49,6 @@ export class KubeStateMetricsAddOn extends HelmAddOn {
     if (this.options.createNamespace == true) {
         // Let CDK Create the Namespace
         const namespace = createNamespace(this.options.namespace!, cluster);
-        const chart = this.addHelmChart(clusterInfo, values);
         chart.node.addDependency(namespace);
     }
     return Promise.resolve(chart);

--- a/lib/addons/metrics-server/index.ts
+++ b/lib/addons/metrics-server/index.ts
@@ -36,25 +36,17 @@ export class MetricsServerAddOn extends HelmAddOn {
         this.options = this.props as MetricsServerAddOnProps;
     }
 
-    // deploy(clusterInfo: ClusterInfo): void {
-    //     this.addHelmChart(clusterInfo, this.options.values);
-    // }
-
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
         let values: Values = this.options ?? {};
         values = merge(values, this.props.values ?? {});
+        const chart = this.addHelmChart(clusterInfo, values);
 
         if (this.options.createNamespace == true) {
             // Let CDK Create the Namespace
             const namespace = createNamespace(this.options.namespace!, cluster);
-            const chart = this.addHelmChart(clusterInfo, values);
             chart.node.addDependency(namespace);
-            return Promise.resolve(chart);
-        } else {
-            //Namespace is already created
-            const chart = this.addHelmChart(clusterInfo, values);
-            return Promise.resolve(chart);
         }
+        return Promise.resolve(chart);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#772 
*Description of changes:*
Add `createNamespace` support for Metrics Server addon

Tests run successfully 
```
Test Suites: 13 passed, 13 total
Tests:       59 passed, 59 total
Snapshots:   0 total
Time:        22.749 s
Ran all test suites.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
