### PR TITLE
added path support to code pipeline:

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -54,9 +54,21 @@ const blueprint = blueprints.EksBlueprint.builder()
         owner: "aws-samples",
         repoUrl: 'cdk-eks-blueprints-patterns',
         credentialsSecretName: 'github-token',
-        targetRevision: 'main' // optional, default is "main"
+        targetRevision: 'main' // optional, default is "main",
     })
 ```
+
+If you IaC code is located under a specific folder, for example `PROJECT_ROOT/infra/blueprints` you can specify that directory with the repository (applies to GitHub. CodeCommit and CodeStar repos). 
+
+```
+ blueprints.CodePipelineStack.builder()
+    .name("eks-blueprints-pipeline")
+    .repository({
+        owner: "aws-samples",
+        repoUrl: 'cdk-eks-blueprints-patterns',
+        credentialsSecretName: 'github-token',
+        path: "./infra/blueprints" // optional, default is './'
+    })```
 
 Note: the above code depends on the AWS secret `github-token` defined in the target account/region. The secret may be fined in one main region, and replicated to all target regions.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -70,7 +70,7 @@ If you IaC code is located under a specific folder, for example `PROJECT_ROOT/in
         path: "./infra/blueprints" // optional, default is './'
     })```
 
-Note: the above code depends on the AWS secret `github-token` defined in the target account/region. The secret may be fined in one main region, and replicated to all target regions.
+Note: the above code depends on the AWS secret `github-token` defined in the target account/region. The secret may be defined in one main region, and replicated to all target regions.
 
 ### Using AWS CodeCommit as CodePipeline repository source.
 

--- a/lib/pipelines/code-pipeline.ts
+++ b/lib/pipelines/code-pipeline.ts
@@ -433,6 +433,8 @@ class CodePipeline {
 
         const app = props.application ? `--app '${props.application}'` : "";
 
+        const path = props.repository.path ?? "./";
+
         return new cdkpipelines.CodePipeline(scope, props.name, {
             pipelineName: props.name,
             synth: new cdkpipelines.ShellStep(`${props.name}-synth`, {
@@ -440,9 +442,9 @@ class CodePipeline {
               installCommands: [
                 'n stable',
                 'npm install -g aws-cdk@2.91.0',
-                'npm install',
+                `cd ${path} && npm install`,
               ],
-              commands: ['npm run build', 'npx cdk synth ' + app]
+              commands: [`cd ${path}`, 'npm run build', 'npx cdk synth ' + app]
             }),
             crossAccountKeys: props.crossAccountKeys,
             codeBuildDefaults: {


### PR DESCRIPTION
*Issue #, if available:* #633  (potentially)

*Description of changes:*
Added support for path specification with code pipeline.  See docs for usage.

Customers can define their blueprints IaC code under arbitrary path in the repo. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
