### PR TITLE
Added support for Windows2019 and Windows2022 as amifamily

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -64,7 +64,7 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
     /**
      * AMI Family: If provided, Karpenter will automatically query the appropriate EKS optimized AMI via AWS Systems Manager
      */
-    amiFamily?: "AL2" | "Bottlerocket" | "Ubuntu"
+    amiFamily?: "AL2" | "Bottlerocket" | "Ubuntu" | "Windows2019" | "Windows2022"
 
     /**
      * AMI Selector

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -73,6 +73,30 @@ describe('Unit tests for Karpenter addon', () => {
         }).toThrow("Consolidation and ttlSecondsAfterEmpty must be mutually exclusive.");
     });
 
+    test("Support Windows2019 as amiFamily", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .version("auto")
+            .addOns(new blueprints.KarpenterAddOn({
+                amiFamily: "Windows2019"
+            }));
+    });
+
+    test("Support Windows2022 as amiFamily", () => {
+        const app = new cdk.App();
+
+        const blueprint = blueprints.EksBlueprint.builder();
+
+        blueprint.account("123567891").region('us-west-1')
+            .version("auto")
+            .addOns(new blueprints.KarpenterAddOn({
+                amiFamily: "Windows2022"
+            }));
+    });
+
     test("Stack creates with interruption enabled", () => {
         const app = new cdk.App();
 


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Added new values for Windows support of Karpenter : Windows 2019 and Windows2022 with relevant tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
