### PR TITLE
fix(addon/karpenter): Disable Interruption Queue on Helm when the addon flag is false. 

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -280,7 +280,7 @@ export class KarpenterAddOn extends HelmAddOn {
                 clusterEndpoint: endpoint,
                 clusterName: name,
                 defaultInstanceProfile: karpenterInstanceProfile.instanceProfileName,
-                interruptionQueueName: stackName
+                interruptionQueueName: interruption ? stackName : "",
             });
         } else {
             setPath(values, "clusterEndpoint", endpoint);

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '../lib';
+import { Template } from 'aws-cdk-lib/assertions';
 
 describe('Unit tests for Karpenter addon', () => {
 
@@ -66,6 +67,46 @@ describe('Unit tests for Karpenter addon', () => {
         expect(()=> {
             blueprint.build(app, 'stack-with-conflicting-karpenter-props');
         }).toThrow("Consolidation and ttlSecondsAfterEmpty must be mutually exclusive.");
+    });
+
+    test("Stack creates with interruption enabled", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-1')
+        .addOns(new blueprints.KarpenterAddOn({
+            interruptionHandling: true
+        }))
+        .build(app, 'karpenter-interruption');
+
+        const template = Template.fromStack(blueprint);
+        
+        template.hasResource("AWS::SQS::Queue", {
+            Properties: {
+                QueueName: "karpenter-interruption",
+            },
+        });
+    });
+
+    test("Stack creates without interruption enabled", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-1')
+        .addOns(new blueprints.KarpenterAddOn({
+            interruptionHandling: false
+        }))
+        .build(app, 'karpenter-without-interruption');
+
+        const template = Template.fromStack(blueprint);
+        
+        expect(()=> {
+            template.hasResource("AWS::SQS::Queue", {
+                Properties: {
+                    QueueName: "karpenter-without-interruption",
+                },
+            })
+        }).toThrow("Template has 0 resources with type AWS::SQS::Queue.");
     });
 });
 

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -105,7 +105,7 @@ describe('Unit tests for Karpenter addon', () => {
                 Properties: {
                     QueueName: "karpenter-without-interruption",
                 },
-            })
+            });
         }).toThrow("Template has 0 resources with type AWS::SQS::Queue.");
     });
 });


### PR DESCRIPTION
*Issue #, if available:* #799

*Description of changes:* Interruption Queue Name was resolved to the stack name even though the queue was disabled. This PR will fix to ensure if the queue is disabled, then the helm interruption queue name will resolve to a blank value (as intended for default helm value).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
