### PR TITLE
fix: 869, support for non default namespace for adot

### DIFF
--- a/docs/addons/adot-addon.md
+++ b/docs/addons/adot-addon.md
@@ -2,7 +2,7 @@
 
 Amazon EKS supports using Amazon EKS API to install and manage the AWS Distro for OpenTelemetry (ADOT) Operator. This enables a simplified experience for instrumenting your applications running on Amazon EKS to send metric and trace data to multiple monitoring service options like Amazon CloudWatch, Prometheus, and X-Ray. 
 
-This add-on is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors.
+This add-on is not automatically installed when you first create a cluster, it must be added to the cluster in order to manage ADOT Collectors. For creating add-on in specific namespace, `namespace` property needs to be passed.
 
 For more information on the add-on, please review the [user guide](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html).
 
@@ -11,6 +11,7 @@ For more information on the add-on, please review the [user guide](https://docs.
 
 ## Usage
 
+### Example with default namespace
 ```typescript
 import * as cdk from 'aws-cdk-lib';
 import * as blueprints from '@aws-quickstart/eks-blueprints';
@@ -18,6 +19,24 @@ import * as blueprints from '@aws-quickstart/eks-blueprints';
 const app = new cdk.App();
 
 const addOn = new blueprints.addons.AdotCollectorAddOn();
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .version("auto")
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+### Example with non-default namespace
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.AdotCollectorAddOn({
+                namespace:'adot', //User supplied, non-default namespace
+                version: 'v0.80.0-eksbuild.2'
+              }),
 
 const blueprint = blueprints.EksBlueprint.builder()
   .version("auto")

--- a/docs/addons/amp-addon.md
+++ b/docs/addons/amp-addon.md
@@ -30,6 +30,24 @@ const blueprint = blueprints.EksBlueprint.builder()
   .build(app, 'my-stack-name');
 ```
 
+With the same pattern, to deploy ADOT collector in non-default namespace:
+
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.AmpAddOn({
+                ampPrometheusEndpoint: ampWorkspace.attrPrometheusEndpoint,
+                namespace: 'adot'
+              }),
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
 Pattern #2: Overriding property values for Name and Tags for a custom AMP Workspace name and tags. This pattern creates a new AMP workspace with property values passed on such as `workspaceName`, `tags` and deploys an ADOT collector on the namespace specified in `namespace` with name in `name` and `deployment` as the mode to remote write metrics to AMP workspace.
 
 ```typescript

--- a/docs/addons/xray-adot-addon.md
+++ b/docs/addons/xray-adot-addon.md
@@ -30,6 +30,24 @@ const blueprint = blueprints.EksBlueprint.builder()
   .build(app, 'my-stack-name');
 ```
 
+With the same pattern, to deploy ADOT collector in non-default namespace:
+
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.XrayAdotAddOn({
+                ampPrometheusEndpoint: ampWorkspace.attrPrometheusEndpoint,
+                namespace: 'adot'
+              }),
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
 Pattern # 2 : Overriding Property value for different deployment Modes. This pattern deploys an ADOT collector on the namespace specified in `namespace`, name specified in `name` with `daemonset` as the mode to X-Ray console. Deployment mode can be overridden to any of these values - `deployment`, `daemonset`, `statefulset`, `sidecar`.
 
 ```typescript

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -60,11 +60,17 @@ export default class BlueprintConstruct {
             new blueprints.addons.CertManagerAddOn(),
             new blueprints.addons.KubeStateMetricsAddOn(),
             new blueprints.addons.PrometheusNodeExporterAddOn(),
-            new blueprints.addons.AdotCollectorAddOn(),
+            new blueprints.addons.AdotCollectorAddOn({
+                namespace:'adot',
+                version: 'v0.80.0-eksbuild.2'
+            }),
             new blueprints.addons.AmpAddOn({
                 ampPrometheusEndpoint: ampWorkspace.attrPrometheusEndpoint,
+                namespace: 'adot'
             }),
-            new blueprints.addons.XrayAdotAddOn(),
+            new blueprints.addons.XrayAdotAddOn({
+                namespace: 'adot'
+            }),
             new blueprints.addons.XrayAddOn(),
             // new blueprints.addons.CloudWatchAdotAddOn(),
             // new blueprints.addons.ContainerInsightsAddOn(),

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -27,8 +27,6 @@ const defaultProps = {
 @supportsALL
 export class AdotCollectorAddOn extends CoreAddOn {
 
-    private namespace: string;
-
     constructor(props?: AdotCollectorAddOnProps) {
         super({ 
             ...defaultProps,
@@ -36,7 +34,6 @@ export class AdotCollectorAddOn extends CoreAddOn {
             ...props
         });
 
-        this.namespace = props?.namespace ?? defaultProps.namespace;
     }
     @dependable(CertManagerAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct>  {
@@ -44,7 +41,7 @@ export class AdotCollectorAddOn extends CoreAddOn {
         const cluster = clusterInfo.cluster;
 
         // Create namespace if not default
-        const ns = createNamespace(this.namespace!, cluster, true, true);
+        const ns = createNamespace(this.coreAddOnProps.namespace!, cluster, true, true);
 
         // Applying ADOT Permission manifest
         const otelPermissionsDoc = readYamlDocument(__dirname + '/otel-permissions.yaml');


### PR DESCRIPTION
*Issue #:* #869


*Description of changes:*
Adds support for non-default namespace for ADOT deployment.

*Tests:*
```
make run-test

Test Suites: 14 passed, 14 total
Tests:       67 passed, 67 total
Snapshots:   0 total
Time:        21.321 s

#Post Deployment validations:

└> k get all -n adot                                                                                                                                                 [9/11/23| 5:54PM]
NAME                                                READY   STATUS    RESTARTS   AGE
pod/otel-collector-amp-collector-6b8996bf5d-lxv6w   1/1     Running   0          101m
pod/otel-collector-xray-collector-c76d86886-rhvjm   1/1     Running   0          101m

NAME                                               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
service/otel-collector-amp-collector-monitoring    ClusterIP   172.20.93.158    <none>        8888/TCP            101m
service/otel-collector-xray-collector              ClusterIP   172.20.216.150   <none>        4317/TCP,4318/TCP   102m
service/otel-collector-xray-collector-headless     ClusterIP   None             <none>        4317/TCP,4318/TCP   102m
service/otel-collector-xray-collector-monitoring   ClusterIP   172.20.120.105   <none>        8888/TCP            102m

NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/otel-collector-amp-collector    1/1     1            1           101m
deployment.apps/otel-collector-xray-collector   1/1     1            1           102m

NAME                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/otel-collector-amp-collector-6b8996bf5d   1         1         1       101m
replicaset.apps/otel-collector-xray-collector-c76d86886   1         1         1       102m
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
