### PR TITLE
Provision add custom security group to secondary eni in vpc cni addon custom networking

### DIFF
--- a/lib/addons/vpc-cni/eniConfig.ytpl
+++ b/lib/addons/vpc-cni/eniConfig.ytpl
@@ -4,5 +4,5 @@ metadata:
   name: "{{availabilityZone}}"
 spec: 
   securityGroups: 
-    - "{{clusterSecurityGroupId}}"
+    - "{{securityGroupId}}"
   subnet: "{{subnetId}}"


### PR DESCRIPTION
*Issue #, if available:* The current implementation of eniconfig manifest creation by default sets the eks cluster's security group id as secondary eni id. If a user wants to use an already existing security group id then its not possible now


*Description of changes:*
Provides capability to specify an existing security group for EniConfig generated by vpc cni addon. The security group id is optional in CustomNetworkingConfig, if security group is not specified cluster security group id will be used.
This change is in reference to the Custom Networking documentation steps which specifies "Replace $cluster_security_group_id with the ID of an existing [security group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) that you want to use for each ENIConfig."

https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html#custom-networking-configure-kubernetes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
