### PR TITLE
feat (Karpenter Add-on): v0.35 update, Node Role custom policies, and other fixes

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -14,6 +14,8 @@ const rikerManifestDir = './examples/teams/team-riker/';
 const teamManifestDirList = [burnhamManifestDir, rikerManifestDir];
 const blueprintID = 'blueprint-construct-dev';
 
+const karpenterNodeRolePoliciesDir = './examples/policies/karpenter/';
+
 export interface BlueprintConstructProps {
     /**
      * Id
@@ -148,6 +150,7 @@ export default class BlueprintConstruct {
                 nodePoolSpec: nodePoolSpec,
                 ec2NodeClassSpec: nodeClassSpec,
                 interruptionHandling: true,
+                nodeRoleAdditionalPoliciesDir: karpenterNodeRolePoliciesDir
             }),
             new blueprints.addons.AwsNodeTerminationHandlerAddOn(),
             new blueprints.addons.KubeviousAddOn(),

--- a/examples/policies/karpenter/node-role-efs-policy.json
+++ b/examples/policies/karpenter/node-role-efs-policy.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "elasticfilesystem:ClientWrite",
+            "Resource": "*",
+            "Condition": {
+                "DateGreaterThan": {"aws:CurrentTime": "2024-02-01T00:00:00Z"},
+                "DateLessThan": {"aws:CurrentTime": "2024-06-30T23:59:59Z"}
+            }
+        }
+    ]
+}

--- a/examples/policies/karpenter/node-role-s3-policy.json
+++ b/examples/policies/karpenter/node-role-s3-policy.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+                "DateGreaterThan": {"aws:CurrentTime": "2024-02-01T00:00:00Z"},
+                "DateLessThan": {"aws:CurrentTime": "2024-06-30T23:59:59Z"}
+            }
+        }
+    ]
+}

--- a/lib/utils/yaml-utils.ts
+++ b/lib/utils/yaml-utils.ts
@@ -1,8 +1,27 @@
 import * as eks from 'aws-cdk-lib/aws-eks';
 import { KubernetesManifest } from 'aws-cdk-lib/aws-eks';
+import { PolicyDocument } from 'aws-cdk-lib/aws-iam';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
+/**
+ * Creates a list of PolicyDocuments for every JSON file in a directory
+ * @param dir Directory path to the JSON files.
+ * @returns List of PolicyDocument objects.
+ */
+export function createPolicyDocuments(dir: string): PolicyDocument[] {
+    const policyDocuments: PolicyDocument[] = [];
+    fs.readdirSync(dir, { encoding: 'utf8' }).forEach((file, _) => {
+        if (file.split('.').pop() == 'json') {
+            const data = fs.readFileSync(dir + file, 'utf8');
+            if (data != undefined) {
+                const policyDocument = PolicyDocument.fromJson(JSON.parse(data));
+                policyDocuments.push(policyDocument);
+            }
+        }
+    });
+    return policyDocuments;
+}
 
 /**
  * Applies all manifests from a directory. Note: The manifests are not checked, 

--- a/test/karpenter/policy.json
+++ b/test/karpenter/policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:* Fixes #859 #893 #945

*Description of changes:*
 
This PR makes the following changes in the Karpenter Add-on:
- Update to v0.35
- Ability to use a directory of IAM policy JSONs to add custom policies to the Karpenter Node Role, in addition to the required policies
- Remove EKS CNI policy if the VPC CNI addon is in the cluster
- Fixes minor error on `instanceStorePolicy` under EC2NodeClass not setting correctly when not provided.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
