### PR TITLE
Updating documentation about in-place upgrades

### DIFF
--- a/docs/builders/observability-builder.md
+++ b/docs/builders/observability-builder.md
@@ -9,7 +9,7 @@ The `ObservabilityBuilder` allows you to get started with a builder class to con
 - `enableNativePatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS native services
 - `enableMixedPatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS managed open source services
 - `enableOpenSourcePatternAddOns`: This method helps you prepare a blueprint for setting up observability with a combination of AWS native and AWS managed open source services
-- `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch. This is an in-place change and should work for new and existing deployments
+- `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch. This is an in-place change and should work for new and existing deployments, , please check the [AWS documentation for Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) for more information on Control Plane logging.
 
 ## Usage 
 

--- a/docs/builders/observability-builder.md
+++ b/docs/builders/observability-builder.md
@@ -9,7 +9,7 @@ The `ObservabilityBuilder` allows you to get started with a builder class to con
 - `enableNativePatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS native services
 - `enableMixedPatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS managed open source services
 - `enableOpenSourcePatternAddOns`: This method helps you prepare a blueprint for setting up observability with a combination of AWS native and AWS managed open source services
-- `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch. This is an in-place change and should work for new and existing deployments, , please check the [AWS documentation for Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) for more information on Control Plane logging.
+- `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch. This is an in-place change and should work for new and existing deployments, please check the [AWS documentation for Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) for more information on Control Plane logging.
 
 ## Usage 
 

--- a/docs/builders/observability-builder.md
+++ b/docs/builders/observability-builder.md
@@ -10,6 +10,7 @@ The `ObservabilityBuilder` allows you to get started with a builder class to con
 - `enableMixedPatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS managed open source services
 - `enableOpenSourcePatternAddOns`: This method helps you prepare a blueprint for setting up observability with a combination of AWS native and AWS managed open source services
 - `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch
+  - According to the [AWS documentation for Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html), this is an in-place change and should work for existing and new deployments
 
 ## Usage 
 

--- a/docs/builders/observability-builder.md
+++ b/docs/builders/observability-builder.md
@@ -9,8 +9,7 @@ The `ObservabilityBuilder` allows you to get started with a builder class to con
 - `enableNativePatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS native services
 - `enableMixedPatternAddOns`: This method helps you prepare a blueprint for setting up observability with AWS managed open source services
 - `enableOpenSourcePatternAddOns`: This method helps you prepare a blueprint for setting up observability with a combination of AWS native and AWS managed open source services
-- `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch
-  - According to the [AWS documentation for Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html), this is an in-place change and should work for existing and new deployments
+- `enableControlPlaneLogging`: This method activates all the control plane logging features for EKS Clusters and feeds them into CloudWatch. This is an in-place change and should work for new and existing deployments
 
 ## Usage 
 

--- a/lib/builders/observability-builder.ts
+++ b/lib/builders/observability-builder.ts
@@ -90,6 +90,8 @@ export class ObservabilityBuilder extends BlueprintBuilder {
 
     /**
      * Enables control plane logging.
+     * Enabling control plane logging is an in-place change for EKS as inferred from
+     * https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
      *
      * @returns {ObservabilityBuilder} - The ObservabilityBuilder instance with control plane logging enabled.
      */


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-observability/cdk-aws-observability-accelerator/issues/118 

*Description of changes:* Documentation stating that in-place upgrades for new and existing clusters should be possible with control plane logging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
