### PR TITLE
Optional version Cluster provider

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,10 +99,12 @@ const addOns: Array<blueprints.ClusterAddOn> = [
 
 const account = 'XXXXXXXXXXXXX';
 const region = 'us-east-2';
+const version = 'auto';
 
 blueprints.EksBlueprint.builder()
     .account(account)
     .region(region)
+    .version(version)
     .addOns(...addOns)
     .build(app, 'eks-blueprint');
 ```

--- a/docs/addons/ack-addon.md
+++ b/docs/addons/ack-addon.md
@@ -21,6 +21,7 @@ const addOn = new blueprints.addons.AckAddOn({
 }),
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -40,6 +41,7 @@ const addOn = new blueprints.addons.AckAddOn({
 }),
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -66,6 +68,7 @@ const addOn = new blueprints.addons.AckAddOn({
 }),
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -20,6 +20,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.AdotCollectorAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/amp-addon.md
+++ b/docs/addons/amp-addon.md
@@ -49,6 +49,7 @@ const addOn = new blueprints.addons.AmpAddOn({
 })
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .resourceProvider(ampWorkspaceName, new blueprints.CreateAmpProvider(ampWorkspaceName, ampWorkspaceName,{
     {
@@ -84,6 +85,7 @@ const addOn = new blueprints.addons.AmpAddOn({
 })
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -110,6 +112,7 @@ const addOn = new blueprints.addons.AmpAddOn({
 })
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .resourceProvider(ampWorkspaceName, new blueprints.CreateAmpProvider(ampWorkspaceName, ampWorkspaceName,{
     {

--- a/docs/addons/apache-airflow.md
+++ b/docs/addons/apache-airflow.md
@@ -36,6 +36,7 @@ const addOn = [new blueprints.EfsCsiDriverAddOn(),
 ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .resourceProvider('apache-airflow-s3-bucket-provider', apacheAirflowS3Bucket)
   .resourceProvider('apache-airflow-efs-provider', apacheAirflowEfs)
   .addOns(addOn)

--- a/docs/addons/app-mesh.md
+++ b/docs/addons/app-mesh.md
@@ -16,6 +16,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.AppMeshAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/argo-cd.md
+++ b/docs/addons/argo-cd.md
@@ -22,6 +22,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.ArgoCDAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -102,6 +103,7 @@ const prodBootstrapArgo = new ArgoCDAddOn({
 });
 
 const blueprint = EksBlueprint.builder()
+    .version("auto")
     .addOns(secretStoreAddOn)
     .account(account);
 
@@ -148,6 +150,7 @@ There are two types of GitOps deployments via ArgoCD depending on whether you wo
     ];
 
     blueprints.EksBlueprint.builder()
+        .version("auto")
         .addOns(...addOns)
         .enableGitOps(blueprints.GitOpsMode.APPLICATION)
         .build(scope, stackID);
@@ -175,6 +178,7 @@ There are two types of GitOps deployments via ArgoCD depending on whether you wo
     ];
 
     blueprints.EksBlueprint.builder()
+        .version("auto")
         .addOns(...addOns)
         .enableGitOps(blueprints.GitOpsMode.APP_OF_APPS)
         .build(scope, stackID);

--- a/docs/addons/aws-batch-on-eks.md
+++ b/docs/addons/aws-batch-on-eks.md
@@ -18,6 +18,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.AwsBatchAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+    .version("auto")
     .addOns(addOn)
     .build(app, 'my-stack-name');
 ```

--- a/docs/addons/aws-for-fluent-bit.md
+++ b/docs/addons/aws-for-fluent-bit.md
@@ -16,6 +16,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.AwsForFluentBitAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/aws-load-balancer-controller.md
+++ b/docs/addons/aws-load-balancer-controller.md
@@ -20,6 +20,7 @@ const addOn = new blueprints.addons.AwsLoadBalancerControllerAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
   .addOns(addOn)
+  .version("auto")
   .build(app, 'my-stack-name');
 ```
 

--- a/docs/addons/aws-node-termination-handler.md
+++ b/docs/addons/aws-node-termination-handler.md
@@ -27,6 +27,7 @@ const clusterProvider = new blueprints.AsgClusterProvider({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .clusterProvider(clusterProvider)
   .addOns(addOn)
   .build(app, 'my-stack-name');

--- a/docs/addons/aws-privateca-issuer.md
+++ b/docs/addons/aws-privateca-issuer.md
@@ -23,6 +23,7 @@ const awsPcaParams = {
 const addOn = new blueprints.addons.AWSPrivateCAIssuerAddon(awsPcaParams)
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/calico-operator.md
+++ b/docs/addons/calico-operator.md
@@ -18,6 +18,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.CalicoOperatorAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/cert-manager.md
+++ b/docs/addons/cert-manager.md
@@ -17,6 +17,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.CertManagerAddOn()
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/cloudwatch-adot-addon.md
+++ b/docs/addons/cloudwatch-adot-addon.md
@@ -26,6 +26,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.CloudWatchAdotAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -47,6 +48,7 @@ const addOn = new blueprints.addons.CloudWatchAdotAddOn({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/cloudwatch-logs.md
+++ b/docs/addons/cloudwatch-logs.md
@@ -24,6 +24,7 @@ const addOn = new blueprints.addons.CloudWatchLogsAddon({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/cluster-autoscaler.md
+++ b/docs/addons/cluster-autoscaler.md
@@ -17,6 +17,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.ClusterAutoScalerAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/container-insights.md
+++ b/docs/addons/container-insights.md
@@ -26,6 +26,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.ContainerInsightsAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/coredns.md
+++ b/docs/addons/coredns.md
@@ -24,6 +24,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.CoreDnsAddOn("v1.8.0-eksbuild.1"); // optionally specify image version to pull or empty constructor
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/datadog.md
+++ b/docs/addons/datadog.md
@@ -30,8 +30,9 @@ const addOns: Array<blueprints.ClusterAddOn> = [
 const account = '<aws account id>'
 const region = '<aws region>'
 const props = { env: { account, region } }
+const version = 'auto';
 
-new blueprints.EksBlueprint(app, { id: '<eks cluster name>', addOns}, props)
+new blueprints.EksBlueprint(app, { id: '<eks cluster name>', addOns, version}, props)
 ```
 
 ### Using AWS Secrets Manager
@@ -60,8 +61,9 @@ const addOns: Array<blueprints.ClusterAddOn> = [
 const account = '<aws account id>'
 const region = '<aws region>'
 const props = { env: { account, region } }
+const version = 'auto'
 
-new blueprints.EksBlueprint(app, { id: '<eks cluster name>', addOns}, props)
+new blueprints.EksBlueprint(app, { id: '<eks cluster name>', addOns, version}, props)
 ```
 
 ## AddOn Options

--- a/docs/addons/ebs-csi-driver.md
+++ b/docs/addons/ebs-csi-driver.md
@@ -32,6 +32,7 @@ const addOn = new blueprints.addons.EbsCsiDriverAddOn({
       }),
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/efs-csi-driver.md
+++ b/docs/addons/efs-csi-driver.md
@@ -26,6 +26,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.EfsCsiDriverAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/emr-eks.md
+++ b/docs/addons/emr-eks.md
@@ -14,6 +14,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.EmrEksAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/external-dns.md
+++ b/docs/addons/external-dns.md
@@ -20,6 +20,7 @@ const addOn = new blueprints.addons.ExternalDnsAddOn({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .resourceProvider(hostedZoneName, new blueprints.LookupHostedZoneProvider(hostedZoneName))
   .addOns(addOn)
@@ -90,6 +91,7 @@ blueprints.EksBlueprint.builder()
     .addOns(new blueprints.addons.ExternalDnsAddOn({
         hostedZoneResources: ["MyHostedZone1"];
     }))
+    .version("auto")
     .build(...);
 ```
 
@@ -132,6 +134,7 @@ blueprints.EksBlueprint.builder()
     .addOns(new blueprints.addons.ExternalDnsAddOn({
         hostedZoneResources: ["MyHostedZone1"];
     }))
+    .version("auto")
 
 ```
 

--- a/docs/addons/external-secrets.md
+++ b/docs/addons/external-secrets.md
@@ -13,6 +13,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.ExternalsSecretsAddOn({});
 
 const blueprint = blueprints.EksBlueprint.builder()
+    .version("auto")
     .addOns(addOn)
     .build(app, 'my-stack-name');
 ```

--- a/docs/addons/fluxcd.md
+++ b/docs/addons/fluxcd.md
@@ -57,6 +57,7 @@ const addOn = new blueprints.addons.FluxCDAddOn({
 ...
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -108,6 +109,7 @@ const addOns: Array<blueprints.ClusterAddOn> = [
 
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOns)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/grafana-operator.md
+++ b/docs/addons/grafana-operator.md
@@ -13,6 +13,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.GrafanaOperatorAddon(),
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/instana-addon.md
+++ b/docs/addons/instana-addon.md
@@ -89,6 +89,7 @@ To use AWS Secret Manager Secrets follow these steps:
     blueprints.EksBlueprint.builder()
         .account(account)
         .region(region)
+        .version("auto")
         .addOns(...addOns)
         .useDefaultSecretEncryption(true)
         .build(app, '<eks cluster name>');
@@ -125,6 +126,7 @@ const region = '<aws region>';
 blueprints.EksBlueprint.builder()
     .account(account)
     .region(region)
+    .version("auto")
     .addOns(...addOns)
     .useDefaultSecretEncryption(true)
     .build(app, '<eks cluster name>');

--- a/docs/addons/istio-base.md
+++ b/docs/addons/istio-base.md
@@ -16,6 +16,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.IstioBaseAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/istio-control-plane.md
+++ b/docs/addons/istio-control-plane.md
@@ -25,6 +25,7 @@ const istioControlPlane = new blueprints.addons.IstioControlPlaneAddOn()
 const addOns: Array<blueprints.ClusterAddOn> = [ istioBase, istioControlPlane ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(...addOns)
   .build(app, 'my-stack-name');
 ```
@@ -72,6 +73,7 @@ const istioControlPlane = new blueprints.addons.IstioControlPlaneAddOn(IstioCont
 const addOns: Array<blueprints.ClusterAddOn> = [ istioBase, istioControlPlane ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(...addOns)
   .build(app, 'my-stack-name');
 

--- a/docs/addons/jupyterhub.md
+++ b/docs/addons/jupyterhub.md
@@ -57,6 +57,7 @@ const externalDnsAddOn = new blueprints.addons.ExternalDnsAddOn({
 const addOns: Array<blueprints.ClusterAddOn> = [ awsAlbAddOn, externalDnsAddOn, efsCsiAddOn, jupyterHubAddOn ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .resourceProvider(GlobalResources.HostedZone, new DelegatingHostedZoneProvider({
     parentDomain,
     subdomain,

--- a/docs/addons/karpenter.md
+++ b/docs/addons/karpenter.md
@@ -57,6 +57,7 @@ const karpenterAddOn = new blueprints.addons.KarpenterAddOn({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(karpenterAddOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/kasten-k10.md
+++ b/docs/addons/kasten-k10.md
@@ -40,6 +40,7 @@ import { KastenK10AddOn } from '@kastenhq/kasten-eks-blueprints-addon';
 const app = new App();
 
 blueprints.EksBlueprint.builder()
+    .version("auto")
     .addOns(new blueprints.ClusterAutoScalerAddOn)
     .addOns(new KastenK10AddOn)
     .build(app, 'eks-with-kastenk10');

--- a/docs/addons/keda.md
+++ b/docs/addons/keda.md
@@ -25,6 +25,7 @@ const kedaParams = {
 const addOn = new blueprints.addons.KedaAddOn(kedaParams)
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/knative-operator.md
+++ b/docs/addons/knative-operator.md
@@ -19,6 +19,7 @@ const addOns = [
 ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+    .version("auto")
     .addOns(...addOns)
     .build(app, 'my-stack-name');
 ```

--- a/docs/addons/kube-proxy.md
+++ b/docs/addons/kube-proxy.md
@@ -23,6 +23,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.KubeProxyAddOn('v1.27.1-eksbuild.1'); // optionally specify the image version to pull or empty constructor for auto selection
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/kube-state-metrics.md
+++ b/docs/addons/kube-state-metrics.md
@@ -17,6 +17,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.KubeStateMetricsAddOn()
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/kubecost.md
+++ b/docs/addons/kubecost.md
@@ -23,6 +23,7 @@ const app = new cdk.App();
 const addOn = new KubecostAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/kubeflow.md
+++ b/docs/addons/kubeflow.md
@@ -37,6 +37,7 @@ const addOn = new KubeflowAddOn(
 );
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/kubevious.md
+++ b/docs/addons/kubevious.md
@@ -18,6 +18,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.KubeviousAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/metrics-server.md
+++ b/docs/addons/metrics-server.md
@@ -17,6 +17,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.MetricsServerAddOn('v0.5.0');
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/newrelic.md
+++ b/docs/addons/newrelic.md
@@ -52,6 +52,7 @@ blueprints.EksBlueprint.builder()
     }))
     .region(process.env.AWS_REGION)
     .account(process.env.AWS_ACCOUNT)
+    .version("auto")
     .build(app, 'demo-cluster');
 ```
 
@@ -81,6 +82,7 @@ blueprints.EksBlueprint.builder()
     }))
     .region(process.env.AWS_REGION)
     .account(process.env.AWS_ACCOUNT)
+    .version("auto")
     .build(app, 'demo-cluster');
 ```
 

--- a/docs/addons/nginx.md
+++ b/docs/addons/nginx.md
@@ -24,6 +24,7 @@ const nginxAddOn = new blueprints.addons.NginxAddOn({ externalDnsHostname })
 const addOns: Array<blueprints.ClusterAddOn> = [ awsLbControllerAddOn, nginxAddOn ];
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(...addOns)
   .build(app, 'my-stack-name');
 ```
@@ -69,6 +70,7 @@ blueprints.EksBlueprint.builder()
         hostedZoneProviders: ["MyHostedZone1"];
     })
     .addOns(new blueprints.NginxAddOn({ internetFacing: true, backendProtocol: "tcp", externaDnsHostname: subdomain, crossZoneEnabled: false })
+    .version("auto")
     .build(...);
 ```
 
@@ -143,6 +145,7 @@ blueprints.EksBlueprint.builder()
         externalDnsHostname: 'my.domain.com'
     }))
     .teams(...)
+    .version("auto")
     .build(app, 'stack-with-cert-provider');
 ```
 
@@ -163,6 +166,7 @@ blueprints.EksBlueprint.builder()
         externalDnsHostname: 'my.domain.com'
     }))
     .teams(...)
+    .version("auto")
     .build(app, 'stack-with-resource-providers');
 ```
 ## Functionality

--- a/docs/addons/opa-gatekeeper.md
+++ b/docs/addons/opa-gatekeeper.md
@@ -36,6 +36,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.OpaGatekeeperAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/paralus.md
+++ b/docs/addons/paralus.md
@@ -71,6 +71,7 @@ blueprints.EksBlueprint.builder()
          }
      }))
      .teams()
+     .version("auto")
      .build(app, 'paralus-test-blueprint');
 ```
 

--- a/docs/addons/pixie.md
+++ b/docs/addons/pixie.md
@@ -43,11 +43,14 @@ const addOns: Array<blueprints.ClusterAddOn> = [
     }),
 ];
 
+const version = "auto";
+
 new blueprints.EksBlueprint(
     app, 
     {
         id: 'my-stack-name', 
         addOns,
+        version,
     },
     {
         env:{
@@ -72,12 +75,14 @@ const addOns: Array<blueprints.ClusterAddOn> = [
         deployKeySecretName: "pixie-deploy-key-secret", // Name of secret in Secrets Manager. 
     }),
 ];
+const version = "auto";
 
 new blueprints.EksBlueprint(
     app,
     {
         id: 'my-stack-name',
         addOns,
+        version,
     },
     {
         env:{

--- a/docs/addons/prometheus-node-exporter.md
+++ b/docs/addons/prometheus-node-exporter.md
@@ -15,6 +15,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.PrometheusNodeExporterAddOn()
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/rafay.md
+++ b/docs/addons/rafay.md
@@ -48,6 +48,7 @@ export default class RafayConstruct extends Construct {
             new rafayAddOn.RafayClusterAddOn(rafayConfig)
         ];
          blueprints.EksBlueprint.builder()
+            .version("auto")
             .account(process.env.CDK_DEFAULT_ACCOUNT!)
             .region(process.env.CDK_DEFAULT_REGION)
             .addOns(...addOns)

--- a/docs/addons/secrets-store.md
+++ b/docs/addons/secrets-store.md
@@ -51,6 +51,7 @@ export class TeamBurnham extends ApplicationTeam {
 }
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .teams(new TeamBurnham(app))
   .build(app, 'my-stack-name');

--- a/docs/addons/ssm-agent.md
+++ b/docs/addons/ssm-agent.md
@@ -28,6 +28,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.SSMAgentAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/upbound-universal-crossplane.md
+++ b/docs/addons/upbound-universal-crossplane.md
@@ -21,6 +21,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.UpboundUniversalCrossplaneAddOn(),
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/velero.md
+++ b/docs/addons/velero.md
@@ -25,6 +25,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.VeleroAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/vpc-cni.md
+++ b/docs/addons/vpc-cni.md
@@ -29,6 +29,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.VpcCniAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -58,6 +59,7 @@ const addOn = new blueprints.addons.VpcCniAddOn({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .resourceProvider(blueprints.GlobalResources.Vpc, new VpcProvider(undefined,"100.64.0.0/24",["100.64.0.0/25","100.64.0.128/26","100.64.0.192/26"],))
   .build(app, 'my-stack-name');
@@ -89,6 +91,7 @@ const addOn = new blueprints.addons.VpcCniAddOn({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .resourceProvider(blueprints.GlobalResources.Vpc, new VpcProvider(yourVpcId))
   .resourceProvider("secondary-cidr-subnet-0", new LookupSubnetProvider(subnet1Id)

--- a/docs/addons/xray-adot-addon.md
+++ b/docs/addons/xray-adot-addon.md
@@ -25,6 +25,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.XrayAdotAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```
@@ -44,6 +45,7 @@ const addOn = new blueprints.addons.XrayAdotAddOn({
 });
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/addons/xray.md
+++ b/docs/addons/xray.md
@@ -18,6 +18,7 @@ const app = new cdk.App();
 const addOn = new blueprints.addons.XrayAddOn();
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .build(app, 'my-stack-name');
 ```

--- a/docs/cluster-management.md
+++ b/docs/cluster-management.md
@@ -72,6 +72,7 @@ export default class MultiRegionConstruct extends cdk.Construct {
         const accountID = process.env.CDK_DEFAULT_ACCOUNT!
         const platformTeam = new team.TeamPlatform(accountID)
         const teams: Array<blueprints.Team> = [platformTeam];
+        const version = "auto";
         // AddOns for the cluster.
         const addOns: Array<blueprints.ClusterAddOn> = [
             new blueprints.addons.NginxAddOn,
@@ -85,15 +86,15 @@ export default class MultiRegionConstruct extends cdk.Construct {
             new blueprints.addons.KubeProxyAddOn()
         ];
         const east = 'blueprint-us-east-2'
-        new blueprints.EksBlueprint(scope, { id: `${id}-${east}`, addOns, teams }, {
+        new blueprints.EksBlueprint(scope, { id: `${id}-${east}`, addOns, teams, version}, {
             env: { region: east }
         });
         const central = 'blueprint-us-central-2'
-        new blueprints.EksBlueprint(scope, { id: `${id}-${central}`, addOns, teams }, {
+        new blueprints.EksBlueprint(scope, { id: `${id}-${central}`, addOns, teams, version }, {
             env: { region: central }
         });
         const west = 'blueprint-us-west-2'
-        new blueprints.EksBlueprint(scope, { id: `${id}-${west}`, addOns, teams }, {
+        new blueprints.EksBlueprint(scope, { id: `${id}-${west}`, addOns, teams, version }, {
             env: { region: west }
         });
     }

--- a/docs/cluster-providers/asg-cluster-provider.md
+++ b/docs/cluster-providers/asg-cluster-provider.md
@@ -9,6 +9,7 @@ const props: AsgClusterProviderProps = {
     minSize: 1,
     maxSize: 10,
     desiredSize: 4,
+    version: "auto",
     instanceType: new InstanceType('m5.large'),
     machineImageType: eks.MachineImageType.AMAZON_LINUX_2,
     updatePolicy: UpdatePolicy.Rolling
@@ -27,6 +28,7 @@ new blueprints.EksBlueprint(scope, { id: 'blueprint', [], [], clusterProvider })
 | minSize           | Min cluster size, must be positive integer greater than 0 (default 1).
 | maxSize           | Max cluster size, must be greater than minSize (default 3).
 | desiredSize       | Desired cluster size, must be greater or equal to minSize (default `min-size`).
+| version           | Kubernetes version for the control plane. Required in cluster props or blueprint props.
 | instanceType      | Type of instance for the EKS cluster, must be a valid instance type, i.e. t3.medium (default "m5.large")
 | machineImageType  | Machine Image Type for the Autoscaling Group.
 | updatePolicy      | Update policy for the Autoscaling Group.
@@ -57,6 +59,7 @@ const props: AsgClusterProviderProps = {
     minSize: 1,
     maxSize: 10,
     desiredSize: 4,
+    version: "auto",
     instanceType: new InstanceType('m5.large'),
     machineImageType: eks.MachineImageType.BOTTLEROCKET,
     updatePolicy: UpdatePolicy.Rolling

--- a/docs/cluster-providers/fargate-cluster-provider.md
+++ b/docs/cluster-providers/fargate-cluster-provider.md
@@ -42,6 +42,7 @@ new blueprints.EksBlueprint(scope, { id: 'blueprint', [], [], clusterProvider })
 | Prop                  | Description |
 |-----------------------|-------------|
 | name                  | The name for the cluster.
+| version               | Kubernetes version for the control plane. Required in cluster props or blueprint props.
 | fargateProfiles       | A map of Fargate profiles to use with the cluster.
 | vpcSubnets            | The subnets for the cluster.
 | tags                  | Tags to propagate to Cluster.

--- a/docs/cluster-providers/generic-cluster-provider.md
+++ b/docs/cluster-providers/generic-cluster-provider.md
@@ -185,7 +185,7 @@ The `GenericClusterProvider` supports the following configuration options.
 | managedNodeGroups     | Zero or more managed node groups.
 | autoscalingNodeGroups | Zero or more autoscaling node groups (mutually exclusive with managed node groups).
 | fargateProfiles       | Zero or more Fargate profiles.
-| version               | Kubernetes version for the control plane.
+| version               | Kubernetes version for the control plane. Required in cluster props or blueprint props.
 | vpc                   | VPC for the cluster.
 | vpcSubnets            | The subnets for control plane ENIs (subnet selection).
 | privateCluster        | If `true` Kubernetes API server is private.

--- a/docs/cluster-providers/index.md
+++ b/docs/cluster-providers/index.md
@@ -15,3 +15,5 @@ The framework currently provides support for the following Cluster Providers:
 By default, the framework will leverage the `MngClusterProvider` which creates a single managed node group.
 
 If you would like to add more node groups to a single cluster, you can leverage `GenericClusterProvider`, which allows multiple managed node groups or autoscaling (self-managed) node groups along with Fargate profiles.
+
+The version property that sets the Kubernetes Version for the Control Plane is required to be set either in the Cluster Provider, or in the Blueprint Properties.  In either spot, it can be set to a `KubernetesVersion` or `"auto"`.  If set to auto, the cluster version will be set to the latest Kubernetes Version. Auto versioning is not recommended in production clusters, as clusters will be updated as new Kubernetes versions release.

--- a/docs/cluster-providers/mng-cluster-provider.md
+++ b/docs/cluster-providers/mng-cluster-provider.md
@@ -9,6 +9,7 @@ const props: MngClusterProviderProps = {
     minSize: 1,
     maxSize: 10,
     desiredSize: 4,
+    version: "auto"
     instanceTypes: [new InstanceType('m5.large')],
     amiType: NodegroupAmiType.AL2_X86_64,
     nodeGroupCapacityType: CapacityType.ON_DEMAND,
@@ -27,6 +28,7 @@ The `MngClusterProvider` supports the following configuration options.
 |-----------------------|-------------|
 | name                  | The name for the cluster. @Deprecated
 | clusterName           | Cluster name
+| version               | Kubernetes version for the control plane. Required in cluster props or blueprint props.
 | minSize               | Min cluster size, must be positive integer greater than 0 (default 1).
 | maxSize               | Max cluster size, must be greater than minSize (default 3).
 | desiredSize           | Desired cluster size, must be greater or equal to minSize (default `min-size`).

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -204,6 +204,7 @@ class MyAddOn extends HelmAddOn {
 }
 
 blueprints.EksBlueprint.builder()
+    .version("auto")
     .addOns(new MyAddOn())
     .build(app, 'my-extension-test-blueprint');
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,7 @@ import * as blueprints from '@aws-quickstart/eks-blueprints';
 const app = new cdk.App();
 const account = 'XXXXXXXXXXXXX';
 const region = 'us-east-2';
+const version = 'auto';
 
 const addOns: Array<blueprints.ClusterAddOn> = [
     new blueprints.addons.ArgoCDAddOn(),
@@ -65,6 +66,7 @@ const addOns: Array<blueprints.ClusterAddOn> = [
 const stack = blueprints.EksBlueprint.builder()
     .account(account)
     .region(region)
+    .version(version)
     .addOns(...addOns)
     .useDefaultSecretEncryption(true) // set to false to turn secret encryption off (non-production/demo cases)
     .build(app, 'eks-blueprint');

--- a/docs/opa-gatekeeper.md
+++ b/docs/opa-gatekeeper.md
@@ -33,10 +33,12 @@ import * as blueprints from '@aws-quickstart/eks-blueprints';
 const app = new cdk.App();
 const account = <AWS_ACCOUNT_ID>;
 const region = <AWS_REGION>;
+const version = "auto";
 
 const blueprint = blueprints.EksBlueprint.builder()
   .account(account) 
   .region(region)
+  .version(version)
   .addOns( new blueprints.addons.OpaGatekeeperAddOn() )
   .teams().build(app, 'my-stack-name');
 ```

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -21,6 +21,7 @@ import * as team from 'path/to/teams'
 const blueprint = blueprints.EksBlueprint.builder()
     .account(account) // the supplied default will fail, but build and synth will pass
     .region('us-west-1')
+    .version("auto")
     .addOns(
         new blueprints.AwsLoadBalancerControllerAddOn,
         new blueprints.ExternalDnsAddOn,

--- a/docs/resource-providers/index.md
+++ b/docs/resource-providers/index.md
@@ -182,6 +182,7 @@ blueprints.EksBlueprint.builder()
         externalDnsHostname: 'my.domain.com'
     }))
     .teams(...)
+    .version("auto")
     .build(app, 'stack-with-resource-providers');
 ```
 
@@ -204,6 +205,7 @@ blueprints.EksBlueprint.builder()
         externalDnsHostname: 'my.domain.com'
     }))
     .teams(...)
+    .version("auto")
     .build(app, 'stack-with-resource-providers');
 ```
 
@@ -231,6 +233,7 @@ const clusterProvider = new blueprints.GenericClusterProvider({
 blueprints.EksBlueprint.builder()
     .addOns(...addOns)
     .clusterProvider(clusterProvider)
+    .version("auto")
     .build(scope, blueprintID, props);
 ```
 
@@ -249,6 +252,7 @@ blueprints.EksBlueprint.builder()
     .resourceProvider("my-role", new blueprints.LookupRoleProvider("SomeExistingRole")) // enables to look up this role from ClusterInfo under "my-role" in add-ons, etc.
     .addOns(...addOns)
     .clusterProvider(clusterProvider)
+    .version("auto")
     .build(scope, blueprintID, props);
 ```
 
@@ -272,6 +276,7 @@ blueprints.EksBlueprint.builder()
     .resourceProvider("FsxLustreFileSystem" ,new MyResourceProvider())
     .addOns(...)
     .teams(...)
+    .version("auto")
     .build();
 ```
 

--- a/docs/teams/aws-batch-on-eks-team.md
+++ b/docs/teams/aws-batch-on-eks-team.md
@@ -31,6 +31,7 @@ const batchTeam: BatchEksTeamProps = {
 };
 
 const blueprint = blueprints.EksBlueprint.builder()
+    .version("auto")
     .addOns(addOn)
     .teams(new blueprints.BatchEksTeam(batchTeam))
     .build(app, 'my-stack-name');

--- a/docs/teams/emr-eks-team.md
+++ b/docs/teams/emr-eks-team.md
@@ -54,6 +54,7 @@ const executionRolePolicyStatement: PolicyStatement [] = [
 
 
 const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
   .addOns(addOn)
   .teams(new blueprints.EmrEksTeam(dataTeam))
   .build(app, 'my-stack-name');

--- a/lib/cluster-providers/asg-cluster-provider.ts
+++ b/lib/cluster-providers/asg-cluster-provider.ts
@@ -5,7 +5,7 @@ import { AutoscalingNodeGroup } from "./types";
 /**
  * Configuration options for the cluster provider.
  */
-export interface AsgClusterProviderProps extends eks.CommonClusterOptions, AutoscalingNodeGroup {
+export interface AsgClusterProviderProps extends Partial<eks.CommonClusterOptions>, AutoscalingNodeGroup {
     
     /**
      * The name for the cluster.

--- a/lib/cluster-providers/fargate-cluster-provider.ts
+++ b/lib/cluster-providers/fargate-cluster-provider.ts
@@ -6,7 +6,7 @@ import { defaultOptions, GenericClusterProvider } from './generic-cluster-provid
 /**
  * Configuration options for the cluster provider.
  */
-export interface FargateClusterProviderProps extends eks.CommonClusterOptions {
+export interface FargateClusterProviderProps extends Partial<eks.CommonClusterOptions> {
 
     /**
     * The name for the cluster.
@@ -57,5 +57,5 @@ export class FargateClusterProvider extends GenericClusterProvider {
      */
     internalCreateCluster(scope: Construct, id: string, clusterOptions: any): eks.Cluster {
         return new eks.FargateCluster(scope, id, clusterOptions);
-    }
+    }    
 }

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -30,16 +30,16 @@ export function clusterBuilder() {
  * @returns ILayerVersion or undefined
  */
 export function selectKubectlLayer(scope: Construct, version: eks.KubernetesVersion): ILayerVersion | undefined {
-    switch(version) {
-        case eks.KubernetesVersion.V1_23:
+    switch(version.version) {
+        case "1.23":
             return new KubectlV23Layer(scope, "kubectllayer23");
-        case eks.KubernetesVersion.V1_24:
+        case "1.24":
             return new KubectlV24Layer(scope, "kubectllayer24");
-        case eks.KubernetesVersion.V1_25:
+        case "1.25":
             return new KubectlV25Layer(scope, "kubectllayer25");
-        case eks.KubernetesVersion.V1_26:
+        case "1.26":
             return new KubectlV26Layer(scope, "kubectllayer26");
-        case eks.KubernetesVersion.V1_27:
+        //case "1.27":
             //return new KubectlV27Layer(scope, "kubectllayer27");
     }
     

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -248,7 +248,7 @@ export class GenericClusterProvider implements ClusterProvider {
         if(builder.versionCalled) {
            version = builder.props.version!;
         } else {
-            version = this.props.version!
+            version = this.props.version!;
         }
         const privateCluster = this.props.privateCluster ?? utils.valueFromContext(scope, constants.PRIVATE_CLUSTER, false);
         const endpointAccess = (privateCluster === true) ? eks.EndpointAccess.PRIVATE : eks.EndpointAccess.PUBLIC_AND_PRIVATE;

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -236,16 +236,16 @@ export class GenericClusterProvider implements ClusterProvider {
     /**
      * @override
      */
-    createCluster(scope: Construct, vpc: ec2.IVpc, secretsEncryptionKey: IKey | undefined, blueprintVersion: eks.KubernetesVersion | undefined): ClusterInfo {
+    createCluster(scope: Construct, vpc: ec2.IVpc, secretsEncryptionKey: IKey | undefined, kubernetesVersion: eks.KubernetesVersion | undefined): ClusterInfo {
         const id = scope.node.id;
 
         // Props for the cluster.
         const clusterName = this.props.clusterName ?? id;
         const outputClusterName = true;
-        if(!blueprintVersion && !this.props.version) {
+        if(!kubernetesVersion && !this.props.version) {
             throw new Error("Version was not specified by cluster builder or in cluster provider props, must be specified in one of these");
         }
-        const version: eks.KubernetesVersion = blueprintVersion || this.props.version || eks.KubernetesVersion.V1_27;
+        const version: eks.KubernetesVersion = kubernetesVersion || this.props.version || eks.KubernetesVersion.V1_27;
 
         const privateCluster = this.props.privateCluster ?? utils.valueFromContext(scope, constants.PRIVATE_CLUSTER, false);
         const endpointAccess = (privateCluster === true) ? eks.EndpointAccess.PRIVATE : eks.EndpointAccess.PUBLIC_AND_PRIVATE;

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -17,7 +17,6 @@ import * as constants from './constants';
 import { AutoscalingNodeGroup, ManagedNodeGroup } from "./types";
 import assert = require('assert');
 import { KubectlV26Layer } from "@aws-cdk/lambda-layer-kubectl-v26";
-import { BlueprintBuilder } from "../stacks";
 
 export function clusterBuilder() {
     return new ClusterBuilder();
@@ -246,7 +245,7 @@ export class GenericClusterProvider implements ClusterProvider {
         if(!blueprintVersion && !this.props.version) {
             throw new Error("Version was not specified by cluster builder or in cluster provider props, must be specified in one of these");
         }
-        const version: eks.KubernetesVersion = blueprintVersion || this.props.version || eks.KubernetesVersion.V1_27
+        const version: eks.KubernetesVersion = blueprintVersion || this.props.version || eks.KubernetesVersion.V1_27;
 
         const privateCluster = this.props.privateCluster ?? utils.valueFromContext(scope, constants.PRIVATE_CLUSTER, false);
         const endpointAccess = (privateCluster === true) ? eks.EndpointAccess.PRIVATE : eks.EndpointAccess.PUBLIC_AND_PRIVATE;

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -247,8 +247,10 @@ export class GenericClusterProvider implements ClusterProvider {
         let version: eks.KubernetesVersion;
         if(builder.versionCalled) {
            version = builder.props.version!;
+        } else if (!this.props.version){
+            throw new Error("Version was not specified in builder, must be specified here");
         } else {
-            version = this.props.version!;
+            version = this.props.version;
         }
         const privateCluster = this.props.privateCluster ?? utils.valueFromContext(scope, constants.PRIVATE_CLUSTER, false);
         const endpointAccess = (privateCluster === true) ? eks.EndpointAccess.PRIVATE : eks.EndpointAccess.PUBLIC_AND_PRIVATE;

--- a/lib/cluster-providers/mng-cluster-provider.ts
+++ b/lib/cluster-providers/mng-cluster-provider.ts
@@ -9,7 +9,7 @@ import { ManagedNodeGroup } from "./types";
 /**
  * Configuration options for the cluster provider.
  */
-export interface MngClusterProviderProps extends eks.CommonClusterOptions, Omit<ManagedNodeGroup, "id"> {
+export interface MngClusterProviderProps extends Partial<eks.CommonClusterOptions>, Omit<ManagedNodeGroup, "id"> {
     /**
     * The name for the cluster.
     * @deprecated use #clusterName

--- a/lib/spi/cluster-contracts.ts
+++ b/lib/spi/cluster-contracts.ts
@@ -2,12 +2,13 @@ import { ClusterInfo } from '.';
 import { Construct } from "constructs";
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import {IKey} from "aws-cdk-lib/aws-kms";
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
 
 /**
  * ClusterProvider is the interface to which all Cluster Providers should conform.
  */
 export declare interface ClusterProvider {
-    createCluster(scope: Construct, vpc: IVpc, secretsEncryptionKey?: IKey): ClusterInfo;
+    createCluster(scope: Construct, vpc: IVpc, secretsEncryptionKey?: IKey, blueprintVersion?: KubernetesVersion): ClusterInfo;
 }
 

--- a/lib/spi/cluster-contracts.ts
+++ b/lib/spi/cluster-contracts.ts
@@ -9,6 +9,6 @@ import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
  * ClusterProvider is the interface to which all Cluster Providers should conform.
  */
 export declare interface ClusterProvider {
-    createCluster(scope: Construct, vpc: IVpc, secretsEncryptionKey?: IKey, blueprintVersion?: KubernetesVersion): ClusterInfo;
+    createCluster(scope: Construct, vpc: IVpc, secretsEncryptionKey?: IKey, kubernetesVersion?: KubernetesVersion): ClusterInfo;
 }
 

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -108,7 +108,6 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
         account?: string,
         region?: string
     };
-    versionCalled: boolean = false;
 
     constructor() {
         this.props = { addOns: new Array<spi.ClusterAddOn>(), teams: new Array<spi.Team>(), resourceProviders: new Map() };
@@ -143,7 +142,6 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
         }
 
         this.props = { ...this.props, ...{ version: version } };
-        this.versionCalled = true;
         return this;
     }
 
@@ -259,7 +257,7 @@ export class EksBlueprint extends cdk.Stack {
             version
         });
 
-        this.clusterInfo = clusterProvider.createCluster(this, vpcResource!, kmsKeyResource);
+        this.clusterInfo = clusterProvider.createCluster(this, vpcResource!, kmsKeyResource, blueprintProps.version);
         this.clusterInfo.setResourceContext(resourceContext);
 
         let enableLogTypes: string[] | undefined = blueprintProps.enableControlPlaneLogTypes;

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -133,14 +133,16 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
         return this;
     }
 
-    public version(version: string): this {
-        let versionKV: KubernetesVersion;
-        if (version == "auto") {
-            versionKV = KubernetesVersion.V1_27;
-        } else {
-            versionKV = KubernetesVersion.of(version);
+    public version(version: string | KubernetesVersion): this {
+        if (typeof version === 'string') {
+            if (version == "auto") {
+               version = KubernetesVersion.V1_27;
+            } else {
+                throw new Error("Only valid options are \"auto\", or a KubernetesVersion.")
+            }
         }
-        this.props = { ...this.props, ...{ version: versionKV } };
+
+        this.props = { ...this.props, ...{ version: version } };
         this.versionCalled = true;
         return this;
     }

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -42,7 +42,7 @@ export class EksBlueprintProps {
     /**
      * Kubernetes version (must be initialized for addons to work properly)
      */
-    readonly version?: KubernetesVersion = KubernetesVersion.V1_25;
+    readonly version?: KubernetesVersion = KubernetesVersion.V1_27;
 
     /**
      * Named resource providers to leverage for cluster resources.
@@ -108,6 +108,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
         account?: string,
         region?: string
     };
+    versionCalled: boolean = false;
 
     constructor() {
         this.props = { addOns: new Array<spi.ClusterAddOn>(), teams: new Array<spi.Team>(), resourceProviders: new Map() };
@@ -132,8 +133,15 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
         return this;
     }
 
-    public version(version: KubernetesVersion): this {
-        this.props = { ...this.props, ...{ version } };
+    public version(version: string): this {
+        let versionKV: KubernetesVersion;
+        if (version == "auto") {
+            versionKV = KubernetesVersion.V1_27;
+        } else {
+            versionKV = KubernetesVersion.of(version);
+        }
+        this.props = { ...this.props, ...{ version: versionKV } };
+        this.versionCalled = true;
         return this;
     }
 

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -42,7 +42,7 @@ export class EksBlueprintProps {
     /**
      * Kubernetes version (must be initialized for addons to work properly)
      */
-    readonly version?: KubernetesVersion | string = KubernetesVersion.V1_25;
+    readonly version?: KubernetesVersion | "auto" = KubernetesVersion.V1_25;
 
     /**
      * Named resource providers to leverage for cluster resources.
@@ -132,7 +132,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
         return this;
     }
 
-    public version(version: string | KubernetesVersion): this {
+    public version(version: "auto" | KubernetesVersion): this {
         this.props = { ...this.props, ...{ version: version } };
         return this;
     }
@@ -236,12 +236,8 @@ export class EksBlueprint extends cdk.Stack {
         }
 
         let version = blueprintProps.version;
-        if (typeof version === 'string') {
-            if (version == "auto") {
-               version = KubernetesVersion.V1_27;
-            } else {
-                throw new Error("Only valid option for passing in a string to version is \"auto\".");
-            }
+        if (version == "auto") {
+            version = KubernetesVersion.V1_27;
         }
 
         let kmsKeyResource: IKey | undefined = resourceContext.get(spi.GlobalResources.KmsKey);

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -42,7 +42,7 @@ export class EksBlueprintProps {
     /**
      * Kubernetes version (must be initialized for addons to work properly)
      */
-    readonly version: KubernetesVersion | string = KubernetesVersion.V1_25;
+    readonly version?: KubernetesVersion | string = KubernetesVersion.V1_25;
 
     /**
      * Named resource providers to leverage for cluster resources.
@@ -198,7 +198,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
     }
 
     public build(scope: Construct, id: string, stackProps?: cdk.StackProps): EksBlueprint {
-        return new EksBlueprint(scope, { ...this.props, ...{version: this.props.version!}, ...{ id } },
+        return new EksBlueprint(scope, { ...this.props, ...{ id } },
             { ...{ env: this.env }, ...stackProps });
     }
 
@@ -240,7 +240,7 @@ export class EksBlueprint extends cdk.Stack {
             if (version == "auto") {
                version = KubernetesVersion.V1_27;
             } else {
-                throw new Error("Only valid options are \"auto\", or a KubernetesVersion.");
+                throw new Error("Only valid option for passing in a string to version is \"auto\".");
             }
         }
 

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -138,7 +138,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
             if (version == "auto") {
                version = KubernetesVersion.V1_27;
             } else {
-                throw new Error("Only valid options are \"auto\", or a KubernetesVersion.")
+                throw new Error("Only valid options are \"auto\", or a KubernetesVersion.");
             }
         }
 

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -42,7 +42,7 @@ export class EksBlueprintProps {
     /**
      * Kubernetes version (must be initialized for addons to work properly)
      */
-    readonly version?: KubernetesVersion | "auto" = KubernetesVersion.V1_25;
+    readonly version?: KubernetesVersion | "auto";
 
     /**
      * Named resource providers to leverage for cluster resources.

--- a/test/amp.test.ts
+++ b/test/amp.test.ts
@@ -8,7 +8,7 @@ describe('Unit tests for AMP addon', () => {
 
         const blueprint = blueprints.EksBlueprint.builder();
 
-        blueprint.account("123567891").region('us-west-1')
+        blueprint.account("123567891").region('us-west-1').version("auto")
         .addOns(new blueprints.addons.AwsLoadBalancerControllerAddOn())
         .addOns(new blueprints.addons.CertManagerAddOn())
         .addOns(new blueprints.addons.AdotCollectorAddOn())
@@ -33,7 +33,7 @@ describe('Unit tests for AMP addon', () => {
 
         const blueprint = blueprints.EksBlueprint.builder();
 
-        blueprint.account("123567891").region('us-west-1')
+        blueprint.account("123567891").region('us-west-1').version("auto")
         .addOns(new blueprints.addons.AwsLoadBalancerControllerAddOn())
         .addOns(new blueprints.addons.CertManagerAddOn())
         .addOns(new blueprints.addons.AdotCollectorAddOn())

--- a/test/backstage.test.ts
+++ b/test/backstage.test.ts
@@ -21,6 +21,7 @@ describe('Unit tests for Backstage addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ExternalsSecretsAddOn)
             .addOns(new blueprints.BackstageAddOn(backstageAddOnProps));
 
@@ -35,6 +36,7 @@ describe('Unit tests for Backstage addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.BackstageAddOn(backstageAddOnProps));
 
@@ -49,6 +51,7 @@ describe('Unit tests for Backstage addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ExternalsSecretsAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.BackstageAddOn(backstageAddOnProps));
@@ -74,6 +77,7 @@ describe('Unit tests for Backstage addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .resourceProvider(backstageAddOnProps.databaseResourceName, new DatabaseInstanceProviderMock())
             .addOns(new blueprints.ExternalsSecretsAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)

--- a/test/cluster-autoscaler.test.ts
+++ b/test/cluster-autoscaler.test.ts
@@ -1,13 +1,14 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as blueprints from '../lib';
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
 test("Cluster autoscaler correctly is using correct defaults if EKS version is not defined in the version map", () => {
     const app = new cdk.App();
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version("1.27")
+        .version(KubernetesVersion.V1_27)
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-127");
 
@@ -26,7 +27,7 @@ test("Cluster autoscaler correctly is using correct version for 1.26", () => {
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version("1.26")
+        .version(KubernetesVersion.V1_26)
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-126");
 
@@ -45,7 +46,7 @@ test("Cluster autoscaler correctly is using correct version for 1.26 specified a
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version("1.27")
+        .version(KubernetesVersion.of("1.27"))
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-127");
 

--- a/test/cluster-autoscaler.test.ts
+++ b/test/cluster-autoscaler.test.ts
@@ -1,6 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import * as blueprints from '../lib';
 
 test("Cluster autoscaler correctly is using correct defaults if EKS version is not defined in the version map", () => {

--- a/test/cluster-autoscaler.test.ts
+++ b/test/cluster-autoscaler.test.ts
@@ -46,7 +46,7 @@ test("Cluster autoscaler correctly is using correct version for 1.26 specified a
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.of("1.27"))
+        .version(KubernetesVersion.of("1.26"))
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-127");
 

--- a/test/cluster-autoscaler.test.ts
+++ b/test/cluster-autoscaler.test.ts
@@ -8,7 +8,7 @@ test("Cluster autoscaler correctly is using correct defaults if EKS version is n
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.of("1.27"))
+        .version("1.27")
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-127");
 
@@ -27,7 +27,7 @@ test("Cluster autoscaler correctly is using correct version for 1.26", () => {
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.V1_26)
+        .version("1.26")
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-126");
 
@@ -46,7 +46,7 @@ test("Cluster autoscaler correctly is using correct version for 1.26 specified a
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.of("1.26"))
+        .version("1.27")
         .addOns(new blueprints.ClusterAutoScalerAddOn())
         .build(app, "ca-stack-127");
 

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -319,7 +319,7 @@ test("Build fails if no version is set in builder or node group", () => {
     expect(() => {
         blueprints.EksBlueprint.builder()
         .clusterProvider(clusterProvider).build(app, "stack-fail");
-    }).toThrow("Version was not specified in builder, must be specified here");
+    }).toThrow("Version was not specified by cluster builder or in cluster provider props, must be specified in one of these");
 });
 
 test("Kubernetes Version gets set correctly for \"auto\"", () => {

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -249,7 +249,7 @@ test("Kubectl layer is correctly injected for EKS version 1.26", () => {
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version("1.26").build(app, "stack-126");
+        .version(KubernetesVersion.V1_26).build(app, "stack-126");
     
     const template = Template.fromStack(stack);
 
@@ -267,7 +267,7 @@ test("Kubectl layer is correctly injected for EKS version 1.25", () => {
 
     const stack = blueprints.EksBlueprint.builder()
       .account('123456789').region('us-west-2')
-      .version("1.25").build(app, "stack-125");
+      .version(KubernetesVersion.V1_25).build(app, "stack-125");
 
     const template = Template.fromStack(stack);
 
@@ -284,7 +284,7 @@ test("Kubectl layer is correctly injected for EKS version 1.24", () => {
 
     const stack = blueprints.EksBlueprint.builder()
       .account('123456789').region('us-west-2')
-      .version("1.24").build(app, "stack-124");
+      .version(KubernetesVersion.V1_24).build(app, "stack-124");
 
     const template = Template.fromStack(stack);
 
@@ -301,8 +301,32 @@ test("Kubectl layer is correctly injected for EKS version 1.21 and below", () =>
 
     const stackV122 = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version("1.21").build(app, "stack-122");
+        .version(KubernetesVersion.V1_22).build(app, "stack-122");
     
     const template = Template.fromStack(stackV122);
     template.resourceCountIs("AWS::Lambda::LayerVersion", 0);
+});
+
+test("Version function errors for random string", () => {
+    expect(() => blueprints.EksBlueprint.builder().version("1.28")).toThrow("Only valid options are \"auto\", or a KubernetesVersion.");
+});
+
+test("Build fails if no version is set in builder or node group", () => {
+    const app = new cdk.App();
+    const clusterProvider = new blueprints.GenericClusterProvider({
+        clusterName: "my-cluster",
+    });
+    expect(() => {
+        blueprints.EksBlueprint.builder()
+        .clusterProvider(clusterProvider).build(app, "stack-fail");
+    }).toThrow("Version was not specified in builder, must be specified here");
+});
+
+test("Kubernetes Version gets set correctly for \"auto\"", () => {
+    const app = new cdk.App();
+    const stack = blueprints.EksBlueprint.builder()
+    .account('123456789').region('us-west-2')
+    .version("auto").build(app, "stack-auto");
+
+    expect(stack.getClusterInfo().version.version).toBe("1.27");
 });

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -249,7 +249,7 @@ test("Kubectl layer is correctly injected for EKS version 1.26", () => {
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.V1_26).build(app, "stack-126");
+        .version("1.26").build(app, "stack-126");
     
     const template = Template.fromStack(stack);
 
@@ -267,7 +267,7 @@ test("Kubectl layer is correctly injected for EKS version 1.25", () => {
 
     const stack = blueprints.EksBlueprint.builder()
       .account('123456789').region('us-west-2')
-      .version(KubernetesVersion.V1_25).build(app, "stack-125");
+      .version("1.25").build(app, "stack-125");
 
     const template = Template.fromStack(stack);
 
@@ -284,7 +284,7 @@ test("Kubectl layer is correctly injected for EKS version 1.24", () => {
 
     const stack = blueprints.EksBlueprint.builder()
       .account('123456789').region('us-west-2')
-      .version(KubernetesVersion.V1_24).build(app, "stack-124");
+      .version("1.24").build(app, "stack-124");
 
     const template = Template.fromStack(stack);
 
@@ -301,7 +301,7 @@ test("Kubectl layer is correctly injected for EKS version 1.21 and below", () =>
 
     const stackV122 = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.V1_21).build(app, "stack-122");
+        .version("1.21").build(app, "stack-122");
     
     const template = Template.fromStack(stackV122);
     template.resourceCountIs("AWS::Lambda::LayerVersion", 0);

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -7,7 +7,6 @@ import { SubnetType } from 'aws-cdk-lib/aws-ec2';
 import { CapacityType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import * as blueprints from '../lib';
 import { AsgClusterProvider, MngClusterProvider } from '../lib';
-import { version } from 'os';
 
 const addAutoScalingGroupCapacityMock = jest.spyOn(eks.Cluster.prototype, 'addAutoScalingGroupCapacity');
 const addNodegroupCapacityMock = jest.spyOn(eks.Cluster.prototype, 'addNodegroupCapacity');

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -308,11 +308,6 @@ test("Kubectl layer is correctly injected for EKS version 1.21 and below", () =>
     template.resourceCountIs("AWS::Lambda::LayerVersion", 0);
 });
 
-test("Version function errors for random string", () => {
-    const app = new cdk.App();
-    expect(() => blueprints.EksBlueprint.builder().version("1.28").build(app, "stack-fail-1")).toThrow("Only valid option for passing in a string to version is \"auto\".");
-});
-
 test("Build fails if no version is set in builder or node group", () => {
     const app = new cdk.App();
     const clusterProvider = new blueprints.GenericClusterProvider({

--- a/test/emr-eks.test.ts
+++ b/test/emr-eks.test.ts
@@ -43,6 +43,7 @@ const dataTeam: EmrEksTeamProps = {
     };
 
 const parentStack = blueprints.EksBlueprint.builder()
+        .version("auto")
         .addOns(
             new blueprints.VpcCniAddOn(),
             new blueprints.CoreDnsAddOn(),

--- a/test/jupyterhub.test.ts
+++ b/test/jupyterhub.test.ts
@@ -10,6 +10,7 @@ describe('Unit tests for JupyterHub addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(
                 new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.JupyterHubAddOn({
@@ -32,6 +33,7 @@ describe('Unit tests for JupyterHub addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(
                 new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.JupyterHubAddOn({
@@ -55,6 +57,7 @@ describe('Unit tests for JupyterHub addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(
                 new blueprints.EfsCsiDriverAddOn,
                 new blueprints.JupyterHubAddOn({
@@ -78,6 +81,7 @@ describe('Unit tests for JupyterHub addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(
                 new blueprints.EfsCsiDriverAddOn,
                 new blueprints.JupyterHubAddOn({

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -10,6 +10,7 @@ describe('Unit tests for Karpenter addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.KarpenterAddOn(), new blueprints.ClusterAutoScalerAddOn)
             .teams(new blueprints.PlatformTeam({ name: 'platform' }));
 
@@ -24,6 +25,7 @@ describe('Unit tests for Karpenter addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.KarpenterAddOn({
                 version: "0.15.0",
                 weight: 30
@@ -41,6 +43,7 @@ describe('Unit tests for Karpenter addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.KarpenterAddOn({
                 version: "0.14.0",
                 consolidation: { enabled: true },
@@ -58,6 +61,7 @@ describe('Unit tests for Karpenter addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.KarpenterAddOn({
                 ttlSecondsAfterEmpty: 30,
                 consolidation: { enabled: true },

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -79,6 +79,7 @@ describe('Unit tests for Karpenter addon', () => {
     const blueprint = blueprints.EksBlueprint.builder();
 
     const stack = await blueprint
+      .version("auto")
       .account("123567891")
       .region("us-west-1")
       .addOns(

--- a/test/knative-addon-validation.test.ts
+++ b/test/knative-addon-validation.test.ts
@@ -13,6 +13,7 @@ test("Generic cluster with kNative Eventing deployment", async () => {
 
     const blueprint = await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-east-1')
+        .version("auto")
         .addOns(...addons)
         .build(app, 'knative-stack');
 

--- a/test/resource-providers/efs.test.ts
+++ b/test/resource-providers/efs.test.ts
@@ -20,6 +20,7 @@ describe("EfsFileSystemProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When
@@ -48,6 +49,7 @@ describe("EfsFileSystemProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When
@@ -82,6 +84,7 @@ describe("EfsFileSystemProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When
@@ -114,6 +117,7 @@ describe("EfsFileSystemProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When

--- a/test/resource-providers/kms-key.test.ts
+++ b/test/resource-providers/kms-key.test.ts
@@ -11,6 +11,7 @@ describe("KmsKeyProvider", () => {
 
     const stack = new blueprints.EksBlueprint(app, {
       id: "east-test-1",
+      version: "auto",
     });
 
     // When
@@ -50,6 +51,7 @@ describe("KmsKeyProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When
@@ -82,6 +84,7 @@ describe("KmsKeyProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When
@@ -118,6 +121,7 @@ describe("KmsKeyProvider", () => {
     const stack = blueprints.EksBlueprint.builder()
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .useDefaultSecretEncryption(false)
       .build(app, "east-test-1");
 

--- a/test/resource-providers/resource-proxy.test.ts
+++ b/test/resource-providers/resource-proxy.test.ts
@@ -42,6 +42,7 @@ describe("ResourceProxy",() => {
 
         const builder = EksBlueprint.builder()
             .clusterProvider(clusterProvider)
+            .version("auto")
             .account("123456789012")
             .region("us-east-1");
 
@@ -78,6 +79,7 @@ describe("ResourceProxy",() => {
 
         const builder = EksBlueprint.builder()
             .clusterProvider(clusterProvider)
+            .version("auto")
             .account("123456789012")
             .region("us-east-1");
 
@@ -99,6 +101,7 @@ describe("ResourceProxy",() => {
         
         const builder = EksBlueprint.builder()
             .resourceProvider(GlobalResources.KmsKey, new CreateKmsKeyProvider())
+            .version("auto")
             .account("123456789012")
             .region("us-east-1")
             .addOns(new AppMeshAddOn( {
@@ -133,6 +136,7 @@ describe("ResourceProxy",() => {
                                   .clusterProvider(genericClusterProvider)
                                   .account("123456789012")
                                   .region("us-east-1")
+                                  .version("auto")
                                   .build(app, "cluster");
 
         // Then

--- a/test/resource-providers/s3.test.ts
+++ b/test/resource-providers/s3.test.ts
@@ -18,6 +18,7 @@ describe("S3BucketProvider", () => {
       )
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     // When
@@ -40,6 +41,7 @@ describe("S3BucketProvider", () => {
       .resourceProvider("my-s3-bucket", s3Bucket)
       .account("123456789012")
       .region("us-east-1")
+      .version("auto")
       .build(app, "east-test-1");
 
     const bucket = <s3.IBucket>stack.node.tryFindChild('imported-s3-bucket');

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -10,13 +10,13 @@ describe('Unit tests for EKS Blueprint', () => {
     test('Usage tracking created', () => {
         let app = new cdk.App();
         // WHEN
-        let stack = new blueprints.EksBlueprint(app, { id: 'MyTestStack' });
+        let stack = new blueprints.EksBlueprint(app, { id: 'MyTestStack', version: "auto"});
         console.debug(stack.templateOptions.description);
         // THEN
         assertBlueprint(stack);
 
         app = new cdk.App();
-        stack = new blueprints.EksBlueprint(app, { id: 'MyOtherTestStack' }, {
+        stack = new blueprints.EksBlueprint(app, { id: 'MyOtherTestStack', version: "auto" }, {
             description: "My awesome description"
         });
 
@@ -33,6 +33,7 @@ describe('Unit tests for EKS Blueprint', () => {
 
         blueprint.account("123567891").region('us-west-1')
             .addOns(new blueprints.NginxAddOn)
+            .version("auto")
             .teams(new blueprints.PlatformTeam({ name: 'platform' }));
 
         expect(() => blueprint.build(app, 'stack-with-missing-deps')).toThrow("Missing a dependency for AwsLoadBalancerControllerAddOn for stack-with-missing-deps");
@@ -44,6 +45,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.AwsNodeTerminationHandlerAddOn);
 
         expect(() => blueprint.build(app, 'stack-with-missing-deps')).toThrow('AWS Node Termination Handler is only supported for self-managed nodes');
@@ -55,6 +57,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ArgoCDAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.NginxAddOn)
@@ -72,7 +75,8 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint3 = blueprints.EksBlueprint.builder().withBlueprintProps({
             addOns: [new blueprints.ArgoCDAddOn],
             name: 'my-blueprint3',
-            id: 'my-blueprint3-id'
+            id: 'my-blueprint3-id',
+            version: "auto"
         });
 
         const stack3 = await blueprint3.buildAsync(new cdk.App(), 'stack-3');
@@ -86,6 +90,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder()
             .account("123567891")
             .region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ArgoCDAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.NginxAddOn)
@@ -144,6 +149,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder()
             .account(devTestAccount)
             .region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ArgoCDAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.NginxAddOn)
@@ -191,6 +197,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder()
             .account("123567891")
             .region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ArgoCDAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.NginxAddOn)
@@ -245,6 +252,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder()
             .account("123567891")
             .region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ArgoCDAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.NginxAddOn)
@@ -302,6 +310,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder()
             .account("123567891")
             .region('us-west-1')
+            .version("auto")
             .addOns(new blueprints.ArgoCDAddOn)
             .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
             .addOns(new blueprints.NginxAddOn)
@@ -380,6 +389,7 @@ describe('Unit tests for EKS Blueprint', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         blueprint.account("123567891").region('us-west-1')
+            .version("auto")
             .addOns(vpcAddOn)
             .teams(new blueprints.PlatformTeam({ name: 'platform' }));
 
@@ -394,6 +404,7 @@ test("Named resource providers are correctly registered and discovered", async (
 
     const blueprint =  await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-1')
+        .version("auto")
         .resourceProvider(blueprints.GlobalResources.HostedZone, new blueprints.ImportHostedZoneProvider('hosted-zone-id1', 'my.domain.com'))
         .resourceProvider(blueprints.GlobalResources.Certificate, new blueprints.CreateCertificateProvider('domain-wildcard-cert', '*.my.domain.com', blueprints.GlobalResources.HostedZone))
         .addOns(new blueprints.AwsLoadBalancerControllerAddOn())
@@ -416,6 +427,7 @@ test("Named resource providers are correctly registered and discovered", async (
 
 test("Building blueprint with builder properly clones properties", () => {
     const blueprint = blueprints.EksBlueprint.builder().name("builer-test1")
+        .version("auto")
         .addOns(new blueprints.AppMeshAddOn);
     expect(blueprint.props.addOns).toHaveLength(1);
 
@@ -438,6 +450,7 @@ test("Building blueprint with version correctly passes k8s version to the cluste
     const app = new cdk.App();
 
     const blueprint = blueprints.EksBlueprint.builder().name("builer-version-test1")
+        .version("auto")
         .addOns(new blueprints.ClusterAutoScalerAddOn);
     expect(blueprint.props.addOns).toHaveLength(1);
 
@@ -459,6 +472,7 @@ test("Account and region are correctly initialized when not explicitly set on th
     process.env.CDK_DEFAULT_REGION  = 'us-west-2';
 
     const blueprint = blueprints.EksBlueprint.builder().name("region-test1")
+        .version("auto")
         .addOns(new blueprints.AwsLoadBalancerControllerAddOn);
 
     const stack = blueprint.build(app, "region-test1");
@@ -481,6 +495,7 @@ test("Missing account and region are not causing failure in blueprint stack", as
     process.env.CDK_DEFAULT_REGION = undefined;
 
     const blueprint = blueprints.EksBlueprint.builder().name("region-test2")
+        .version("auto")
         .addOns(new blueprints.AwsLoadBalancerControllerAddOn)
         .addOns(new blueprints.addons.ClusterAutoScalerAddOn);
 


### PR DESCRIPTION
*Issue #, if available:* #792

*Description of changes:*
Made version optional for all cluster providers as long as .version() is run on the builder


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
