### PR TITLE
VpcCniAddOn - enable supports of Kubernetes Network Policies with enableNetworkPolicy after Amazon VPC CNI version 1.14.0 #850

### DIFF
--- a/docs/addons/vpc-cni.md
+++ b/docs/addons/vpc-cni.md
@@ -144,7 +144,7 @@ blueprints.EksBlueprint.builder()
     .build(scope, "blueprint", props);
 ```
 
-## Configuration Options
+## Configuration Options 
 
    - `version`: Pass in the optional vpc-cni plugin version compatible with kubernetes-cluster version as shown below
 ```bash
@@ -180,6 +180,12 @@ False
 v1.0.0-eksbuild.preview
 False
 ```  
+   - enableNetworkPolicy - set to string `true` enables Kubernetes Network policy. This setting is introduced on `1.14.0` or latter.
+
+```typescript
+new blueprints.addons.VpcCniAddOn({ enableNetworkPolicy: 'true', version: 'v1.15.0-eksbuild.2' }) 
+```  
+
 # Validation
 To validate that vpc-cni add-on is running, ensure that the pod is in Running state.
 
@@ -215,3 +221,4 @@ Please check our [Amazon EKS Best Practices Guide for Networking](https://aws.gi
 - Reference [VpcCniAddon](https://aws-quickstart.github.io/cdk-eks-blueprints/api/classes/addons.VpcCniAddOn.html) to learn more about this addon
 - Reference [Amazon EKS Best Practices Guide for Networking](https://aws.github.io/aws-eks-best-practices/networking/index/) to learn about Amazon EKS networking best practices
 - Reference [Custom Networking Tutorial](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html) to learn how custome networking is manually setup on your Amazon EKS cluster.
+- Reference [Configure your cluster for Kubernetes network policies](https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html) to learn about how to enable and use kubernetes Network policies

--- a/docs/addons/vpc-cni.md
+++ b/docs/addons/vpc-cni.md
@@ -180,10 +180,11 @@ False
 v1.0.0-eksbuild.preview
 False
 ```  
-   - enableNetworkPolicy - set to string `true` enables Kubernetes Network policy. This setting is introduced on `1.14.0` or latter.
+   - enableNetworkPolicy - set to `true` enables Kubernetes Network policy. This setting is introduced on `1.14.0` or latter.
 
+For example:
 ```typescript
-new blueprints.addons.VpcCniAddOn({ enableNetworkPolicy: 'true', version: 'v1.15.0-eksbuild.2' }) 
+new blueprints.addons.VpcCniAddOn({ enableNetworkPolicy: true, version: 'v1.15.0-eksbuild.2' }) 
 ```  
 
 # Validation

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -225,14 +225,14 @@ export interface VpcCniAddOnProps {
   * `MAX_ENI` Environment Variable. Format integer.
   * Specifies the maximum number of ENIs that will be attached to the node. 
   */
-  maxEni?: number;  
+  maxEni?: number;
 
   /**
   * `MINIMUM_IP_TARGET` Environment Variable. Format integer.
   * Specifies the number of total IP addresses that the ipamd 
   * daemon should attempt to allocate for pod assignment on the node.
   */
-  minimumIpTarget?: number; 
+  minimumIpTarget?: number;
 
   /**
    * `POD_SECURITY_GROUP_ENFORCING_MODE` Environment Variable. Type: String. 
@@ -274,6 +274,13 @@ export interface VpcCniAddOnProps {
    * 
    */
   serviceAccountPolicies?: iam.IManagedPolicy[];
+
+  /**
+   * Enable kubernetes network policy in the VPC CNI introduced in vpc-cni 1.14
+   * More informaton on official AWS documentation: https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html
+   * 
+   */
+  enableNetworkPolicy?: string;
 
   /**
    * Version of the add-on to use. Must match the version of the cluster where it
@@ -410,14 +417,15 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       POD_SECURITY_GROUP_ENFORCING_MODE: props?.podSecurityGroupEnforcingMode,
       WARM_ENI_TARGET: props?.warmEniTarget,
       WARM_IP_TARGET: props?.warmIpTarget,
-      WARM_PREFIX_TARGET: props?.warmPrefixTarget
-    }
+      WARM_PREFIX_TARGET: props?.warmPrefixTarget,
+    },
+    enableNetworkPolicy: props?.enableNetworkPolicy
   };
 
   // clean up all undefined
   const values = result.env;
   Object.keys(values).forEach(key => values[key] === undefined ? delete values[key] : {});
-  Object.keys(values).forEach(key => values[key] = typeof values[key] !== 'string' ?  JSON.stringify(values[key]):values[key]);
- 
+  Object.keys(values).forEach(key => values[key] = typeof values[key] !== 'string' ? JSON.stringify(values[key]) : values[key]);
+
   return result;
 }

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -299,7 +299,7 @@ export interface CustomNetworkingConfig {
 
 const defaultProps: CoreAddOnProps = {
   addOnName: 'vpc-cni',
-  version: 'v1.13.4-eksbuild.1',
+  version: 'v1.14.1-eksbuild.1',
   saName: 'aws-node',
   namespace: 'kube-system',
   controlPlaneAddOn: false,
@@ -364,14 +364,14 @@ export class VpcCniAddOn extends CoreAddOn {
    * @returns 
    */
   createServiceAccount(clusterInfo: ClusterInfo, saNamespace: string, policies: iam.IManagedPolicy[]): eks.ServiceAccount {
-      const sa = new ReplaceServiceAccount(clusterInfo.cluster, `${this.coreAddOnProps.saName}-sa`, {
-        cluster: clusterInfo.cluster,
-        name: this.coreAddOnProps.saName,
-        namespace: saNamespace
-      });
+    const sa = new ReplaceServiceAccount(clusterInfo.cluster, `${this.coreAddOnProps.saName}-sa`, {
+      cluster: clusterInfo.cluster,
+      name: this.coreAddOnProps.saName,
+      namespace: saNamespace
+    });
 
-      policies.forEach(p => sa.role.addManagedPolicy(p));
-      return sa as any as eks.ServiceAccount;
+    policies.forEach(p => sa.role.addManagedPolicy(p));
+    return sa as any as eks.ServiceAccount;
   }
 }
 

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -280,7 +280,7 @@ export interface VpcCniAddOnProps {
    * More informaton on official AWS documentation: https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html
    * 
    */
-  enableNetworkPolicy?: string;
+  enableNetworkPolicy?: boolean;
 
   /**
    * Version of the add-on to use. Must match the version of the cluster where it
@@ -419,7 +419,7 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       WARM_IP_TARGET: props?.warmIpTarget,
       WARM_PREFIX_TARGET: props?.warmPrefixTarget,
     },
-    enableNetworkPolicy: props?.enableNetworkPolicy
+    enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy)
   };
 
   // clean up all undefined


### PR DESCRIPTION

*Issue #850 :*

*Description of changes:*

Introduce enableNetworkPolicy parameter and when is set to 'true' enable Network policy with AWS VPC-CNI plugin.

For example:
```typescript
    const addOns: Array<blueprints.ClusterAddOn> = [
      new blueprints.addons.CoreDnsAddOn(),
      new blueprints.addons.KubeProxyAddOn(),
      new blueprints.addons.EbsCsiDriverAddOn(),
      new blueprints.addons.VpcCniAddOn({ enableNetworkPolicy: 'true', version: 'v1.15.0-eksbuild.2' })
    ];
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
