### PR TITLE
Change to use eks.nodeGroupOptions in the builder

### DIFF
--- a/lib/builders/windows-builder.ts
+++ b/lib/builders/windows-builder.ts
@@ -21,50 +21,50 @@ export interface WindowsOptions {
      */
     kubernetesVersion: eks.KubernetesVersion,
 
-    /** 
-     * Required, Instance class to use for the cluster. 
+    /**
+     * Required, Instance class to use for the cluster.
      */
     instanceClass: ec2.InstanceClass,
 
-    /** 
-     * Required, Instance size to use for the cluster. 
+    /**
+     * Required, Instance size to use for the cluster.
      */
     instanceSize: ec2.InstanceSize,
 
-    /** 
-     * optional, Node IAM Role to be attached to Windows 
+    /**
+     * optional, Node IAM Role to be attached to Windows
      * and Non-windows nodes.
      */
     nodeRole?: iam.Role,
 
-    /** 
+    /**
      * Optional, AMI Type for Windows Nodes
      */
     windowsAmiType?: NodegroupAmiType,
 
-    /** 
-     * Optional, Desired number of nodes to use for the cluster. 
+    /**
+     * Optional, Desired number of nodes to use for the cluster.
      */
-    desiredNodeSize?: number,
+    desiredNodeCount?: number,
 
-    /** 
-     * Optional, Minimum number of nodes to use for the cluster. 
+    /**
+     * Optional, Minimum number of nodes to use for the cluster.
      */
     minNodeSize?: number,
 
-    /** 
-     * Optional, Maximum number of nodes to use for the cluster. 
+    /**
+     * Optional, Maximum number of nodes to use for the cluster.
      */
     maxNodeSize?: number,
 
-    /** 
+    /**
      * Optional, Block device size.
      */
     blockDeviceSize?: number,
 
     /**
-     * Optional, No Schedule for Windows Nodes, this allows Windows 
-     * nodes to be marked as no-schedule by default to prevent any 
+     * Optional, No Schedule for Windows Nodes, this allows Windows
+     * nodes to be marked as no-schedule by default to prevent any
      * linux workloads from scheduling.
      */
     noScheduleForWindowsNodes?: boolean,
@@ -134,7 +134,7 @@ const defaultOptions: WindowsOptions = {
 export class WindowsBuilder extends BlueprintBuilder {
 
     /**
-     * This method helps you prepare a blueprint for setting up windows nodes with 
+     * This method helps you prepare a blueprint for setting up windows nodes with
      * usage tracking addon
      */
     public static builder(options: WindowsOptions): WindowsBuilder {
@@ -147,7 +147,7 @@ export class WindowsBuilder extends BlueprintBuilder {
                     version: mergedOptions.kubernetesVersion,
                     tags: mergedOptions.clusterProviderTags,
                     role: resourceproviders.getResource(context => {
-                        return new iam.Role(context.scope, 'ClusterRole', { 
+                        return new iam.Role(context.scope, 'ClusterRole', {
                             assumedBy: new iam.ServicePrincipal("eks.amazonaws.com"),
                             managedPolicies: [
                                 iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSClusterPolicy"),

--- a/lib/builders/windows-builder.ts
+++ b/lib/builders/windows-builder.ts
@@ -119,6 +119,31 @@ const defaultOptions: WindowsOptions = {
     }
   };
 
+const defaultKarpenterProps: addons.KarpenterAddOnProps = {
+    version: "v0.31.3",
+    requirements: [
+        { key: 'kubernetes.io/os', op: 'In', vals: ['windows']},
+    ],
+    //subnetTags: {
+        //"Name": `${stackID}/${stackID}-vpc/Private*`,
+    //},
+    //securityGroupTags: {
+        //[`kubernetes.io/cluster/${stackID}`]: "owned",
+    //},
+    consolidation: { enabled: true },
+    ttlSecondsUntilExpired: 2592000,
+    weight: 20,
+    interruptionHandling: true,
+    taints: [
+        {
+            key: "os",
+            value: "windows",
+            effect: "NoSchedule"
+        }
+    ],
+    amiFamily: "Windows2022"
+};
+
 /**
  * This builder class helps you prepare a blueprint for setting up
  * windows nodes with EKS cluster. The `WindowsBuilder` creates the following:
@@ -127,6 +152,8 @@ const defaultOptions: WindowsOptions = {
  * 3. A windows nodegroup to schedule windows workloads
  */
 export class WindowsBuilder extends BlueprintBuilder {
+
+    private karpenterProps:addons.KarpenterAddOnProps;
 
     /**
      * This method helps you prepare a blueprint for setting up windows nodes with
@@ -160,10 +187,22 @@ export class WindowsBuilder extends BlueprintBuilder {
                 new addons.NestedStackAddOn({
                     id: "usage-tracking-addon",
                     builder: UsageTrackingAddOn.builder(),
-                })
+                }),
             );
         return builder;
     }
+
+    public enableKarpenter(): WindowsBuilder {
+        return this.addOns(
+            new addons.KarpenterAddOn(this.karpenterProps)
+        )
+    }
+
+    public withKarpenterProps(props:addons.KarpenterAddOnProps) : this {
+        this.karpenterProps = { ...this.karpenterProps, ...utils.cloneDeep(props) };
+        return this;
+    }
+
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Change to use eks.nodeGroupOptions so we can have all options override in case it's needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
