### PR TITLE
[feat] Add service override parameter to ExternalDNS props

### DIFF
--- a/lib/addons/external-dns/index.ts
+++ b/lib/addons/external-dns/index.ts
@@ -17,6 +17,10 @@ export interface ExternalDnsProps extends HelmAddOnUserProps {
      * Hosted zone providers are registered as named resource providers with the EksBlueprintProps.
      */
     readonly hostedZoneResources: string[];
+    /**
+     * List of sources to watch when synthesizing DNS records.  If empty, the default types are "service" and "ingress".
+     */
+    readonly sources?: string[];
 }
 
 const defaultProps = {
@@ -96,6 +100,13 @@ export class ExternalDnsAddOn extends HelmAddOn {
         };
 
         values = merge(values, this.props.values ?? {});
+
+        const sources = this.options.sources;
+
+        if (sources) {
+            values.sources = sources;
+        }
+
         const chart = this.addHelmChart(clusterInfo, values);
 
         chart.node.addDependency(namespaceManifest);


### PR DESCRIPTION
*Issue #, if available:*
Issue #1010 
*Description of changes:*

The current default values will allow ExternalDNS to listen for Service and Ingress only.  If you're using something else, such as Istio or Envoy Gateway, it will not look for host names in Gateway, VirtualService, or HTTPRoutes.  This allows that override via helm values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
