### PR TITLE
feat(SecretProviderClass): add support for objectAlias

### DIFF
--- a/docs/addons/secrets-store.md
+++ b/docs/addons/secrets-store.md
@@ -69,6 +69,24 @@ const blueprint = blueprints.EksBlueprint.builder()
 
 The AWS Secrets Manger and Config Provider provides compatibility for legacy applications that access secrets as mounted files in the pod. Security conscious applications should use the native AWS APIs to fetch secrets and optionally cache them in memory rather than storing them in the file system.
 
+## Renaming Mounted Kubernetes Secrets
+
+By default, mounted Kubernetes Secrets inherit the name of their corresponding AWS Secret or SSM Parameter. If the AWS Secret or Parameter name contains slashes ("/" or "\"), they will be replaced by underscores by the CSI Driver.  
+
+This can result in undesirable secret names being mounted to your pods, so as a workaround the driver also offers an aliasing feature.
+
+```typescript
+{
+    secretProvider: new blueprints.LookupSsmSecretByAttrs('/path/to/my/parameter', 1),
+    kubernetesSecret: {
+        secretName: 'my_parameter', // not respected when mounting the secret directly to the pod, and will result in sync errors during pod init
+        secretAlias: 'my_parameter', // respected during mounting. File will be called "my_parameter" instead of "_path_to_my_parameter"
+    }
+}
+```
+
+NOTE: `secretAlias` is only applicable to secrets that are **mounted** to a pod. In these scenarios, `secretName` should match the name of the Secret or Parameter in AWS.
+
 ## Example
 
 After the Blueprint stack is deployed you can test consuming the secret from within a `deployment`.

--- a/lib/addons/secrets-store/csi-driver-provider-aws-secrets.ts
+++ b/lib/addons/secrets-store/csi-driver-provider-aws-secrets.ts
@@ -108,10 +108,12 @@ function createParameterObject(csiSecret: CsiSecretProps, secretName: string, se
     const result: ParameterObject = {
         objectName: secretName,
         objectType: secretType,
-        objectAlias: secretAlias,
     };
     if (csiSecret.jmesPath) {
         result.jmesPath = csiSecret.jmesPath;
+    }
+    if (secretAlias) {
+        result.objectAlias = secretAlias;
     }
     return result;
 }

--- a/test/secretproviderclass.test.ts
+++ b/test/secretproviderclass.test.ts
@@ -1,0 +1,46 @@
+import * as cdk from "aws-cdk-lib";
+import * as blueprints from "../lib";
+import {
+    ClusterAddOn,
+    ClusterInfo,
+    GenerateSecretManagerProvider,
+    SecretProviderClass,
+    SecretsStoreAddOn
+} from "../lib";
+import {ServiceAccount} from "aws-cdk-lib/aws-eks";
+
+class TestSecretAddon implements ClusterAddOn {
+    public deploy(clusterInfo: ClusterInfo): void {
+        const sa = new ServiceAccount(clusterInfo.cluster.stack, "sa", {name: "acme-sa", cluster: clusterInfo.cluster});
+        new SecretProviderClass(clusterInfo, sa, "acme-aws-secrets",
+            {
+                secretProvider: new GenerateSecretManagerProvider("acme-secret", "real-secret-name"),
+                kubernetesSecret: {
+                    secretName: "real-secret-name",
+                    secretAlias: "aliased-secret-name",
+                }
+            }
+        );
+    }
+}
+describe('Unit tests for SecretProviderClass', () => {
+
+    test("SecretProviderClass contains objectAlas when configured.", async () => {
+
+        const app = new cdk.App();
+        const stack = new blueprints.EksBlueprint(app, {
+            id: 'MySecretTestStack',
+            version: "auto",
+            addOns: [
+                new SecretsStoreAddOn(),
+                new TestSecretAddon(),
+            ],
+            });
+
+        const stackResolved = await stack.waitForAsyncTasks();
+        const template = app.synth().getStackArtifact(stackResolved.artifactId).template;
+        const stringTemplate = JSON.stringify(template);
+        const expectedSubstring = "\\\\\\\"objectAlias\\\\\\\":\\\\\\\"aliased-secret-name\\\\\\";
+        expect(stringTemplate).toContain(expectedSubstring);
+    });
+});

--- a/test/secretproviderclass.test.ts
+++ b/test/secretproviderclass.test.ts
@@ -23,6 +23,7 @@ class TestSecretAddon implements ClusterAddOn {
         );
     }
 }
+
 describe('Unit tests for SecretProviderClass', () => {
 
     test("SecretProviderClass contains objectAlas when configured.", async () => {


### PR DESCRIPTION
*Issue #, if available:*

Closes #939 

*Description of changes:*

Adds support for the `objectAlias` parameter via the `secretAlias?` input. This input lives next to `secretName` and allows for the name of the kubernetes secret to differ from the name of the AWS Secret or SSM Parameter it is sourced from.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
