### PR TITLE
feat: adding tag option for karpenter's default AWSNodeTemplate

### DIFF
--- a/docs/addons/karpenter.md
+++ b/docs/addons/karpenter.md
@@ -51,6 +51,9 @@ const karpenterAddOn = new blueprints.addons.KarpenterAddOn({
   ttlSecondsUntilExpired: 2592000,
   weight: 20,
   interruptionHandling: true,
+  tags: {
+    schedule: 'always-on'
+  }
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
@@ -82,7 +85,7 @@ blueprints-addon-karpenter-54fd978b89-hclmp   2/2     Running   0          99m
 2. Creates `karpenter` namespace.
 3. Creates Kubernetes Service Account, and associate AWS IAM Role with Karpenter Controller Policy attached using [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html).
 4. Deploys Karpenter helm chart in the `karpenter` namespace, configuring cluster name and cluster endpoint on the controller by default.
-5. (Optionally) provisions a default Karpenter Provisioner and AWSNodeTemplate CRD based on user-provided parameters such as [spec.requirements](https://karpenter.sh/docs/concepts/provisioners/#specrequirements), [AMI type](https://karpenter.sh/docs/concepts/instance-types/),[weight](https://karpenter.sh/docs/concepts/provisioners/#specweight), [Subnet Selector](https://karpenter.sh/v0.26/concepts/node-templates/#specsubnetselector), and [Security Group Selector](https://karpenter.sh/v0.28/concepts/node-templates/#specsecuritygroupselector). If created, the provisioner will discover the EKS VPC subnets and security groups to launch the nodes with.
+5. (Optionally) provisions a default Karpenter Provisioner and AWSNodeTemplate CRD based on user-provided parameters such as [spec.requirements](https://karpenter.sh/docs/concepts/provisioners/#specrequirements), [AMI type](https://karpenter.sh/docs/concepts/instance-types/),[weight](https://karpenter.sh/docs/concepts/provisioners/#specweight), [Subnet Selector](https://karpenter.sh/v0.26/concepts/node-templates/#specsubnetselector), [Security Group Selector](https://karpenter.sh/v0.28/concepts/node-templates/#specsecuritygroupselector) and [Tags](https://karpenter.sh/v0.28/concepts/node-templates/#spectags). If created, the provisioner will discover the EKS VPC subnets and security groups to launch the nodes with.
 
 **NOTE:**
 1. The default provisioner is created only if both the subnet tags and the security group tags are provided.
@@ -90,6 +93,7 @@ blueprints-addon-karpenter-54fd978b89-hclmp   2/2     Running   0          99m
 3. Consolidation, which is a flag that enables , is supported on versions 0.15.0 and later. It is also mutually exclusive with `ttlSecondsAfterEmpty`, so if you provide both properties, the addon will throw an error.
 4. Weight, which is a property to prioritize provisioners based on weight, is supported on versions 0.16.0 and later. Addon will throw an error if weight is provided for earlier versions.
 5. Interruption Handling, which is a native way to handle interruption due to involuntary interruption events, is supported on versions 0.19.0 and later. For interruption handling in the earlier versions, Karpenter supports using AWS Node Interruption Handler (which you will need to add as an add-on and ***must be in add-on array after the Karpenter add-on*** for it to work.
+6. Karpenter allows overrides of the default "Name" tag but does not allow overrides to restricted domain (such as "karpenter.sh", "karpenter.k8s.aws", and "kubernetes.io/cluster").
 
 ## Using Karpenter
 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -132,6 +132,9 @@ export default class BlueprintConstruct {
                         cpu: 20,
                         memory: "64Gi",
                     }
+                },
+                tags: {
+                    schedule: 'always-on'
                 }
             }),
             new blueprints.addons.AwsNodeTerminationHandlerAddOn(),

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -122,7 +122,15 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
            */
           [k: string]: unknown;
         };
-    };
+    },
+
+    /**
+     * Tags adds tags to all resources created, including EC2 Instances, EBS volumes and Launch Templates.
+     * Karpenter allows overrides of the default "Name" tag but does not allow overrides to restricted domains 
+     * (such as "karpenter.sh", "karpenter.k8s.aws", and "kubernetes.io/cluster").
+     * This ensures that Karpenter is able to correctly auto-discover machines that it owns.
+     */
+    tags?: Values;
 }
 
 const KARPENTER = 'karpenter';
@@ -180,6 +188,7 @@ export class KarpenterAddOn extends HelmAddOn {
         const repo = this.options.repository!;
         const interruption = this.options.interruptionHandling || false;
         const limits = this.options.limits || null;
+        const tags = this.options.tags || null;
         
         // Various checks for version errors
         const consolidation = this.versionFeatureChecksForError(clusterInfo, version, weight, consol, repo, ttlSecondsAfterEmpty, interruption);
@@ -329,6 +338,7 @@ export class KarpenterAddOn extends HelmAddOn {
                     amiSelector: amiSelector,
                     subnetSelector: subnetTags,
                     securityGroupSelector: sgTags,
+                    tags: tags,
                 },
             });
             nodeTemplate.node.addDependency(provisioner);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding tags option to the default provisioner so that Karpenter adds tags to all resources created, including EC2 Instances, EBS volumes and Launch Templates.

This change supports accounts with governance requirements where tags are required such as enforcing use of the [AWS Instance Scheduler](https://aws.amazon.com/solutions/implementations/instance-scheduler-on-aws/)

Karpenter allows overrides of the default "Name" tag but does not allow overrides to restricted domains (such as "karpenter.sh", "karpenter.k8s.aws", and "kubernetes.io/cluster"). This ensures that Karpenter is able to correctly auto-discover machines that it owns, so Karpenter will validate these requirements itself.

An integration test would verify that the tags are added to EC2 instances, EBS volumes and Launch Templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
