### PR TITLE
Ack addon must support inline policies for EKS

### DIFF
--- a/lib/addons/ack/index.ts
+++ b/lib/addons/ack/index.ts
@@ -91,7 +91,7 @@ export class AckAddOn extends HelmAddOn {
       sa.role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName(this.options.managedPolicyName!));
     }
     if (this.options.inlinePolicyStatements && this.options.inlinePolicyStatements.length > 0) {
-      sa.role.attachInlinePolicy(new Policy(cluster.stack, "inline-policy", {
+      sa.role.attachInlinePolicy(new Policy(cluster.stack, `${this.options.chart}-inline-policy`, {
         statements: this.options.inlinePolicyStatements
       }));
     }

--- a/lib/addons/ack/serviceMappings.ts
+++ b/lib/addons/ack/serviceMappings.ts
@@ -1,10 +1,13 @@
+import {PolicyStatement} from "aws-cdk-lib/aws-iam";
+
 /**
  * Chart Mapping for fields such as chart, version, managed IAM policy.
  */
 export interface AckChartMapping {
     chart: string,
     version: string,
-    managedPolicyName: string
+    managedPolicyName?: string
+    inlinePolicyStatements?: PolicyStatement[]
 }
 
 /**
@@ -125,7 +128,16 @@ export const serviceMappings : {[key in AckServiceName]?: AckChartMapping } = {
     [AckServiceName.EKS]: {
       chart: "eks-chart",
       version:  "1.0.5",
-      managedPolicyName: "AmazonEKSClusterPolicy"
+      managedPolicyName: "AmazonEKSClusterPolicy",
+      inlinePolicyStatements: [PolicyStatement.fromJson({
+        "Effect": "Allow",
+        "Action": [
+          "eks:*",
+          "iam:GetRole",
+          "iam:PassRole"
+        ],
+        "Resource": "*"
+      })]
     },
     [AckServiceName.APPLICATIONAUTOSCALING]: {
       chart: "applicationautoscaling-chart",

--- a/lib/addons/ack/serviceMappings.ts
+++ b/lib/addons/ack/serviceMappings.ts
@@ -128,7 +128,6 @@ export const serviceMappings : {[key in AckServiceName]?: AckChartMapping } = {
     [AckServiceName.EKS]: {
       chart: "eks-chart",
       version:  "1.0.5",
-      managedPolicyName: "AmazonEKSClusterPolicy",
       inlinePolicyStatements: [PolicyStatement.fromJson({
         "Effect": "Allow",
         "Action": [


### PR DESCRIPTION
*Description of changes:*
The EKS ack controller doesn't have a recommended managed policy, only an inline one, and the currently provided managed policy in blueprints doesn't seem to give any eks permissions, nor does any other managed policy seem to be appropriate. The best option is to support inline policies. There may be other ack controllers with similar issues, but EKS is the one I'm aware of.

Also, this file appeared to have CRLF, so I've converted it to LF to match the rest of the project - I suggest viewing the diff without whitespace


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
