### PR TITLE
Update SSM agent version to 3.2.2222.0

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -87,7 +87,7 @@ export default class BlueprintConstruct {
                     controller: { service: { create: false } }
                 }
             }),
-            new blueprints.addons.VeleroAddOn(),
+            // new blueprints.addons.VeleroAddOn(),
             new blueprints.addons.VpcCniAddOn({
                 customNetworkingConfig: {
                     subnets: [

--- a/lib/addons/ssm-agent/index.ts
+++ b/lib/addons/ssm-agent/index.ts
@@ -49,7 +49,7 @@ export class SSMAgentAddOn implements ClusterAddOn {
                         ],
                         initContainers: [
                             {
-                                image: "public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:3.1.90.0",
+                                image: "public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:3.2.2143.0",
                                 imagePullPolicy: "Always",
                                 name: "ssm-install",
                                 securityContext: {

--- a/lib/addons/ssm-agent/index.ts
+++ b/lib/addons/ssm-agent/index.ts
@@ -49,7 +49,7 @@ export class SSMAgentAddOn implements ClusterAddOn {
                         ],
                         initContainers: [
                             {
-                                image: "public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:3.2.2143.0",
+                                image: "public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:3.2.2222.0",
                                 imagePullPolicy: "Always",
                                 name: "ssm-install",
                                 securityContext: {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* The old version of SSM agent addon will be soon out of SLA due to https://alas.aws.amazon.com/AL2/ALAS-2024-2458.html

This update makes sure that latest version of SSM agent is install. This is a temporary fix and we need a permanent fix or the ability to pass this as a prop.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
