### PR TITLE
new withEnv function

### DIFF
--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -191,6 +191,11 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
             .account(account ?? this.env.account).region(region ?? this.env.region);
     }
 
+    public cloneEnv(env? : cdk.Environment): BlueprintBuilder {
+        return new BlueprintBuilder().withBlueprintProps(this.props)
+            .account(env?.account ?? this.env.account).region(env?.region ?? this.env.region);
+    }
+
     public build(scope: Construct, id: string, stackProps?: cdk.StackProps): EksBlueprint {
         return new EksBlueprint(scope, { ...this.props, ...{ id } },
             { ...{ env: this.env }, ...stackProps });

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -191,9 +191,10 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
             .account(account ?? this.env.account).region(region ?? this.env.region);
     }
 
-    public cloneEnv(env? : cdk.Environment): BlueprintBuilder {
-        return new BlueprintBuilder().withBlueprintProps(this.props)
-            .account(env?.account ?? this.env.account).region(env?.region ?? this.env.region);
+    public withEnv(env: cdk.Environment): this {
+        this.env.account = env.account;
+        this.env.region = env.region;
+        return this;
     }
 
     public build(scope: Construct, id: string, stackProps?: cdk.StackProps): EksBlueprint {


### PR DESCRIPTION
Fix #778.
Add `cloneEnv` method.
See description of 778 --> 
AWS CDK has a basic type of cdk.Environment, which is an object holds the account and the region for a target environemtn for deployment.
Having a new clone function that accept a cdk.Evironment type can simplify code using the clone method