### PR TITLE
Adding missing efs policy statements DescribeAvailabilityZones, Descr…

### DIFF
--- a/lib/addons/efs-csi-driver/iam-policy.ts
+++ b/lib/addons/efs-csi-driver/iam-policy.ts
@@ -19,7 +19,9 @@ export function getEfsDriverPolicyStatements(
       "Effect": "Allow",
       "Action": [
         "elasticfilesystem:DescribeAccessPoints",
-        "elasticfilesystem:DescribeFileSystems"
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets",
+        "ec2:DescribeAvailabilityZones"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
This PR aligns the efs provider IAM policy with the reference policy found here 
https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/docs/iam-policy-example.json

Without this, when provisioning a dynamic volume the user may see this error.

![image](https://github.com/aws-quickstart/cdk-eks-blueprints/assets/47243318/df03788a-f923-4cb8-89ca-c33e0f131c7c)
