### PR TITLE
Fix: allow to extend configurations of AWS LB controller and EBS CSI driver.

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -118,6 +118,7 @@ export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
             region: clusterInfo.cluster.stack.region,
             ...image,
             vpcId: clusterInfo.cluster.vpc.vpcId,
+            ...this.options.values,
         }, undefined, false);
 
         awsLoadBalancerControllerChart.node.addDependency(serviceAccount);

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -58,6 +58,7 @@ export class EbsCsiDriverAddOn extends CoreAddOn {
       version: options?.version ?? defaultProps.version,
       versionMap: defaultProps.versionMap,
       saName: defaultProps.saName,
+      configurationValues: options?.configurationValues,
     });
 
     this.ebsProps = {


### PR DESCRIPTION
*Issue #, if available:*

This PR resolve:

- issue #968 - allow to extend LB controller with helm values.
- issue #995 - allow ebs-csi-controller to have custom configurationValues.

*Description of changes:*

These change have been tested on my current deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
