### PR TITLE
Use TypeScript mapping for Fargate profile

### DIFF
--- a/docs/cluster-providers/fargate-cluster-provider.md
+++ b/docs/cluster-providers/fargate-cluster-provider.md
@@ -2,26 +2,42 @@
 
 The `FargateClusterProvider` allows you to provision an EKS cluster which runs Kubernetes pods on [AWS Fargate](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html). To create a Fargate cluster, you must provide [Fargate Profiles](https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html), which allows cluster operators to specify which Pods should be run on Fargate.
 
-## Usage 
+## Usage
 
-In the example below, the Fargate profile indicates that all Pods in the `dynatrace` namespace should run on Fargate.
+In the example below, the Fargate profile indicates that all Pods in the
+`dynatrace` namespace having the label `example.com/fargate` set to `true` (the
+string, not the boolean value) should run on Fargate. (The label may be omitted
+if you want all Pods in the namespace to run on Fargate.)
 
 ```typescript
-const fargateProfiles: Map<string, eks.FargateProfileOptions> = new Map([
-    ["dynatrace", { selectors: [{ namespace: "dynatrace" }] }]
-]);
+const fargateProfiles = {
+    dynatrace: {
+        selectors: [
+            {
+                namespace: 'dynatrace',
+                labels: { // optional
+                    'example.com/fargate': 'true'
+                }
+            }
+        ]
+    }
+};
 const tags = {
     "Name": "blueprints-example-cluster",
     "Type": "fargate-cluster"
 }
-const clusterProvider = new blueprints.FargateClusterProvider({ fargateProfiles, tags });
+const clusterProvider = new blueprints.FargateClusterProvider({
+    version: KubernetesVersion.V1_27,
+    fargateProfiles,
+    tags
+});
 
 new blueprints.EksBlueprint(scope, { id: 'blueprint', [], [], clusterProvider });
 ```
 
 ## Configuration
 
-`FargateClusterProvider` supports the following configuration options. 
+`FargateClusterProvider` supports the following configuration options.
 
 | Prop                  | Description |
 |-----------------------|-------------|
@@ -29,7 +45,7 @@ new blueprints.EksBlueprint(scope, { id: 'blueprint', [], [], clusterProvider })
 | fargateProfiles       | A map of Fargate profiles to use with the cluster.
 | vpcSubnets            | The subnets for the cluster.
 | tags                  | Tags to propagate to Cluster.
-| privateCluster        | Public cluster, you will need to provide a list of subnets. There should be public and private subnets 
+| privateCluster        | Public cluster, you will need to provide a list of subnets. There should be public and private subnets
 for EKS cluster to work. For more information see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html)
 
 You can find more details on the supported configuration options in the API documentation for the [FargateClusterProviderProps](../api/interfaces/clusters.FargateClusterProviderProps.html).

--- a/lib/cluster-providers/fargate-cluster-provider.ts
+++ b/lib/cluster-providers/fargate-cluster-provider.ts
@@ -14,9 +14,11 @@ export interface FargateClusterProviderProps extends eks.CommonClusterOptions {
     name?: string
 
     /**
-     * The Fargate for the cluster.
+     * The Fargate profiles associated with the cluster.
+     *
+     * <b>Note</b> The `Map<>` form is deprecated and will be removed from a future release.
      */
-    fargateProfiles?: Map<string, eks.FargateProfileOptions>,
+    fargateProfiles?: { [key: string]: eks.FargateProfileOptions } | Map<string, eks.FargateProfileOptions>,
 
     /**
      * Subnets are passed to the cluster configuration.
@@ -45,7 +47,7 @@ export class FargateClusterProvider extends GenericClusterProvider {
 
     constructor(props?: FargateClusterProviderProps) {
         super({...defaultOptions, ...props, ...{
-                fargateProfiles: Object.fromEntries(props?.fargateProfiles ?? new Map())
+                fargateProfiles: props?.fargateProfiles instanceof Map ? Object.fromEntries(props?.fargateProfiles) : props?.fargateProfiles
             }
         });
     }
@@ -55,5 +57,5 @@ export class FargateClusterProvider extends GenericClusterProvider {
      */
     internalCreateCluster(scope: Construct, id: string, clusterOptions: any): eks.Cluster {
         return new eks.FargateCluster(scope, id, clusterOptions);
-    }    
+    }
 }


### PR DESCRIPTION
Use a TypeScript-native mapping type for Fargate profiles instead of the non-idiomatic `Map<>` type. The old type remains supported for backward compatibility, but should be deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
