### PR TITLE
Fix for Bug#921:Load balancer controller warning message incomplete

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -69,7 +69,7 @@ const defaultProps: AwsLoadBalancerControllerProps = {
 
 function lookupImage(registry?: string, region?: string): Values {
     if (registry == null) {
-        console.log("Unable to get ECR repository for AWS Loadbalancer Controller for region " + region) + ". Using default helm image";
+        console.log("Unable to get ECR repository for AWS Loadbalancer Controller for region " + region + ". Using default helm image");
         return {};
     }
 


### PR DESCRIPTION
*Issue #, if available:* 921 : AWS Loadbalancer Controller: Warning message incomplete due to code bug

*Description of changes:*
Updated the location of the closing braces to display the complete warning message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
