### PR TITLE
Cluster Autoscaler fails when installing in new namespace. Fixes #957

### DIFF
--- a/examples/monorepo/lib/pipeline.ts
+++ b/examples/monorepo/lib/pipeline.ts
@@ -28,7 +28,7 @@ export function build(app: App) {
         .repository({
             repoUrl: 'cdk-eks-blueprints',
             credentialsSecretName: 'github-token',
-            targetRevision: 'bug/broken-monorepo-pipelines',
+            targetRevision: 'main',
             path: "examples/monorepo",
             trigger: blueprints.GitHubTrigger.POLL
         })

--- a/lib/addons/cluster-autoscaler/index.ts
+++ b/lib/addons/cluster-autoscaler/index.ts
@@ -108,14 +108,15 @@ export class ClusterAutoScalerAddOn extends HelmAddOn {
             Tags.of(ng).add("k8s.io/cluster-autoscaler/enabled", "true", { applyToLaunchedInstances: true });
         }
         
-        // Create namespace
-        if (this.options.createNamespace) {
-            createNamespace(namespace, cluster, true);
-        }
-
         // Create IRSA
         const sa = createServiceAccount(cluster, RELEASE, namespace, autoscalerPolicyDocument);
 
+        // Create namespace
+        if (this.options.createNamespace) {
+            const ns = createNamespace(namespace, cluster, true);
+            sa.node.addDependency(ns);
+        }
+    
         // Create Helm Chart
         setPath(values, "cloudProvider", "aws");
         setPath(values, "autoDiscovery.clusterName", cluster.clusterName);


### PR DESCRIPTION
*Issue #, if available:* #957

*Description of changes:* dependency fixed. Pending manual e2e tests as this addon conflicts with Karpenter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
