### PR TITLE
[addons/karpenter] Covers the use of KubernetesVersion.of('1.28') syntax to get a KubernetesVersion

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -14,15 +14,23 @@ import { Rule } from 'aws-cdk-lib/aws-events';
 import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import { Cluster, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
-const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_29, '0.34.0'],
-    [KubernetesVersion.V1_28, '0.31.0'],
-    [KubernetesVersion.V1_27, '0.28.0'],
-    [KubernetesVersion.V1_26, '0.28.0'],
-    [KubernetesVersion.V1_25, '0.25.0'],
-    [KubernetesVersion.V1_24, '0.21.0'],
-    [KubernetesVersion.V1_23, '0.21.0'],
-]);
+class versionMap {
+    private static readonly versionMap: Map<string, string> = new Map([
+        [KubernetesVersion.V1_29.version, '0.34.0'],
+        [KubernetesVersion.V1_28.version, '0.31.0'],
+        [KubernetesVersion.V1_27.version, '0.28.0'],
+        [KubernetesVersion.V1_26.version, '0.28.0'],
+        [KubernetesVersion.V1_25.version, '0.25.0'],
+        [KubernetesVersion.V1_24.version, '0.21.0'],
+        [KubernetesVersion.V1_23.version, '0.21.0'],
+    ]);
+    public static has(version: KubernetesVersion) {
+      return this.versionMap.has(version.version);
+    }
+    public static get(version: KubernetesVersion) {
+      return this.versionMap.get(version.version);
+    }
+  }
 
 /**
  * Utility type for Karpenter requirement values for NodePools


### PR DESCRIPTION
*Issue #, if available:* #976

*Description of changes:* This is a test that reproduce the problem I faced in #976, I'll look at possible solution next. It's currently failing (hence the bug). Let me know if you think that is wrong.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
