### PR TITLE
feat: Amp AddOn - Update OTEL collector cluster role to support container logs collection

### DIFF
--- a/lib/addons/amp/collector-config-amp.ytpl
+++ b/lib/addons/amp/collector-config-amp.ytpl
@@ -1891,30 +1891,53 @@ metadata:
   name: otel-prometheus-role
   namespace: "{{namespace}}"
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - nodes/proxy
-      - services
-      - endpoints
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods/logs
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  - events
+  - namespaces/status
+  - nodes/spec
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the clusterRole that Amp AddOn creates to support ADOT container logs collection. Without these updates logs collection will not work for all namespaces and pods. These updates are based on container logs collection working example found at https://github.com/lewinkedrs/cop-401-instrumentation/blob/f970e59a55ef042a885423f6201602bd91ee5336/python-manual-instrumentation-sample-app/prometheus-daemonset.yaml#L181

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
