### PR TITLE
Added configuration value enableWindowsIpam for Vpc-cni add on

### DIFF
--- a/docs/addons/vpc-cni.md
+++ b/docs/addons/vpc-cni.md
@@ -185,7 +185,14 @@ False
 For example:
 ```typescript
 new blueprints.addons.VpcCniAddOn({ enableNetworkPolicy: true, version: 'v1.15.0-eksbuild.2' }) 
+
 ```  
+   - enableWindowsIpam - set to `true` enables Windows support for EKS cluster. 
+
+For example:
+```typescript
+new blueprints.addons.VpcCniAddOn({ enableWindowsIpam: true, version: 'v1.15.0-eksbuild.2' }) 
+``` 
 
 # Validation
 To validate that vpc-cni add-on is running, ensure that the pod is in Running state.

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -290,9 +290,16 @@ export interface VpcCniAddOnProps {
   enableNetworkPolicy?: boolean;
 
   /**
+   * Enable windows support for your cluster
+   * 
+   */
+  enableWindowsIpam?: boolean;
+
+  /**
    * Version of the add-on to use. Must match the version of the cluster where it
    * will be deployed.
    */
+
   version?: string;
 }
 
@@ -436,7 +443,8 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       WARM_IP_TARGET: props?.warmIpTarget,
       WARM_PREFIX_TARGET: props?.warmPrefixTarget,
     },
-    enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy)
+    enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
+    enableWindowsIpam:JSON.stringify(props?.enableWindowsIpam)
   };
 
   // clean up all undefined

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -444,7 +444,7 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       WARM_PREFIX_TARGET: props?.warmPrefixTarget,
     },
     enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
-    enableWindowsIpam:JSON.stringify(props?.enableWindowsIpam)
+    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam)
   };
 
   // clean up all undefined


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added and exposed the configuration for "enableWindowsIpam" for the vpc-cni add on. This will allow to turn on the configuration value for Windows EKS clusters while using the Windows patterns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
