### PR TITLE
[Karpenter] Fix ignored namespace prop

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -432,8 +432,8 @@ export class KarpenterAddOn extends HelmAddOn {
         }
 
         // Create Namespace
-        const ns = utils.createNamespace(KARPENTER, cluster, true, true);
-        const sa = utils.createServiceAccount(cluster, RELEASE, KARPENTER, karpenterPolicyDocument);
+        const ns = utils.createNamespace(this.options.namespace!, cluster, true, true);
+        const sa = utils.createServiceAccount(cluster, RELEASE, this.options.namespace!, karpenterPolicyDocument);
         sa.node.addDependency(ns);
 
         // Create global helm values based on v1beta1 migration as shown below:


### PR DESCRIPTION
I've stumbled across a bug while installing karpenter: I can set the namespace in the KarpenterAddOnProps, but the createNamespace() and createServiceAccount() functions would still use the default variable as their namespace.