### PR TITLE
Add FluxCD support for S3 Bucket sources

### DIFF
--- a/docs/addons/fluxcd.md
+++ b/docs/addons/fluxcd.md
@@ -6,6 +6,8 @@ Flux is a declarative, GitOps-based continuous delivery tool that can be integra
 
 ## Usage
 
+Only specify unique values for the repository and bucket `name` field.
+
 ### Single bootstrap repo path
 
 ```typescript
@@ -66,6 +68,42 @@ const blueprint = blueprints.EksBlueprint.builder()
     .addOns(addOn)
     .build(app, 'my-stack-name');
 ```
+
+### Single bootstrap S3 bucket repository
+
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
+const app = new cdk.App();
+
+const fluxBootstrap = new s3.Bucket(this, "FluxBootstrap", {
+    removalPolicy: cdk.RemovalPolicy.RETAIN,
+});
+
+const addOn = new blueprints.addons.FluxCDAddOn({
+    buckets: [{
+        name: "bootstrap-bucket",
+        namespace: "flux-system",
+        repository: {
+            repoUrl: fluxBootstrap.bucketName,
+        },
+        bucketRegion: cdk.Aws.REGION,
+        values: {},
+    }],
+})
+...
+
+const blueprint = blueprints.EksBlueprint.builder()
+  .addOns(addOn)
+  .build(app, 'my-stack-name');
+```
+
+By default the FluxCD source-controller attempts to access the S3 bucket by using the IAM instance profile.
+To grant access assign node group instances IAM role granting read access to the S3 bucket.
+Alternatively reference to a Secret containing the `accesskey` and `secretkey` values with the `secretRef` parameter to authenticate using IAM user authentication.
+See [FluxCD Bucket Source Controller documentation](https://fluxcd.io/flux/components/source/buckets/).
 
 ## Workload Repositories
 

--- a/docs/addons/fluxcd.md
+++ b/docs/addons/fluxcd.md
@@ -85,7 +85,6 @@ const fluxBootstrap = new s3.Bucket(this, "FluxBootstrap", {
 const addOn = new blueprints.addons.FluxCDAddOn({
     buckets: [{
         name: "bootstrap-bucket",
-        namespace: "flux-system",
         bucketName: fluxBootstrap.bucketName,
         bucketRegion: cdk.Aws.REGION,
     }],

--- a/docs/addons/fluxcd.md
+++ b/docs/addons/fluxcd.md
@@ -86,11 +86,8 @@ const addOn = new blueprints.addons.FluxCDAddOn({
     buckets: [{
         name: "bootstrap-bucket",
         namespace: "flux-system",
-        repository: {
-            repoUrl: fluxBootstrap.bucketName,
-        },
+        bucketName: fluxBootstrap.bucketName,
         bucketRegion: cdk.Aws.REGION,
-        values: {},
     }],
 })
 ...

--- a/lib/addons/fluxcd/bucket.ts
+++ b/lib/addons/fluxcd/bucket.ts
@@ -6,7 +6,7 @@ import { setPath } from "../../utils";
  */
 export class FluxBucket {
 
-    constructor(private readonly bucketName: string, private readonly region: string, private readonly bucketPrefix?: string) {}
+    constructor(private readonly bucketName: string, private readonly region: string, private readonly prefixPath?: string) {}
 
     public generate(name: string, namespace: string, fluxSyncInterval: string, provider: string, endpoint: string, fluxSecretRefName?: string) {
 
@@ -30,8 +30,8 @@ export class FluxBucket {
             setPath(bucketManifest, "spec.secretRef.name", fluxSecretRefName);
         }
 
-        if (this.bucketPrefix) {
-            setPath(bucketManifest, "spec.prefix", this.bucketPrefix);
+        if (this.prefixPath) {
+            setPath(bucketManifest, "spec.prefix", this.prefixPath);
         }
 
         return bucketManifest;

--- a/lib/addons/fluxcd/bucket.ts
+++ b/lib/addons/fluxcd/bucket.ts
@@ -1,0 +1,39 @@
+import { setPath } from "../../utils";
+
+/**
+ * Flux Bucket API defines a Source to produce an Artifact for objects from storage solutions like Amazon S3.
+ * @see https://fluxcd.io/flux/components/source/buckets/
+ */
+export class FluxBucket {
+
+    constructor(private readonly bucketName: string, private readonly region: string, private readonly bucketPrefix?: string) {}
+
+    public generate(name: string, namespace: string, fluxSyncInterval: string, provider: string, endpoint: string, fluxSecretRefName?: string) {
+
+        const bucketManifest =  {
+            apiVersion: "source.toolkit.fluxcd.io/v1beta2",
+            kind: "Bucket",
+            metadata: {
+                name: name,
+                namespace: namespace
+            },
+            spec: {
+                interval: fluxSyncInterval,
+                bucketName: this.bucketName,
+                provider: provider,
+                endpoint: endpoint,
+                region: this.region,
+            }
+        };
+
+        if (fluxSecretRefName) {
+            setPath(bucketManifest, "spec.secretRef.name", fluxSecretRefName);
+        }
+
+        if (this.bucketPrefix) {
+            setPath(bucketManifest, "spec.prefix", this.bucketPrefix);
+        }
+
+        return bucketManifest;
+    }
+}

--- a/lib/addons/fluxcd/index.ts
+++ b/lib/addons/fluxcd/index.ts
@@ -7,6 +7,7 @@ import { createNamespace, supportsALL } from "../../utils";
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from "../helm-addon";
 import { FluxGitRepository } from "./gitrepository";
 import { FluxKustomization } from "./kustomization";
+import { FluxBucket } from './bucket';
 import { KubernetesManifest } from 'aws-cdk-lib/aws-eks/lib/k8s-manifest';
 
 /**
@@ -14,44 +15,94 @@ import { KubernetesManifest } from 'aws-cdk-lib/aws-eks/lib/k8s-manifest';
  * path and name parameter within repository parameter do not have any affect in flux, may have an affect in argo
  */
 export interface FluxGitRepo extends Required<spi.GitOpsApplicationDeployment> {
-  /** 
-  * Flux SecretRef */
-  secretRefName?: string;
+    /** 
+     * Flux SecretRef
+     */
+    secretRefName?: string;
 
-  /** 
-  * Internal for Flux sync.
-  * Default `5m0s` */
-  syncInterval?: string;
+    /** 
+     * Internal for Flux sync.
+     * Default `5m0s`
+     */
+    syncInterval?: string;
 
-  /**
-  * List of kustomizations to create from different paths in repo. */
-  kustomizations?: FluxKustomizationProps[];
+    /**
+     * List of kustomizations to create from different paths in repo
+     */
+    kustomizations?: FluxKustomizationProps[];
+}
+
+/**
+ * Options for a FluxCD Bucket.
+ * `repoUrl` is the S3 bucket name,
+ * `path` is an optional prefix path and is used server-side filtering, and
+ * `targetRevision` has no effect
+ */
+export interface FluxBucketRepo extends Required<spi.GitOpsApplicationDeployment> {
+    /**
+     * Source S3 Bucket region
+     */
+    bucketRegion: string;
+
+    /** 
+     * References to a Secret containing `accesskey` and `secretkey` fields to authenticate as an IAM user (optional) 
+     * Default to authentication using the IAM instance profile
+     */
+    secretRefName?: string;
+
+    /** 
+     * Syncronization time interval for Flux sync
+     * Default `5m0s`
+     */
+    syncInterval?: string;
+
+    /**
+     * Override S3 Bucket endpoint (optional)
+     * Default `s3.amazonaws.com`
+     */
+    endpoint?: string;
+
+    /**
+     * Override S3 Bucket provider (optional)
+     * Default `aws`
+     */
+    provider?: string;
+
+    /**
+     * List of kustomizations to create from different paths in repo (optional)
+     */
+    kustomizations?: FluxKustomizationProps[];
 }
 
 export interface FluxKustomizationProps {
     /**
      * Flux Kustomization path within the GitRepository 
-     * Do not use the path in the repository field*/
+     * Do not use the path in the repository field
+     */
     kustomizationPath: string;
 
     /** 
     * Flux Kustomization Target Namespace.
-    * Note: when set, this parameter will override all the objects that are part of the Kustomization, please see https://fluxcd.io/flux/components/kustomize/kustomization/#target-namespace */
+    * Note: when set, this parameter will override all the objects that are part of the Kustomization, please see https://fluxcd.io/flux/components/kustomize/kustomization/#target-namespace
+    */
     kustomizationTargetNamespace?: string;
 
     /** 
     * Internal for Flux sync.
-    * Default `5m0s` */
+    * Default `5m0s`
+    */
     syncInterval?: string;
 
     /** 
     * Flux Kustomization Prune.
-    * Default `true` */
+    * Default `true`
+    */
     prune?: boolean;
 
     /** 
     * Flux Kustomization Timeout.
-    * Default `1m` */
+    * Default `1m`
+    */
     timeout?: string;
 }
 
@@ -60,53 +111,65 @@ export interface FluxKustomizationProps {
  */
 export interface FluxCDAddOnProps extends HelmAddOnUserProps {
 
-  /**
-   * Namespace where add-on will be deployed. 
-   * @default flux-system
-   */
-  namespace?: string;
+    /**
+     * Namespace where add-on will be deployed. 
+     * @default flux-system
+     */
+    namespace?: string;
 
-  /**
-  * Helm chart version to use to install.
-  * @default 2.12.4
-  */
-  version?: string;
+    /**
+     * Helm chart version to use to install.
+     * @default 2.13.0
+     */
+    version?: string;
 
-  /**
-   * Values to pass to the chart as per https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml.
-   */
-  values?: spi.Values;
+    /**
+     * Values to pass to the chart as per https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml.
+     */
+    values?: spi.Values;
 
-  /**
-   * To Create Namespace using CDK
-   */    
-  createNamespace?: boolean;
+    /**
+     * To Create Namespace using CDK
+     */    
+    createNamespace?: boolean;
 
-  /**
-   * List of repositories to sync from.
-   */
-  repositories?: FluxGitRepo[];
+    /**
+     * List of repositories to sync from.
+     */
+    repositories?: FluxGitRepo[];
+
+    /**
+     * List of buckets to sync from.
+     */
+    buckets?: FluxBucketRepo[];
 }
 
 /**
  * Default props to be used when creating the Helm chart
  */
 const defaultProps: HelmAddOnProps & FluxCDAddOnProps = {
-  name: "fluxcd-addon",
-  namespace: "flux-system",
-  chart: "flux2",
-  version: "2.12.4",
-  release: "blueprints-fluxcd-addon",
-  repository: "https://fluxcd-community.github.io/helm-charts",
-  values: {},
-  createNamespace: true,
+    name: "fluxcd-addon",
+    namespace: "flux-system",
+    chart: "flux2",
+    version: "2.13.0",
+    release: "blueprints-fluxcd-addon",
+    repository: "oci://ghcr.io/fluxcd-community/charts/flux2",
+    values: {},
+    createNamespace: true,
 };
 
 const defaultRepoProps: Partial<FluxGitRepo> = {
     syncInterval: "5m0s",
 };
 
-const defaultKustomiationProps: FluxKustomizationProps = {
+const defaultBucketProps: Partial<FluxBucketRepo> = {
+    namespace: "default",
+    syncInterval: "5m0s",
+    endpoint: "s3.amazonaws.com",
+    provider: "aws",
+};
+
+const defaultKustomizationProps: FluxKustomizationProps = {
     kustomizationPath: ".",
     syncInterval: "5m0s",
     prune: true,
@@ -119,84 +182,114 @@ const defaultKustomiationProps: FluxKustomizationProps = {
 @supportsALL
 export class FluxCDAddOn extends HelmAddOn {
 
-  readonly options: FluxCDAddOnProps;
+    readonly options: FluxCDAddOnProps;
 
-  constructor(props?: FluxCDAddOnProps) {
-    super({...defaultProps, ...props});
-    this.options = this.props as FluxCDAddOnProps;
-  }
-
-  deploy(clusterInfo: ClusterInfo): Promise<Construct> {
-    const cluster = clusterInfo.cluster;
-    let values: Values = this.options.values ?? {};
-    values = merge(values, this.props.values ?? {});
-    const chart = this.addHelmChart(clusterInfo, values);
-
-    if( this.options.createNamespace == true){
-      // Let CDK Create the Namespace
-      const namespace = createNamespace(this.options.namespace! , cluster);
-      chart.node.addDependency(namespace);
+    constructor(props?: FluxCDAddOnProps) {
+        super({...defaultProps, ...props});
+        this.options = this.props as FluxCDAddOnProps;
     }
 
-    //Create GitRepository sources and Kustomizations
-    if (this.options.repositories) {
-        this.options.repositories.map((repo) => {
-            repo = {...defaultRepoProps, ...repo};
-            const gitRepositoryConstruct = createGitRepository(clusterInfo, this.options.name!, this.options.namespace!, repo);
-            gitRepositoryConstruct.node.addDependency(chart);
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
+        const cluster = clusterInfo.cluster;
+        let values: Values = this.options.values ?? {};
+        values = merge(values, this.props.values ?? {});
+        const chart = this.addHelmChart(clusterInfo, values);
 
-            const kustomizationConstructs = createKustomizations(clusterInfo, this.options.name!, this.options.namespace!, repo);
-            kustomizationConstructs.map(kustomizationConstruct => kustomizationConstruct.node.addDependency(gitRepositoryConstruct));
-        });
+        if( this.options.createNamespace == true){
+            // Let CDK Create the Namespace
+            const namespace = createNamespace(this.options.namespace! , cluster);
+            chart.node.addDependency(namespace);
+        }
 
+        //Create GitRepository sources and Kustomizations
+        if (this.options.repositories) {
+            this.options.repositories.map((repo) => {
+                repo = {...defaultRepoProps, ...repo};
+                const gitRepositoryConstruct = createGitRepository(clusterInfo, this.options.name!, this.options.namespace!, repo);
+                gitRepositoryConstruct.node.addDependency(chart);
+
+                const kustomizationConstructs = createKustomizations(clusterInfo, this.options.name!, this.options.namespace!, repo);
+                kustomizationConstructs.map(kustomizationConstruct => kustomizationConstruct.node.addDependency(gitRepositoryConstruct));
+            });
+        }
+
+        // Create Bucket sources and Kustomizations
+        if (this.options.buckets) {
+            this.options.buckets.map((bucket) => {
+                bucket = {...defaultBucketProps, ...bucket};
+                const bucketConstruct = createBucket(clusterInfo, this.options.name!, this.options.namespace!, bucket);
+                bucketConstruct.node.addDependency(chart);
+
+                const kustomizationConstructs = createKustomizations(clusterInfo, this.options.name!, this.options.namespace!, bucket, "Bucket");
+                kustomizationConstructs.map(kustomizationConstruct => kustomizationConstruct.node.addDependency(bucketConstruct));
+            });
+        }
+
+        return Promise.resolve(chart);
     }
-
-    return Promise.resolve(chart);
-  }
 }
 
 /**
  * create GitRepository calls the FluxGitRepository().generate to create GitRepostory resource.
  */
 function createGitRepository(clusterInfo: ClusterInfo, name: string, namespace: string, fluxGitRepo: FluxGitRepo): KubernetesManifest {
-  if (fluxGitRepo.repository === undefined) {
-    throw new Error("Missing Git repository");
-  }
-  
-  const manifest = new FluxGitRepository(fluxGitRepo.repository).generate(
+    if (fluxGitRepo.repository === undefined) {
+        throw new Error("Missing Git repository");
+    }
+
+    const manifest = new FluxGitRepository(fluxGitRepo.repository).generate(
         fluxGitRepo.name,
         fluxGitRepo.namespace ?? namespace,
         fluxGitRepo.syncInterval!,
         fluxGitRepo.secretRefName!);
-  let manifestName: string | undefined = name + 'gitrepository' + fluxGitRepo.name;
-  const construct = clusterInfo.cluster.addManifest(manifestName!, manifest);
-  return construct;
+    let manifestName: string | undefined = name + 'gitrepository' + fluxGitRepo.name;
+    const construct = clusterInfo.cluster.addManifest(manifestName!, manifest);
+    return construct;
+}
+
+/**
+ * create Bucket calls the FluxBucket().generate to create Bucket resource.
+ */
+function createBucket(clusterInfo: ClusterInfo, name: string, namespace: string, props: FluxBucketRepo): KubernetesManifest {
+    if (props.repository === undefined) {
+        throw new Error("Missing S3 bucket repository");
+    }
+
+    const manifest = new FluxBucket(props.repository.repoUrl, props.bucketRegion, props.repository.path).generate(
+        props.name,
+        props.namespace ?? namespace,
+        props.syncInterval!,
+        props.provider!,
+        props.endpoint!,
+        props.secretRefName!);
+    let manifestName: string | undefined = name + 'bucketrepository' + props.name;
+    return clusterInfo.cluster.addManifest(manifestName!, manifest);
 }
 
 /**
  * create Kustomizations calls the FluxKustomization().generate multiple times to create Kustomization resources.
  */
-function createKustomizations(clusterInfo: ClusterInfo, name: string, namespace: string, fluxGitRepo: FluxGitRepo): KubernetesManifest[] {
-  const constructs: KubernetesManifest[] = [];
-  const kustomizations = fluxGitRepo.kustomizations ?? [{kustomizationPath: "."}];
-  const fluxKustomization = new FluxKustomization();
-  kustomizations?.map((kustomization, index) => {
-    kustomization = {...defaultKustomiationProps, ...kustomization};
-    const manifest =fluxKustomization.generate(
-      fluxGitRepo.name + "-" + index,
-      fluxGitRepo.name,
-      fluxGitRepo.namespace ?? namespace,
-      kustomization.syncInterval!,
-      kustomization.prune!,
-      kustomization.timeout!,
-      fluxGitRepo.values,
-      kustomization.kustomizationPath,
-      kustomization.kustomizationTargetNamespace,
-    );
-    let manifestName: string | undefined = name + 'kustomization' +fluxGitRepo.name + index;
-    constructs.push(clusterInfo.cluster.addManifest(manifestName!, manifest));
-    
-  });
+function createKustomizations(clusterInfo: ClusterInfo, name: string, namespace: string, fluxSource: FluxGitRepo | FluxBucketRepo, fluxSourceKind?: string): KubernetesManifest[] {
+    const constructs: KubernetesManifest[] = [];
+    const kustomizations = fluxSource.kustomizations ?? [{kustomizationPath: "."}];
+    const fluxKustomization = new FluxKustomization();
+    kustomizations?.map((kustomization, index) => {
+        kustomization = {...defaultKustomizationProps, ...kustomization};
+        const manifest = fluxKustomization.generate(
+            fluxSource.name + "-" + index,
+            fluxSource.name,
+            fluxSource.namespace ?? namespace,
+            kustomization.syncInterval!,
+            kustomization.prune!,
+            kustomization.timeout!,
+            fluxSource.values || {},
+            kustomization.kustomizationPath,
+            kustomization.kustomizationTargetNamespace,
+            fluxSourceKind,
+        );
+        let manifestName: string | undefined = name + 'kustomization' + fluxSource.name + index;
+        constructs.push(clusterInfo.cluster.addManifest(manifestName!, manifest));
+    });
 
-  return constructs;
+    return constructs;
 }

--- a/lib/addons/fluxcd/index.ts
+++ b/lib/addons/fluxcd/index.ts
@@ -191,7 +191,6 @@ const defaultRepoProps: Partial<FluxGitRepo> = {
 };
 
 const defaultBucketProps: Partial<FluxBucketRepo> = {
-    namespace: "flux-system",
     syncInterval: "5m0s",
     endpoint: "s3.amazonaws.com",
     provider: "aws",

--- a/lib/addons/fluxcd/index.ts
+++ b/lib/addons/fluxcd/index.ts
@@ -145,7 +145,11 @@ export interface FluxCDAddOnProps extends HelmAddOnUserProps {
 }
 
 /**
- * Default props to be used when creating the Helm chart
+ * Default props to be used when creating the Helm chart.
+ * Find the latest version using the GitHub CLI command:
+ * `$ gh release  list --repo fluxcd-community/helm-charts`
+ * or from the packages page:
+ * @link https://github.com/fluxcd-community/helm-charts/pkgs/container/charts%2Fflux2
  */
 const defaultProps: HelmAddOnProps & FluxCDAddOnProps = {
     name: "fluxcd-addon",

--- a/lib/addons/fluxcd/index.ts
+++ b/lib/addons/fluxcd/index.ts
@@ -43,7 +43,7 @@ export interface FluxBucketRepo {
 
     /**
      * Namespace for the FluxCD bucket source (optional)
-     * Default is `default`
+     * Default is the chart namespace
      */
     namespace?: string;
     

--- a/lib/addons/fluxcd/kustomization.ts
+++ b/lib/addons/fluxcd/kustomization.ts
@@ -8,7 +8,7 @@ export class FluxKustomization {
 
     constructor() {}
 
-    public generate(name: string, repoName: string, namespace: string, fluxSyncInterval: string, fluxPrune: boolean, fluxTimeout: string, values: spi.Values, fluxKustomizationPath: string, fluxTargetNamespace?: string) {
+    public generate(name: string, repoName: string, namespace: string, fluxSyncInterval: string, fluxPrune: boolean, fluxTimeout: string, values: spi.Values, fluxKustomizationPath: string, fluxTargetNamespace?: string, fluxSourceKind?: string) {
         
         const kustomizationManifest = {
             apiVersion: "kustomize.toolkit.fluxcd.io/v1beta2",
@@ -20,7 +20,7 @@ export class FluxKustomization {
             spec: {
                 interval: fluxSyncInterval,
                 sourceRef: {
-                    kind: "GitRepository",
+                    kind: fluxSourceKind || "GitRepository",
                     name: repoName
                 },
                 path: fluxKustomizationPath,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 - implement support for FluxCD Bucket source: https://fluxcd.io/flux/components/source/buckets/
 - bump FluxCD default version to 2.13.0
 - use the more reliable OCI registry for the FluxCD Helm chart
 - make indentation consistent within the modified files
 - changed typo in `defaultKustomiationProps`
 - basic use case tested
 - kustomizations not tested

Example use:

```
        .addOns(new blueprints.addons.FluxCDAddOn({
            buckets: [
                {
                    name: "bootstrap-bucket",
                    bucketName:base.bucket.bucketName,
                    bucketRegion: cdk.Aws.REGION,
                }
            ],
        }),
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
