### PR TITLE
Added Windows2019 and Windows2022 to amiFamily for Karpenter

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -64,7 +64,7 @@ interface KarpenterAddOnProps extends HelmAddOnUserProps {
     /**
      * AMI Family: If provided, Karpenter will automatically query the appropriate EKS optimized AMI via AWS Systems Manager
      */
-    amiFamily?: "AL2" | "Bottlerocket" | "Ubuntu"
+    amiFamily?: "AL2" | "Bottlerocket" | "Ubuntu" | "Windows2019" | "Windows2022"
 
     /**
      * AMI Selector


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Added Windows2019 and Windows2022 as accepted values for amiFamily


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
