### PR TITLE
fix(addons/karpenter): merge user provided `settings.aws` values with addon provided values.

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -276,12 +276,13 @@ export class KarpenterAddOn extends HelmAddOn {
 
         // Add helm chart
         if (semver.gte(this.options.version!, '0.19.0')){
-            setPath(values, "settings.aws", {
+            const awsSettings = {
                 clusterEndpoint: endpoint,
                 clusterName: name,
                 defaultInstanceProfile: karpenterInstanceProfile.instanceProfileName,
                 interruptionQueueName: stackName
-            });
+            };
+            setPath(values, "settings.aws", merge(awsSettings, values?.settings?.aws ?? {}));
         } else {
             setPath(values, "clusterEndpoint", endpoint);
             setPath(values, "clusterName", name);


### PR DESCRIPTION
_Issue #, if available:_
Closes #802

_Description of changes:_

- Added initially failing unit test demonstrating the issue.
- Made test green by merging user provided values with the addon provided values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
