### PR TITLE
Add Amazon EKS Pod Identity Agent add-on

### DIFF
--- a/docs/addons/eks-pod-identity-agent.md
+++ b/docs/addons/eks-pod-identity-agent.md
@@ -1,0 +1,73 @@
+# Amazon EKS Pod Identity Agent Add-on
+
+Amazon EKS Pod Identity associations provide the ability to manage credentials for your applications, similar to the way that Amazon EC2 instance profiles provide credentials to Amazon EC2 instances.
+
+Amazon EKS Pod Identity provides credentials to your workloads with an additional EKS Auth API and an agent pod that runs on each node
+
+For more information on the driver, please review the [user guide](https://docs.aws.amazon.com/en_ca/eks/latest/userguide/pod-id-agent-setup.html).
+
+## Prerequisites
+- Amazon EKS Pod Identity Driver add-on is only available on Amazon EKS clusters running Kubernetes version 1.24 and later.
+- EKS Pod Identities are available on Linux Amazon EC2 instances
+
+## Usage
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+const addOn = new blueprints.addons.EksPodIdentityAgentAddOn();
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+## Configuration Options
+
+- `version`: Version of the Amazon EKS Pod Identity Agent add-on to be installed. The version must be compatible with kubernetes cluster version.
+
+```bash
+# Command to show versions of the EKS Pod Identity Agent add-on available for cluster version is 1.24
+ aws eks describe-addon-versions \
+--addon-name eks-pod-identity-agent \
+--kubernetes-version 1.24 \
+--query "addons[].addonVersions[].[addonVersion, compatibilities[].defaultVersion]" --output text
+
+# Output
+v1.0.0-eksbuild.1
+
+```
+
+## Validation
+
+To validate that EKS Pod Identity Agent add-on is installed properly, ensure that the pods are running in the cluster
+
+```bash
+kubectl get pods -n kube-system | grep 'eks-pod-identity-agent'
+
+# Output
+eks-pod-identity-agent-gmqp7                                          1/1     Running   1 (24h ago)   24h
+eks-pod-identity-agent-prnsh                                          1/1     Running   1 (24h ago)   24h
+
+```
+
+Additionally, the `aws cli` can be used to determine which version of the add-on is installed in the cluster
+```bash
+# Assuming cluster-name is my-cluster, below command shows the version of coredns installed. Check if it is same as the version installed via EKS add-on
+aws eks describe-addon \
+    --cluster-name my-cluster \
+    --addon-name eks-pod-identity-agent \
+    --query "addon.addonVersion" \
+    --output text
+
+# Output
+v1.0.0-eksbuild.1
+```
+
+## Functionality
+
+Applies the EKS Pod Identity Agent add-on to an Amazon EKS cluster.

--- a/docs/addons/index.md
+++ b/docs/addons/index.md
@@ -72,6 +72,7 @@ The framework currently supports the following add-ons.
 | [`XrayAddOn`](./xray.md)                                                  | Adds XRay Daemon to the EKS Cluster.                                                                                                   | NA | NA
 | [`XrayAdotAddOn`](./xray-adot-addon.md)                                   | Deploys ADOT Collector for Xray to receive traces from your workloads.                                                                 | ✅ | ✅ |
 | [`GmaestroAddOn`](./gmaestro.md) | Adds [gMaestro](https://app.granulate.io/gMaestroSignup) cost optimization solution for EKS cluster.                                                                         |
+| [`EksPodIdentityAgentAddOn`](./eks-pod-identity-agent.md)       | [Setting up the EKS Pod Identity Agent](https://docs.aws.amazon.com/en_ca/eks/latest/userguide/pod-id-agent-setup.html)                  | ✅ | ✅ |
 
 # Standard Helm Add-On Configuration Options
 

--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -51,7 +51,7 @@ export default class BlueprintConstruct {
             s3BucketProps: { removalPolicy: cdk.RemovalPolicy.DESTROY }
         });
         const apacheAirflowEfs = new blueprints.CreateEfsFileSystemProvider({
-            name: 'blueprints-apache-airflow-efs',    
+            name: 'blueprints-apache-airflow-efs',
         });
 
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -93,7 +93,7 @@ export default class BlueprintConstruct {
                         blueprints.getNamedResource("secondary-cidr-subnet-0"),
                         blueprints.getNamedResource("secondary-cidr-subnet-1"),
                         blueprints.getNamedResource("secondary-cidr-subnet-2"),
-                    ]   
+                    ]
                 },
                 awsVpcK8sCniCustomNetworkCfg: true,
                 eniConfigLabelDef: 'topology.kubernetes.io/zone',
@@ -208,7 +208,7 @@ export default class BlueprintConstruct {
             }),
             new blueprints.GrafanaOperatorAddon(),
             new blueprints.CloudWatchLogsAddon({
-                logGroupPrefix: '/aws/eks/blueprints-construct-dev', 
+                logGroupPrefix: '/aws/eks/blueprints-construct-dev',
                 logRetentionDays: 30
             }),
             new blueprints.ApacheAirflowAddOn({
@@ -218,6 +218,7 @@ export default class BlueprintConstruct {
                 efsFileSystem: 'apache-airflow-efs-provider'
             }),
             new blueprints.ExternalsSecretsAddOn(),
+            new blueprints.EksPodIdentityAgentAddOn(),
         ];
 
         // Instantiated to for helm version check.
@@ -248,7 +249,7 @@ export default class BlueprintConstruct {
               actions: ['s3:*'],
             }),
             new iam.PolicyStatement({
-              resources: ['*'],   
+              resources: ['*'],
               actions: ['glue:*'],
             }),
             new iam.PolicyStatement({
@@ -258,7 +259,7 @@ export default class BlueprintConstruct {
               ],
             }),
           ];
-      
+
         const dataTeam: blueprints.EmrEksTeamProps = {
               name:'dataTeam',
               virtualClusterName: 'batchJob',
@@ -290,7 +291,7 @@ export default class BlueprintConstruct {
         blueprints.EksBlueprint.builder()
             .addOns(...addOns)
             .resourceProvider(blueprints.GlobalResources.Vpc, new blueprints.VpcProvider(undefined, {
-                primaryCidr: "10.2.0.0/16", 
+                primaryCidr: "10.2.0.0/16",
                 secondaryCidr: "100.64.0.0/16",
                 secondarySubnetCidrs: ["100.64.0.0/24","100.64.1.0/24","100.64.2.0/24"]
             }))
@@ -313,7 +314,7 @@ function addGenericNodeGroup(): blueprints.ManagedNodeGroup {
         amiType: NodegroupAmiType.AL2_X86_64,
         instanceTypes: [new ec2.InstanceType('m5.4xlarge')],
         desiredSize: 2,
-        maxSize: 3, 
+        maxSize: 3,
         nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
         nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
         launchTemplate: {
@@ -330,9 +331,9 @@ function addGenericNodeGroup(): blueprints.ManagedNodeGroup {
 }
 
 function addCustomNodeGroup(): blueprints.ManagedNodeGroup {
-    
+
     const userData = ec2.UserData.forLinux();
-    userData.addCommands(`/etc/eks/bootstrap.sh ${blueprintID}`); 
+    userData.addCommands(`/etc/eks/bootstrap.sh ${blueprintID}`);
 
     return {
         id: "mng2-customami",
@@ -370,7 +371,7 @@ function addWindowsNodeGroup(): blueprints.ManagedNodeGroup {
         amiType: NodegroupAmiType.WINDOWS_CORE_2019_X86_64,
         instanceTypes: [new ec2.InstanceType('m5.4xlarge')],
         desiredSize: 0,
-        minSize: 0, 
+        minSize: 0,
         nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
         diskSize: 50,
         tags: {
@@ -388,8 +389,8 @@ function addGpuNodeGroup(): blueprints.ManagedNodeGroup {
         id: "mng-linux-gpu",
         amiType: NodegroupAmiType.AL2_X86_64_GPU,
         instanceTypes: [new ec2.InstanceType('g5.xlarge')],
-        desiredSize: 0, 
-        minSize: 0, 
+        desiredSize: 0,
+        minSize: 0,
         maxSize: 1,
         nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
         launchTemplate: {

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -39,7 +39,7 @@ export class CoreAddOnProps {
     readonly controlPlaneAddOn?: boolean;
 
 
-    /** 
+    /**
      * Map between kubernetes versions and addOn versions for auto selection.
      */
     readonly versionMap?: Map<KubernetesVersion, string>;
@@ -60,7 +60,7 @@ export class CoreAddOn implements ClusterAddOn {
     }
 
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
-        
+
         let serviceAccountRoleArn: string | undefined = undefined;
         let serviceAccount: ServiceAccount | undefined = undefined;
         let saNamespace: string | undefined = undefined;
@@ -111,8 +111,8 @@ export class CoreAddOn implements ClusterAddOn {
     /**
      * Template method with default implementation to execute the supplied function of policyDocumentProvider.
      * Allows overriding this method in subclasses for more complex cases of policies.
-     * @param clusterInfo 
-     * @returns 
+     * @param clusterInfo
+     * @returns
      */
     providePolicyDocument(clusterInfo: ClusterInfo) : PolicyDocument | undefined {
         if(this.coreAddOnProps?.policyDocumentProvider) {
@@ -122,13 +122,13 @@ export class CoreAddOn implements ClusterAddOn {
     }
 
     /**
-     * Template method to return managed policies for the service account. 
+     * Template method to return managed policies for the service account.
      * Allows overriding in subclasses to handle more complex cases of policies.
      */
     provideManagedPolicies(clusterInfo: ClusterInfo) : IManagedPolicy[] | undefined {
         let result : IManagedPolicy[] | undefined;
         const policyDocument = this.providePolicyDocument(clusterInfo);
-        
+
         if(policyDocument) {
             const policy = new ManagedPolicy(clusterInfo.cluster, `${this.coreAddOnProps.addOnName}-managed-policy`, {
                 document: policyDocument

--- a/lib/addons/eks-pod-identity-agent/index.ts
+++ b/lib/addons/eks-pod-identity-agent/index.ts
@@ -1,0 +1,24 @@
+import { CoreAddOn } from "../core-addon";
+
+/**
+ * Default values for the add-on
+ */
+const defaultProps = {
+    addOnName: 'eks-pod-identity-agent',
+    version: 'v1.0.0-eksbuild.1',
+    saName: "eks-pod-identity-agent-sa",
+};
+
+/**
+ * Implementation of Amazon EKS Pod Identity Agent add-on.
+ */
+export class EksPodIdentityAgentAddOn extends CoreAddOn {
+
+    constructor(version?: string) {
+        super({
+            addOnName: defaultProps.addOnName,
+            version: version ?? defaultProps.version,
+            saName: defaultProps.saName,
+        });
+    }
+}

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -53,6 +53,7 @@ export * from './emr-on-eks';
 export * from './aws-batch-on-eks';
 export * from './upbound-universal-crossplane';
 export * from './apache-airflow';
+export * from './eks-pod-identity-agent';
 
 export class Constants {
     public static readonly BLUEPRINTS_ADDON = "blueprints-addon";


### PR DESCRIPTION
*Issue #, if available:*
Amazon EKS introduces [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), a new feature that simplifies how cluster administrators can configure Kubernetes applications to obtain AWS [IAM](https://aws.amazon.com/iam/) permissions. These permissions can now be easily configured with fewer steps directly through EKS console, APIs, and CLI. EKS Pod Identity makes it easy to use an IAM role across multiple clusters and simplifies policy management by enabling the reuse of permission policies across IAM roles.

*Description of changes:*
Add Amazon EKS Pod Identity Agent add-on

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
