### PR TITLE
[kubevious AddOn] Correct kubevious service type setpath

### DIFF
--- a/lib/addons/kubevious/index.ts
+++ b/lib/addons/kubevious/index.ts
@@ -66,7 +66,7 @@ function populateValues(helmOptions: KubeviousAddOnProps): Values {
     const values = helmOptions.values ?? {};
 
     setPath(values, "ingress.enabled",  helmOptions.ingressEnabled);
-    setPath(values, "kubevious.service.type",  helmOptions.kubeviousServiceType);
+    setPath(values, "ui.service.type",  helmOptions.kubeviousServiceType);
     // Generate a random password for MySQL DB root user
     setPath(values, "mysql.generate_passwords",  true);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
From [kubevious helm Doc](https://github.com/kubevious/helm/blob/master/README.md?plain=1#L172), current setpath of UI service type `kubevious.service.type` is not correct
 
Test:
- AddOn
```
AddOns.push(new KubeviousAddOn({
      version: '1.2.1',
      kubeviousServiceType: 'NodePort',
    }));
```

- Deploy
```
➜  ~ k get svc -n kubevious
NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
kubevious-backend-clusterip     ClusterIP   172.20.230.157   <none>        4000/TCP       28h
kubevious-collector-clusterip   ClusterIP   172.20.22.28     <none>        4000/TCP       28h
kubevious-guard-clusterip       ClusterIP   172.20.181.25    <none>        4000/TCP       28h
kubevious-mysql                 ClusterIP   172.20.169.242   <none>        3306/TCP       28h
kubevious-parser-clusterip      ClusterIP   172.20.119.231   <none>        4000/TCP       28h
kubevious-redis                 ClusterIP   172.20.161.139   <none>        6379/TCP       28h
kubevious-ui-nodeport           NodePort    172.20.34.122    <none>        80:30737/TCP   15m
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
