### PR TITLE
Docs: Fixed amp-addon.md typo

### DIFF
--- a/docs/addons/amp-addon.md
+++ b/docs/addons/amp-addon.md
@@ -69,7 +69,7 @@ const addOn = new blueprints.addons.AmpAddOn({
 const blueprint = blueprints.EksBlueprint.builder()
   .version("auto")
   .addOns(addOn)
-  .resourceProvider(ampWorkspaceName, new blueprints.CreateAmpProvider(ampWorkspaceName, ampWorkspaceName,{
+  .resourceProvider(ampWorkspaceName, new blueprints.CreateAmpProvider(ampWorkspaceName, ampWorkspaceName, [
     {
         key: 'Name',
         value: 'Sample-AMP-Workspace',
@@ -82,7 +82,7 @@ const blueprint = blueprints.EksBlueprint.builder()
         key: 'Department',
         value: 'Operations',
     }
-  }))
+  ]))
   .build(app, 'my-stack-name');
 ```
 Pattern #3: Passing on AMP Remote Endpoint of an existing AMP workspace to be used to remote write metrics. This pattern does not create an AMP workspace. Deploys an ADOT collector on the namespace specified in `namespace` with name in `name` and `deployment` as the mode to remote write metrics to AMP workspace of the URL passed as input. This pattern ignores any other property values passed if `ampPrometheusEndpoint` is present.


### PR DESCRIPTION
*Issue #, if available:*

#876 

*Description of changes:*

The constructor for the `CreateAmpProvider` class is shown below.

https://github.com/aws-quickstart/cdk-eks-blueprints/blob/a63f2721a7838ed1bc5e50b60a24d4b05375d8db/lib/resource-providers/amp.ts#L17

`workspaceTags` is an array type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
