### PR TITLE
Upgrade Core Addons to support Default Versions from AWS sdk for different Kubernetes versions 

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -100,8 +100,8 @@ export default class BlueprintConstruct {
                 eniConfigLabelDef: 'topology.kubernetes.io/zone',
                 serviceAccountPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKS_CNI_Policy")]
             }),
-            new blueprints.addons.CoreDnsAddOn(),
-            new blueprints.addons.KubeProxyAddOn(),
+            new blueprints.addons.CoreDnsAddOn("auto"),
+            new blueprints.addons.KubeProxyAddOn("auto"),
             new blueprints.addons.OpaGatekeeperAddOn(),
             new blueprints.addons.AckAddOn({
                 id: "kafk-ack",

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -6,6 +6,13 @@ import { CertManagerAddOn } from "../cert-manager";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { getAdotCollectorPolicyDocument } from "./iam-policy";
 import { semverComparator } from "../helm-addon/helm-version-checker";
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
+const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_28, "v0.90.0-eksbuild.1"],
+    [KubernetesVersion.V1_27, "v0.90.0-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v0.90.0-eksbuild.1"]
+]);
 
 /**
  * Configuration options for the Adot add-on.
@@ -16,7 +23,8 @@ export type AdotCollectorAddOnProps = Omit<CoreAddOnProps, "saName" | "addOnName
 
 const defaultProps = {
     addOnName: 'adot',
-    version: 'v0.88.0-eksbuild.2',
+    version: 'auto',
+    versionMap: versionMap,
     saName: 'adot-collector',
     policyDocumentProvider: getAdotCollectorPolicyDocument,
     namespace: 'default',

--- a/lib/addons/cloud-watch-insights/index.ts
+++ b/lib/addons/cloud-watch-insights/index.ts
@@ -6,6 +6,13 @@ import {conflictsWith, createNamespace, supportsALL} from "../../utils";
 import {CoreAddOn, CoreAddOnProps} from "../core-addon";
 import {ebsCollectorPolicy} from "./iam-policy";
 import {ManagedPolicy} from "aws-cdk-lib/aws-iam";
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
+const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_28, "v1.2.1-eksbuild.1"],
+    [KubernetesVersion.V1_27, "v1.2.1-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.2.1-eksbuild.1"]
+]);
 
 /**
  * Configuration options for AWS Container Insights add-on.
@@ -30,7 +37,8 @@ export type CloudWatchInsightsAddOnProps = Omit<CoreAddOnProps, "saName" | "addO
 
 const defaultProps = {
   addOnName: "amazon-cloudwatch-observability",
-  version: "v1.1.1-eksbuild.1",
+  version: "auto",
+  versionMap: versionMap,
   saName: "cloudwatch-agent",
   namespace: "amazon-cloudwatch"
 };

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -6,10 +6,7 @@ import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-i
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
-<<<<<<< HEAD
 import { RemovalPolicy } from "aws-cdk-lib";
-=======
->>>>>>> 2db90598 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions)
 
 export class CoreAddOnProps {
     /**

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,11 +1,15 @@
-import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+<<<<<<< HEAD
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
+=======
+import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
+>>>>>>> 6467b1c9 (CoreDns Retain on delete)
 import { RemovalPolicy } from "aws-cdk-lib";
 
 export class CoreAddOnProps {

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,4 +1,4 @@
-import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -4,12 +4,8 @@ import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
-<<<<<<< HEAD
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
-=======
-import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
->>>>>>> 6467b1c9 (CoreDns Retain on delete)
 import { RemovalPolicy } from "aws-cdk-lib";
 
 export class CoreAddOnProps {

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,4 +1,4 @@
-import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
@@ -6,10 +6,7 @@ import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-i
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
-<<<<<<< HEAD
 import { RemovalPolicy } from "aws-cdk-lib";
-=======
->>>>>>> 2db90598 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions)
 
 export class CoreAddOnProps {
     /**
@@ -110,7 +107,7 @@ export class CoreAddOn implements ClusterAddOn {
          * */ 
         
         if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
-            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -158,20 +158,20 @@ export class CoreAddOn implements ClusterAddOn {
 
                 const version: string | undefined = defaultVersions[0]?.addonVersion;
                 if (!version) { 
-                    throw new Error("No default version found");
+                    throw new Error(`No default version found for addo-on ${this.coreAddOnProps.addOnName}`);
                 }
                 userLog.debug(`Core add-on ${this.coreAddOnProps.addOnName} has autoselected version ${version}`);
                 return version;
             }
             else {
-                throw new Error("No add-on versions found");
+                throw new Error(`No add-on versions found for addon-on ${this.coreAddOnProps.addOnName}`);
             }
         }
         catch (error) {
             logger.warn(error);
-            logger.warn("Failed to retrieve add-on versions from EKS. Falling back to default version.");
+            logger.warn(`Failed to retrieve add-on versions from EKS for add-on ${this.coreAddOnProps.addOnName}. Falling back to default version.`);
             if (!versionMap) {
-                throw new Error("No version map provided and no default version found");
+                throw new Error(`No version map provided and no default version found for add-on ${this.coreAddOnProps.addOnName}`);
             }
             let version: string = versionMap.get(clusterInfo.version) ?? versionMap.values().next().value;
             userLog.debug(`Core add-on ${this.coreAddOnProps.addOnName} has autoselected version ${version}`);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,4 +1,4 @@
-import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -6,7 +6,17 @@ import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-i
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
+<<<<<<< HEAD
 import { RemovalPolicy } from "aws-cdk-lib";
+=======
+=======
+import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
+<<<<<<< HEAD
+import { RemovalPolicy } from "aws-cdk-lib";
+>>>>>>> 6467b1c9 (CoreDns Retain on delete)
+=======
+>>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
+>>>>>>> bb411535 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions - Fixing Tests)
 
 export class CoreAddOnProps {
     /**
@@ -101,6 +111,7 @@ export class CoreAddOn implements ClusterAddOn {
         if(this.coreAddOnProps.controlPlaneAddOn) {
             deployBeforeCapacity(cfnAddon, clusterInfo);
         }
+<<<<<<< HEAD
         /**
          *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
          *  https://github.com/aws/aws-cdk/issues/28621
@@ -109,6 +120,8 @@ export class CoreAddOn implements ClusterAddOn {
         if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
             cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
         }
+=======
+>>>>>>> 763c1e10 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions - PR Fix)
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);
     }

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -6,17 +6,7 @@ import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-i
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
-<<<<<<< HEAD
 import { RemovalPolicy } from "aws-cdk-lib";
-=======
-=======
-import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
-<<<<<<< HEAD
-import { RemovalPolicy } from "aws-cdk-lib";
->>>>>>> 6467b1c9 (CoreDns Retain on delete)
-=======
->>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
->>>>>>> bb411535 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions - Fixing Tests)
 
 export class CoreAddOnProps {
     /**
@@ -111,7 +101,6 @@ export class CoreAddOn implements ClusterAddOn {
         if(this.coreAddOnProps.controlPlaneAddOn) {
             deployBeforeCapacity(cfnAddon, clusterInfo);
         }
-<<<<<<< HEAD
         /**
          *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
          *  https://github.com/aws/aws-cdk/issues/28621
@@ -120,8 +109,6 @@ export class CoreAddOn implements ClusterAddOn {
         if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
             cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
         }
-=======
->>>>>>> 763c1e10 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions - PR Fix)
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);
     }

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -4,16 +4,8 @@ import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
-<<<<<<< HEAD
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
-=======
-import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
-<<<<<<< HEAD
-import { RemovalPolicy } from "aws-cdk-lib";
->>>>>>> 6467b1c9 (CoreDns Retain on delete)
-=======
->>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
 
 export class CoreAddOnProps {
     /**

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -6,7 +6,10 @@ import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-i
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
+<<<<<<< HEAD
 import { RemovalPolicy } from "aws-cdk-lib";
+=======
+>>>>>>> 2db90598 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions)
 
 export class CoreAddOnProps {
     /**

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,4 +1,4 @@
-import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
@@ -9,8 +9,11 @@ import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog, 
 import * as sdk from "@aws-sdk/client-eks";
 =======
 import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
+<<<<<<< HEAD
 import { RemovalPolicy } from "aws-cdk-lib";
 >>>>>>> 6467b1c9 (CoreDns Retain on delete)
+=======
+>>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
 
 export class CoreAddOnProps {
     /**
@@ -104,14 +107,6 @@ export class CoreAddOn implements ClusterAddOn {
 
         if(this.coreAddOnProps.controlPlaneAddOn) {
             deployBeforeCapacity(cfnAddon, clusterInfo);
-        }
-        /**
-         *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
-         *  https://github.com/aws/aws-cdk/issues/28621
-         * */ 
-        
-        if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
-            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,16 +1,12 @@
-import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
-<<<<<<< HEAD
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
-=======
-import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
 import { RemovalPolicy } from "aws-cdk-lib";
->>>>>>> 6467b1c9 (CoreDns Retain on delete)
 
 export class CoreAddOnProps {
     /**

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -5,7 +5,6 @@ import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
-import { RemovalPolicy } from "aws-cdk-lib";
 
 export class CoreAddOnProps {
     /**
@@ -99,14 +98,6 @@ export class CoreAddOn implements ClusterAddOn {
 
         if(this.coreAddOnProps.controlPlaneAddOn) {
             deployBeforeCapacity(cfnAddon, clusterInfo);
-        }
-        /**
-         *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
-         *  https://github.com/aws/aws-cdk/issues/28621
-         * */ 
-        
-        if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
-            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -111,7 +111,7 @@ export class CoreAddOn implements ClusterAddOn {
          * */ 
         
         if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
-            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -5,6 +5,7 @@ import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
+import * as sdk from "@aws-sdk/client-eks";
 
 export class CoreAddOnProps {
     /**

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,11 +1,16 @@
-import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+<<<<<<< HEAD
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
 import * as sdk from "@aws-sdk/client-eks";
+=======
+import { createServiceAccountWithPolicy, deployBeforeCapacity, userLog,  } from "../../utils";
+import { RemovalPolicy } from "aws-cdk-lib";
+>>>>>>> 6467b1c9 (CoreDns Retain on delete)
 
 export class CoreAddOnProps {
     /**
@@ -99,6 +104,14 @@ export class CoreAddOn implements ClusterAddOn {
 
         if(this.coreAddOnProps.controlPlaneAddOn) {
             deployBeforeCapacity(cfnAddon, clusterInfo);
+        }
+        /**
+         *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
+         *  https://github.com/aws/aws-cdk/issues/28621
+         * */ 
+        
+        if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
+            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);

--- a/lib/addons/core-addon/index.ts
+++ b/lib/addons/core-addon/index.ts
@@ -1,11 +1,10 @@
-import { CfnAddon, FargateCluster, ServiceAccount } from "aws-cdk-lib/aws-eks";
+import { CfnAddon, ServiceAccount } from "aws-cdk-lib/aws-eks";
 import { ClusterAddOn } from "../..";
 import { ClusterInfo, Values } from "../../spi";
 import { Construct } from "constructs";
 import { IManagedPolicy, ManagedPolicy, PolicyDocument } from "aws-cdk-lib/aws-iam";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import { createServiceAccountWithPolicy, deployBeforeCapacity, logger, userLog,  } from "../../utils";
-import * as sdk from "@aws-sdk/client-eks";
 import { RemovalPolicy } from "aws-cdk-lib";
 
 export class CoreAddOnProps {
@@ -107,7 +106,7 @@ export class CoreAddOn implements ClusterAddOn {
          * */ 
         
         if(clusterInfo.cluster instanceof FargateCluster && this.coreAddOnProps.addOnName === "coredns"){
-            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+            cfnAddon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
         }
         // Instantiate the Add-on
         return Promise.resolve(cfnAddon);

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -7,12 +7,9 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
-    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
-    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
 
 /**

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -59,5 +59,10 @@ export class CoreDnsAddOn extends CoreAddOn {
             }
         })
         return addonPromise;
+<<<<<<< HEAD
     }   
+=======
+    }
+    
+>>>>>>> bb411535 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions - Fixing Tests)
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -55,13 +55,12 @@ export class CoreDnsAddOn extends CoreAddOn {
      *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
      *  https://github.com/aws/aws-cdk/issues/28621
      */ 
-    handleFargatePatch( addonPromise: Promise<Construct> ): Promise<Construct> {
+    handleFargatePatch( addonPromise: Promise<Construct> ){
         addonPromise.then(addon => {
             if(addon instanceof CfnAddon){
-                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
             }
-        })
-        return addonPromise;
+        });
     }
     
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -2,15 +2,14 @@ import { Construct } from "constructs";
 import { ClusterInfo } from "../../spi";
 import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
+import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
+import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 const versionMap: Map<KubernetesVersion, string> = new Map([
     [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
     [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
     [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
-
-import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
-import { RemovalPolicy } from "aws-cdk-lib";
 
 /**
  * Configuration options for the coredns add-on.

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -3,12 +3,9 @@ import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
-    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
-    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
 
 /**

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -1,5 +1,8 @@
+import { Construct } from "constructs";
+import { ClusterInfo } from "../../spi";
 import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
+<<<<<<< HEAD
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
@@ -7,6 +10,10 @@ const versionMap: Map<KubernetesVersion, string> = new Map([
     [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
     [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
+=======
+import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
+import { RemovalPolicy } from "aws-cdk-lib";
+>>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
 
 /**
  * Configuration options for the coredns add-on.
@@ -34,4 +41,27 @@ export class CoreDnsAddOn extends CoreAddOn {
         });
     }
 
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
+
+        const addonPromise: Promise<Construct> = super.deploy(clusterInfo);
+
+        if(clusterInfo.cluster instanceof FargateCluster){
+            this.handleFargatePatch(addonPromise);
+        }
+        return addonPromise;
+    }
+
+    /**
+     *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
+     *  https://github.com/aws/aws-cdk/issues/28621
+     */ 
+    handleFargatePatch( addonPromise: Promise<Construct> ): Promise<Construct> {
+        addonPromise.then(addon => {
+            if(addon instanceof CfnAddon){
+                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+            }
+        })
+        return addonPromise;
+    }
+    
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -2,18 +2,18 @@ import { Construct } from "constructs";
 import { ClusterInfo } from "../../spi";
 import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
-<<<<<<< HEAD
+import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
+import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
-    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
-    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
 ]);
-=======
-import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
-import { RemovalPolicy } from "aws-cdk-lib";
->>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
 
 /**
  * Configuration options for the coredns add-on.

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -12,7 +12,6 @@ const versionMap: Map<KubernetesVersion, string> = new Map([
 import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
 import { RemovalPolicy } from "aws-cdk-lib";
 
-
 /**
  * Configuration options for the coredns add-on.
  */

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -6,12 +6,9 @@ import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
-    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
-    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
-    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
 
 /**

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -59,10 +59,5 @@ export class CoreDnsAddOn extends CoreAddOn {
             }
         })
         return addonPromise;
-<<<<<<< HEAD
     }   
-=======
-    }
-    
->>>>>>> bb411535 (Upgrade Core Addons to support MAP of Versions for Kubernetes versions - Fixing Tests)
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -51,12 +51,11 @@ export class CoreDnsAddOn extends CoreAddOn {
      *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
      *  https://github.com/aws/aws-cdk/issues/28621
      */ 
-    handleFargatePatch( addonPromise: Promise<Construct> ): Promise<Construct> {
+    handleFargatePatch( addonPromise: Promise<Construct> ){
         addonPromise.then(addon => {
             if(addon instanceof CfnAddon){
                 addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
             }
         })
-        return addonPromise;
     }   
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -7,9 +7,12 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
-    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
-    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
 ]);
 
 /**

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -54,8 +54,8 @@ export class CoreDnsAddOn extends CoreAddOn {
     handleFargatePatch( addonPromise: Promise<Construct> ){
         addonPromise.then(addon => {
             if(addon instanceof CfnAddon){
-                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
             }
-        })
+        });
     }   
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -4,7 +4,6 @@ import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
 import { RemovalPolicy } from "aws-cdk-lib";
-<<<<<<< HEAD
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
@@ -12,8 +11,6 @@ const versionMap: Map<KubernetesVersion, string> = new Map([
     [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
     [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
-=======
->>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
 
 /**
  * Configuration options for the coredns add-on.
@@ -55,14 +52,6 @@ export class CoreDnsAddOn extends CoreAddOn {
      *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
      *  https://github.com/aws/aws-cdk/issues/28621
      */ 
-<<<<<<< HEAD
-    handleFargatePatch( addonPromise: Promise<Construct> ){
-        addonPromise.then(addon => {
-            if(addon instanceof CfnAddon){
-                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
-            }
-        });
-=======
     handleFargatePatch( addonPromise: Promise<Construct> ): Promise<Construct> {
         addonPromise.then(addon => {
             if(addon instanceof CfnAddon){
@@ -70,7 +59,5 @@ export class CoreDnsAddOn extends CoreAddOn {
             }
         })
         return addonPromise;
->>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
-    }
-    
+    }   
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -4,6 +4,7 @@ import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
 import { RemovalPolicy } from "aws-cdk-lib";
+<<<<<<< HEAD
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
@@ -11,6 +12,8 @@ const versionMap: Map<KubernetesVersion, string> = new Map([
     [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
     [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
+=======
+>>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
 
 /**
  * Configuration options for the coredns add-on.
@@ -52,12 +55,22 @@ export class CoreDnsAddOn extends CoreAddOn {
      *  Retain the addon otherwise cluster destroy will fail due to CoreDnsComputeTypePatch 
      *  https://github.com/aws/aws-cdk/issues/28621
      */ 
+<<<<<<< HEAD
     handleFargatePatch( addonPromise: Promise<Construct> ){
         addonPromise.then(addon => {
             if(addon instanceof CfnAddon){
                 addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
             }
         });
+=======
+    handleFargatePatch( addonPromise: Promise<Construct> ): Promise<Construct> {
+        addonPromise.then(addon => {
+            if(addon instanceof CfnAddon){
+                addon.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+            }
+        })
+        return addonPromise;
+>>>>>>> 963c7d30 (Migrate logic to coredns addon from core addon)
     }
     
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -6,9 +6,12 @@ import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
-    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
-    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
 ]);
 
 /**

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -1,14 +1,24 @@
 import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
+const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_28, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_27, "v1.10.1-eksbuild.6"],
+    [KubernetesVersion.V1_26, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_25, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_24, "v1.9.3-eksbuild.10"],
+    [KubernetesVersion.V1_23, "v1.8.7-eksbuild.9"],
+]);
 
 /**
  * Configuration options for the coredns add-on.
  */
-export type CoreDnsAddOnProps = Omit<CoreAddOnProps, "saName" | "addOnName">;
+export type CoreDnsAddOnProps = Omit<CoreAddOnProps, "saName" | "addOnName" | "version" >;
 
 const defaultProps = {
     addOnName: 'coredns',
-    version: 'v1.10.1-eksbuild.4',
+    versionMap: versionMap,
     saName: 'coredns',
     configurationValues: {}
 };
@@ -19,8 +29,12 @@ const defaultProps = {
 @supportsALL
 export class CoreDnsAddOn extends CoreAddOn {
 
-    constructor(props?: CoreDnsAddOnProps) {
-        super({ ...defaultProps, ...props });
+    constructor(version?: string, props?: CoreDnsAddOnProps) {
+        super({
+            version: version ?? "auto",
+            ... defaultProps,
+            ... props
+        });
     }
 
 }

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -2,15 +2,16 @@ import { Construct } from "constructs";
 import { ClusterInfo } from "../../spi";
 import {supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
-import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
-import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
-
 const versionMap: Map<KubernetesVersion, string> = new Map([
     [KubernetesVersion.V1_28, "v1.10.1-eksbuild.2"],
     [KubernetesVersion.V1_27, "v1.10.1-eksbuild.1"],
     [KubernetesVersion.V1_26, "v1.9.3-eksbuild.2"],
 ]);
+
+import { CfnAddon, FargateCluster } from "aws-cdk-lib/aws-eks";
+import { RemovalPolicy } from "aws-cdk-lib";
+
 
 /**
  * Configuration options for the coredns add-on.

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -46,7 +46,8 @@ export class EbsCsiDriverAddOn extends CoreAddOn {
         super({
             addOnName: defaultProps.addOnName,
             version: options?.version ?? defaultProps.version,
-            saName: defaultProps.saName
+            saName: defaultProps.saName,
+            versionMap: defaultProps.versionMap,
         });
     }
 

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -4,6 +4,13 @@ import { ClusterInfo } from "../../spi";
 import { CoreAddOn } from "../core-addon";
 import { getEbsDriverPolicyDocument } from "./iam-policy";
 import { supportsALL } from "../../utils";
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
+const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_28, "v1.26.1-eksbuild.1"],
+    [KubernetesVersion.V1_27, "v1.26.1-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.26.1-eksbuild.1"]
+]);
 
 /**
  * Interface for EBS CSI Driver EKS add-on options
@@ -24,7 +31,8 @@ export interface EbsCsiDriverAddOnProps {
  */
 const defaultProps = {
     addOnName: "aws-ebs-csi-driver",
-    version: "v1.23.0-eksbuild.1",
+    version: "auto",
+    versionMap: versionMap,
     saName: "ebs-csi-controller-sa",
 };
 

--- a/lib/addons/eks-pod-identity-agent/index.ts
+++ b/lib/addons/eks-pod-identity-agent/index.ts
@@ -27,6 +27,7 @@ export class EksPodIdentityAgentAddOn extends CoreAddOn {
             addOnName: defaultProps.addOnName,
             version: version ?? defaultProps.version,
             saName: defaultProps.saName,
+            versionMap: defaultProps.versionMap
         });
     }
 }

--- a/lib/addons/eks-pod-identity-agent/index.ts
+++ b/lib/addons/eks-pod-identity-agent/index.ts
@@ -1,11 +1,19 @@
 import { CoreAddOn } from "../core-addon";
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
+const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_28, "v1.0.0-eksbuild.1"],
+    [KubernetesVersion.V1_27, "v1.0.0-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.0.0-eksbuild.1"]
+]);
 
 /**
  * Default values for the add-on
  */
 const defaultProps = {
     addOnName: 'eks-pod-identity-agent',
-    version: 'v1.0.0-eksbuild.1',
+    version: 'auto',
+    versionMap: versionMap,
     saName: "eks-pod-identity-agent-sa",
 };
 

--- a/lib/addons/kube-proxy/index.ts
+++ b/lib/addons/kube-proxy/index.ts
@@ -3,12 +3,9 @@ import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { supportsALL } from "../../utils";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_28, "v1.28.2-eksbuild.2"],
-    [KubernetesVersion.V1_27, "v1.27.6-eksbuild.2"],
-    [KubernetesVersion.V1_26, "v1.26.2-eksbuild.1"],
-    [KubernetesVersion.V1_25, "v1.25.6-eksbuild.1"],
-    [KubernetesVersion.V1_24, "v1.24.7-eksbuild.2"],
-    [KubernetesVersion.V1_23, "v1.23.7-eksbuild.1"],
+    [KubernetesVersion.V1_28, "v1.28.1-eksbuild.1"],
+    [KubernetesVersion.V1_27, "v1.27.1-eksbuild.1"],
+    [KubernetesVersion.V1_26, "v1.26.2-eksbuild.1"]
 ]);
 
 /**

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -6,6 +6,13 @@ import { ClusterInfo, Values } from "../../spi";
 import { loadYaml, readYamlDocument, ReplaceServiceAccount, supportsALL } from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { KubectlProvider, ManifestDeployment } from "../helm-addon/kubectl-provider";
+import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
+
+const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_28, "v1.14.1-eksbuild.1"],
+  [KubernetesVersion.V1_27, "v1.12.6-eksbuild.2"],
+  [KubernetesVersion.V1_26, "v1.12.5-eksbuild.2"],
+]);
 
 /**
  * User provided option for the Helm Chart
@@ -303,7 +310,8 @@ export interface CustomNetworkingConfig {
 
 const defaultProps: CoreAddOnProps = {
   addOnName: 'vpc-cni',
-  version: 'v1.14.1-eksbuild.1',
+  version: 'auto',
+  versionMap: versionMap,
   saName: 'aws-node',
   namespace: 'kube-system',
   controlPlaneAddOn: false,

--- a/lib/builders/observability-builder.ts
+++ b/lib/builders/observability-builder.ts
@@ -12,6 +12,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
     private certManagerProps: addons.CertManagerAddOnProps;
     private cloudWatchInsightsAddOnProps: addons.CloudWatchInsightsAddOnProps;
     private coreDnsProps: addons.CoreDnsAddOnProps;
+    private CoreDnsVersion: string = "auto";
     private kubeProxyProps: addons.kubeProxyAddOnProps;
     private kubeProxyVersion: string = "auto";
     private kubeStateMetricsProps: addons.KubeStateMetricsAddOnProps;
@@ -31,7 +32,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.AwsLoadBalancerControllerAddOn(this.awsLoadbalancerProps),
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.CloudWatchInsights(this.cloudWatchInsightsAddOnProps),
-            new addons.CoreDnsAddOn(this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion,this.kubeProxyProps),
             new addons.KubeStateMetricsAddOn(this.kubeStateMetricsProps),
             new addons.MetricsServerAddOn(this.metricsServerProps),
@@ -46,7 +47,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.AwsLoadBalancerControllerAddOn(this.awsLoadbalancerProps),
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.AdotCollectorAddOn(this.adotCollectorProps),
-            new addons.CoreDnsAddOn(this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion, this.kubeProxyProps),
             new addons.KubeStateMetricsAddOn(this.kubeStateMetricsProps),
             new addons.MetricsServerAddOn(this.metricsServerProps));
@@ -62,7 +63,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.AwsLoadBalancerControllerAddOn(this.awsLoadbalancerProps),
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.AdotCollectorAddOn(this.adotCollectorProps),
-            new addons.CoreDnsAddOn(this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion, this.kubeProxyProps),
             new addons.KubeStateMetricsAddOn(this.kubeStateMetricsProps),
             new addons.MetricsServerAddOn(this.metricsServerProps),
@@ -79,7 +80,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.AdotCollectorAddOn(this.adotCollectorProps),
             new addons.AmpAddOn(this.ampProps),
-            new addons.CoreDnsAddOn(this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
             new addons.ExternalsSecretsAddOn(this.externalSecretProps),
             new addons.GrafanaOperatorAddon(this.grafanaOperatorProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion,this.kubeProxyProps),

--- a/lib/builders/observability-builder.ts
+++ b/lib/builders/observability-builder.ts
@@ -12,7 +12,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
     private certManagerProps: addons.CertManagerAddOnProps;
     private cloudWatchInsightsAddOnProps: addons.CloudWatchInsightsAddOnProps;
     private coreDnsProps: addons.CoreDnsAddOnProps;
-    private CoreDnsVersion: string = "auto";
+    private coreDnsVersion: string = "auto";
     private kubeProxyProps: addons.kubeProxyAddOnProps;
     private kubeProxyVersion: string = "auto";
     private kubeStateMetricsProps: addons.KubeStateMetricsAddOnProps;
@@ -32,7 +32,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.AwsLoadBalancerControllerAddOn(this.awsLoadbalancerProps),
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.CloudWatchInsights(this.cloudWatchInsightsAddOnProps),
-            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.coreDnsVersion,this.coreDnsProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion,this.kubeProxyProps),
             new addons.KubeStateMetricsAddOn(this.kubeStateMetricsProps),
             new addons.MetricsServerAddOn(this.metricsServerProps),
@@ -47,7 +47,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.AwsLoadBalancerControllerAddOn(this.awsLoadbalancerProps),
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.AdotCollectorAddOn(this.adotCollectorProps),
-            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.coreDnsVersion,this.coreDnsProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion, this.kubeProxyProps),
             new addons.KubeStateMetricsAddOn(this.kubeStateMetricsProps),
             new addons.MetricsServerAddOn(this.metricsServerProps));
@@ -63,7 +63,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.AwsLoadBalancerControllerAddOn(this.awsLoadbalancerProps),
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.AdotCollectorAddOn(this.adotCollectorProps),
-            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.coreDnsVersion,this.coreDnsProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion, this.kubeProxyProps),
             new addons.KubeStateMetricsAddOn(this.kubeStateMetricsProps),
             new addons.MetricsServerAddOn(this.metricsServerProps),
@@ -80,7 +80,7 @@ export class ObservabilityBuilder extends BlueprintBuilder {
             new addons.CertManagerAddOn(this.certManagerProps),
             new addons.AdotCollectorAddOn(this.adotCollectorProps),
             new addons.AmpAddOn(this.ampProps),
-            new addons.CoreDnsAddOn(this.CoreDnsVersion,this.coreDnsProps),
+            new addons.CoreDnsAddOn(this.coreDnsVersion,this.coreDnsProps),
             new addons.ExternalsSecretsAddOn(this.externalSecretProps),
             new addons.GrafanaOperatorAddon(this.grafanaOperatorProps),
             new addons.KubeProxyAddOn(this.kubeProxyVersion,this.kubeProxyProps),

--- a/test/amp.test.ts
+++ b/test/amp.test.ts
@@ -53,5 +53,5 @@ test("Stack creation fails due to ruleFilePaths.length == 0", async () => {
     catch (error){
         return;
     }
-    fail("Expected exception wasnt thrown for AMP Addon-on Rule Path test.")      
+    fail("Expected exception wasnt thrown for AMP Addon-on Rule Path test.");
 });

--- a/test/amp.test.ts
+++ b/test/amp.test.ts
@@ -45,8 +45,7 @@ test("Stack creation fails due to ruleFilePaths.length == 0", async () => {
                     ruleFilePaths: []
                 }
             })
-        );
-
+    );
     try {
         const stack = await blueprint.buildAsync(app, "amp-missing-rules");
         expect(stack).toBeDefined();

--- a/test/coredns.test.ts
+++ b/test/coredns.test.ts
@@ -1,32 +1,31 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
 import * as blueprints from '../lib';
 import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
-test("Coredns Addon deploying correct default version of Addon for 1.28", () => {
+test("Coredns Addon deploying correct default version of Addon for 1.28", async () => {
     const app = new cdk.App();
 
-    const stack = blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_28)
         .addOns(new blueprints.CoreDnsAddOn("auto"))
         .build(app, "coredns-stack-001");
 });
 
-test("Coredns Addon deploying correct default version of Addon for 1.27", () => {
+test("Coredns Addon deploying correct default version of Addon for 1.27", async () => {
     const app = new cdk.App();
 
-    const stack = blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_27)
         .addOns(new blueprints.CoreDnsAddOn("auto"))
         .build(app, "coredns-stack-002");
 });
 
-test("Coredns Addon deploying correct default version of Addon for 1.26", () => {
+test("Coredns Addon deploying correct default version of Addon for 1.26", async () => {
     const app = new cdk.App();
 
-    const stack = blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_26)
         .addOns(new blueprints.CoreDnsAddOn("auto"))

--- a/test/coredns.test.ts
+++ b/test/coredns.test.ts
@@ -1,0 +1,34 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as blueprints from '../lib';
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
+
+test("Coredns Addon deploying correct default version of Addon for 1.28", () => {
+    const app = new cdk.App();
+
+    const stack = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-2')
+        .version(KubernetesVersion.V1_28)
+        .addOns(new blueprints.CoreDnsAddOn("auto"))
+        .build(app, "coredns-stack-001");
+});
+
+test("Coredns Addon deploying correct default version of Addon for 1.27", () => {
+    const app = new cdk.App();
+
+    const stack = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-2')
+        .version(KubernetesVersion.V1_27)
+        .addOns(new blueprints.CoreDnsAddOn("auto"))
+        .build(app, "coredns-stack-002");
+});
+
+test("Coredns Addon deploying correct default version of Addon for 1.26", () => {
+    const app = new cdk.App();
+
+    const stack = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-2')
+        .version(KubernetesVersion.V1_26)
+        .addOns(new blueprints.CoreDnsAddOn("auto"))
+        .build(app, "coredns-stack-003");
+});

--- a/test/coredns.test.ts
+++ b/test/coredns.test.ts
@@ -9,7 +9,7 @@ test("Coredns Addon deploying correct default version of Addon for 1.28", async 
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_28)
         .addOns(new blueprints.CoreDnsAddOn("auto"))
-        .build(app, "coredns-stack-001");
+        .buildAsync(app, "coredns-stack-001");
 });
 
 test("Coredns Addon deploying correct default version of Addon for 1.27", async () => {
@@ -19,7 +19,7 @@ test("Coredns Addon deploying correct default version of Addon for 1.27", async 
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_27)
         .addOns(new blueprints.CoreDnsAddOn("auto"))
-        .build(app, "coredns-stack-002");
+        .buildAsync(app, "coredns-stack-002");
 });
 
 test("Coredns Addon deploying correct default version of Addon for 1.26", async () => {
@@ -29,5 +29,5 @@ test("Coredns Addon deploying correct default version of Addon for 1.26", async 
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_26)
         .addOns(new blueprints.CoreDnsAddOn("auto"))
-        .build(app, "coredns-stack-003");
+        .buildAsync(app, "coredns-stack-003");
 });

--- a/test/emr-eks.test.ts
+++ b/test/emr-eks.test.ts
@@ -43,16 +43,16 @@ const dataTeam: EmrEksTeamProps = {
     };
 
 const parentStack = blueprints.EksBlueprint.builder()
-        .version("auto")
-        .addOns(
-            new blueprints.MetricsServerAddOn,
-            new blueprints.ClusterAutoScalerAddOn,
-            new blueprints.AwsLoadBalancerControllerAddOn,
-            new blueprints.CertManagerAddOn,
-            new blueprints.EmrEksAddOn)
-        .teams(
-            new blueprints.EmrEksTeam(dataTeam))
-        .build(app, "test-emr-eks-blueprint");
+  .version("auto")
+  .addOns(
+      new blueprints.MetricsServerAddOn,
+      new blueprints.ClusterAutoScalerAddOn,
+      new blueprints.AwsLoadBalancerControllerAddOn,
+      new blueprints.CertManagerAddOn,
+      new blueprints.EmrEksAddOn)
+  .teams(
+      new blueprints.EmrEksTeam(dataTeam))
+  .build(app, "test-emr-eks-blueprint");
 
 const template = Template.fromStack(parentStack);
 

--- a/test/emr-eks.test.ts
+++ b/test/emr-eks.test.ts
@@ -45,14 +45,10 @@ const dataTeam: EmrEksTeamProps = {
 const parentStack = blueprints.EksBlueprint.builder()
         .version("auto")
         .addOns(
-            new blueprints.VpcCniAddOn(),
-            new blueprints.CoreDnsAddOn(),
             new blueprints.MetricsServerAddOn,
             new blueprints.ClusterAutoScalerAddOn,
             new blueprints.AwsLoadBalancerControllerAddOn,
             new blueprints.CertManagerAddOn,
-            new blueprints.EbsCsiDriverAddOn,
-            new blueprints.KubeProxyAddOn,
             new blueprints.EmrEksAddOn)
         .teams(
             new blueprints.EmrEksTeam(dataTeam))

--- a/test/kubeproxy.test.ts
+++ b/test/kubeproxy.test.ts
@@ -1,32 +1,31 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
 import * as blueprints from '../lib';
 import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
-test("Kubeproxy Addon deploying correct default version of Addon for 1.28", () => {
+test("Kubeproxy Addon deploying correct default version of Addon for 1.28", async () => {
     const app = new cdk.App();
 
-    const stack = blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_28)
         .addOns(new blueprints.KubeProxyAddOn("auto"))
         .build(app, "KubeProxy-stack-001");
 });
 
-test("Kubeproxy Addon deploying correct default version of Addon for 1.27", () => {
+test("Kubeproxy Addon deploying correct default version of Addon for 1.27", async () => {
     const app = new cdk.App();
 
-    const stack = blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_27)
         .addOns(new blueprints.KubeProxyAddOn("auto"))
         .build(app, "KubeProxy-stack-002");
 });
 
-test("Kubeproxy Addon deploying correct default version of Addon for 1.26", () => {
+test("Kubeproxy Addon deploying correct default version of Addon for 1.26", async () => {
     const app = new cdk.App();
 
-    const stack = blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_26)
         .addOns(new blueprints.KubeProxyAddOn("auto"))

--- a/test/kubeproxy.test.ts
+++ b/test/kubeproxy.test.ts
@@ -1,0 +1,34 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as blueprints from '../lib';
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
+
+test("Kubeproxy Addon deploying correct default version of Addon for 1.28", () => {
+    const app = new cdk.App();
+
+    const stack = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-2')
+        .version(KubernetesVersion.V1_28)
+        .addOns(new blueprints.KubeProxyAddOn("auto"))
+        .build(app, "KubeProxy-stack-001");
+});
+
+test("Kubeproxy Addon deploying correct default version of Addon for 1.27", () => {
+    const app = new cdk.App();
+
+    const stack = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-2')
+        .version(KubernetesVersion.V1_27)
+        .addOns(new blueprints.KubeProxyAddOn("auto"))
+        .build(app, "KubeProxy-stack-002");
+});
+
+test("Kubeproxy Addon deploying correct default version of Addon for 1.26", () => {
+    const app = new cdk.App();
+
+    const stack = blueprints.EksBlueprint.builder()
+        .account('123456789').region('us-west-2')
+        .version(KubernetesVersion.V1_26)
+        .addOns(new blueprints.KubeProxyAddOn("auto"))
+        .build(app, "KubeProxy-stack-003");
+});

--- a/test/kubeproxy.test.ts
+++ b/test/kubeproxy.test.ts
@@ -9,7 +9,7 @@ test("Kubeproxy Addon deploying correct default version of Addon for 1.28", asyn
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_28)
         .addOns(new blueprints.KubeProxyAddOn("auto"))
-        .build(app, "KubeProxy-stack-001");
+        .buildAsync(app, "KubeProxy-stack-001");
 });
 
 test("Kubeproxy Addon deploying correct default version of Addon for 1.27", async () => {
@@ -19,7 +19,7 @@ test("Kubeproxy Addon deploying correct default version of Addon for 1.27", asyn
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_27)
         .addOns(new blueprints.KubeProxyAddOn("auto"))
-        .build(app, "KubeProxy-stack-002");
+        .buildAsync(app, "KubeProxy-stack-002");
 });
 
 test("Kubeproxy Addon deploying correct default version of Addon for 1.26", async () => {
@@ -29,5 +29,5 @@ test("Kubeproxy Addon deploying correct default version of Addon for 1.26", asyn
         .account('123456789').region('us-west-2')
         .version(KubernetesVersion.V1_26)
         .addOns(new blueprints.KubeProxyAddOn("auto"))
-        .build(app, "KubeProxy-stack-003");
+        .buildAsync(app, "KubeProxy-stack-003");
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrade Core Addons to support MAP of Versions for Kubernetes versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
