### PR TITLE
(karpenter add-on) Blocked Device Mapping EBS Volume Size type issue fix

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -127,9 +127,6 @@ export default class BlueprintConstruct {
                     value: "test",
                     effect: "NoSchedule",
                 }],
-                amiSelector: {
-                    "karpenter.sh/discovery/MyClusterName": '*',
-                },
                 consolidation: { enabled: true },
                 ttlSecondsUntilExpired: 2592000,
                 weight: 20,
@@ -142,7 +139,18 @@ export default class BlueprintConstruct {
                 },
                 tags: {
                     schedule: 'always-on'
-                }
+                },
+                blockDeviceMappings: [{
+                    deviceName: "/dev/xvda",
+                    ebs: {
+                        deleteOnTermination: true,
+                        iops: 3000,
+                        volumeSize: "100Gi",
+                        volumeType: ec2.EbsDeviceVolumeType.GP3,
+                        throughput: 250,
+                        encrypted: true,
+                    },
+                }]
             }),
             new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
             new blueprints.addons.KubeviousAddOn(),

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -26,7 +26,7 @@ export interface EbsVolumeMapping {
     deleteOnTermination?: boolean;
     iops?: number;
     snapshotId?: string;
-    volumeSize?: number;
+    volumeSize?: string;
     volumeType?: EbsDeviceVolumeType;
     kmsKeyId?: string;
     throughput?: number;

--- a/test/karpenter.test.ts
+++ b/test/karpenter.test.ts
@@ -161,7 +161,7 @@ describe('Unit tests for Karpenter addon', () => {
         const blueprint = blueprints.EksBlueprint.builder();
 
         const ebsVolumeMapping: EbsVolumeMapping = {
-            volumeSize: 20,
+            volumeSize: "20Gi",
             volumeType: EbsDeviceVolumeType.GP3,
             deleteOnTermination: true,
         };


### PR DESCRIPTION
*Issue #, if available:* #899 #914

*Description of changes:*
Volume Size on Blocked Device Mapping was mistyped. This PR addresses it, with the right test implementation under `examples`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
