### PR TITLE
Fix ADOT Versions

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -63,7 +63,7 @@ export default class BlueprintConstruct {
             new blueprints.addons.PrometheusNodeExporterAddOn(),
             new blueprints.addons.AdotCollectorAddOn({
                 namespace:'adot',
-                version: 'v0.88.0-eksbuild.2'
+                version: 'auto'
             }),
             new blueprints.addons.AmpAddOn({
                 ampPrometheusEndpoint: ampWorkspace.attrPrometheusEndpoint,

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -47,12 +47,6 @@ export class AdotCollectorAddOn extends CoreAddOn {
     }
     @dependable(CertManagerAddOn.name)
     deploy(clusterInfo: ClusterInfo): Promise<Construct>  {
-        if (semverComparator("0.88",this.coreAddOnProps.version)) {
-            console.log("Used Adot Addon Version is Valid");
-        } 
-        else {
-            throw new Error(`Adot Addon Version is not Valid and greater than 0.88.0`);
-        }
         
         const addOnPromise = super.deploy(clusterInfo);
         return addOnPromise;

--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -5,7 +5,6 @@ import { createNamespace, dependable, loadYaml, readYamlDocument, supportsALL } 
 import { CertManagerAddOn } from "../cert-manager";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { getAdotCollectorPolicyDocument } from "./iam-policy";
-import { semverComparator } from "../helm-addon/helm-version-checker";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([

--- a/lib/builders/windows-builder.ts
+++ b/lib/builders/windows-builder.ts
@@ -195,7 +195,7 @@ export class WindowsBuilder extends BlueprintBuilder {
     public enableKarpenter(): WindowsBuilder {
         return this.addOns(
             new addons.KarpenterAddOn(this.karpenterProps)
-        )
+        );
     }
 
     public withKarpenterProps(props:addons.KarpenterAddOnProps) : this {
@@ -249,7 +249,7 @@ function getInstanceType(nodegroupOptions: eks.NodegroupOptions, windowsOptions:
 function buildGenericNodeGroup(options: WindowsOptions, overrideOptions?: eks.NodegroupOptions): clusterproviders.ManagedNodeGroup {
 
     let currentOptions = options.genericNodeGroupOptions;
-    if ( overrideOptions ) { currentOptions = merge(options.genericNodeGroupOptions, overrideOptions) }
+    if ( overrideOptions ) { currentOptions = merge(options.genericNodeGroupOptions, overrideOptions); }
 
     return {
         id: currentOptions.nodegroupName || "",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
kubectl get all -n adot
NAME                                                 READY   STATUS    RESTARTS   AGE
pod/otel-collector-amp-collector-5db7c94fbd-kg2mp    1/1     Running   0          9m44s
pod/otel-collector-xray-collector-858f4c5454-5r8qk   1/1     Running   0          9m45s

NAME                                               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
service/otel-collector-amp-collector-monitoring    ClusterIP   172.20.135.254   <none>        8888/TCP            9m44s
service/otel-collector-xray-collector              ClusterIP   172.20.159.154   <none>        4317/TCP,4318/TCP   9m45s
service/otel-collector-xray-collector-headless     ClusterIP   None             <none>        4317/TCP,4318/TCP   9m45s
service/otel-collector-xray-collector-monitoring   ClusterIP   172.20.77.89     <none>        8888/TCP            9m45s

NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/otel-collector-amp-collector    1/1     1            1           9m44s
deployment.apps/otel-collector-xray-collector   1/1     1            1           9m45s

NAME                                                       DESIRED   CURRENT   READY   AGE
replicaset.apps/otel-collector-amp-collector-5db7c94fbd    1         1         1       9m45s
replicaset.apps/otel-collector-xray-collector-858f4c5454   1         1         1       9m46s
░▒▓    ~/WorkDocsDownloads/AWS_Internal/Containers/cdk-eks-blueprints    fix/adotVersion ▓▒░                         ░▒▓ 4s   blueprint-construct-dev ⎈  18:07:47  ▓▒░─╮

^C
░▒▓    ~/WorkDocsDownloads/AWS_Internal/Containers/cdk-eks-blueprints    fix/adotVersion ▓▒░                        ░▒▓ INT ✘  blueprint-construct-dev ⎈  18:08:02  ▓▒░─╮
❯
─╯
kubectl get all -n opentelemetry-operator-system
NAME                                          READY   STATUS    RESTARTS   AGE
pod/opentelemetry-operator-767c6c87d8-vptqc   2/2     Running   0          2m11s

NAME                                     TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
service/opentelemetry-operator           ClusterIP   172.20.214.55   <none>        8443/TCP,8080/TCP   10m
service/opentelemetry-operator-webhook   ClusterIP   172.20.83.176   <none>        443/TCP             10m

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/opentelemetry-operator   1/1     1            1           10m

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/opentelemetry-operator-6785bf4fc7   0         0         0       10m
replicaset.apps/opentelemetry-operator-767c6c87d8   1         1         1       2m12s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
