### PR TITLE
chore(docs): use correct path to bedrock-team.md

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ nav:
     - Teams: 'teams/teams.md'
     - EMR on EKS Team: 'teams/emr-eks-team.md'
     - AWS Batch on EKS Team: 'teams/aws-batch-on-eks-team.md'
-    - Bedrock Team: 'teams/geneai-team/bedrock-team.md'
+    - Bedrock Team: 'teams/bedrock-team.md'
   - Pipelines: 'pipelines.md'
   - AddOns:
     - Overview: 'addons/index.md'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Resolves an issue with the mkdocs config that was causing the Bedrock Team page to render incorrectly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
