### PR TITLE
Generic Construct for EKS blueprint

### DIFF
--- a/lib/resource-providers/hosted-zone.ts
+++ b/lib/resource-providers/hosted-zone.ts
@@ -1,6 +1,7 @@
 import { Role } from "aws-cdk-lib/aws-iam";
 import * as r53 from 'aws-cdk-lib/aws-route53';
 import { ResourceContext, ResourceProvider } from "../spi";
+import {Stack} from "aws-cdk-lib";
 
 /**
  * Simple lookup host zone provider
@@ -70,7 +71,7 @@ export class DelegatingHostedZoneProvider implements ResourceProvider<r53.IHoste
     constructor(private options: DelegatingHostedZoneProviderProps) { }
 
     provide(context: ResourceContext): r53.IHostedZone {
-        const stack = context.scope;
+        const stack = Stack.of(context.scope);
 
         const subZone = new r53.PublicHostedZone(stack, `${this.options.subdomain}-SubZone`, {
             zoneName: this.options.subdomain

--- a/lib/resource-providers/iam.ts
+++ b/lib/resource-providers/iam.ts
@@ -2,6 +2,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import * as spi from '../spi';
 import assert = require('assert');
+import {Stack} from "aws-cdk-lib";
 
 /**
  * Role provider that imports an existing role, performing its lookup by the provided name.
@@ -55,9 +56,9 @@ export class LookupOpenIdConnectProvider implements spi.ResourceProvider<iam.IOp
 
     provide(context: spi.ResourceContext): iam.IOpenIdConnectProvider {
         return iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
-            context.scope,
+            Stack.of(context.scope),
             this.id,
-            `arn:aws:iam::${context.scope.account}:oidc-provider/${this.url.substring(httpsPrefix.length)}`
+            `arn:aws:iam::${Stack.of(context.scope).account}:oidc-provider/${this.url.substring(httpsPrefix.length)}`
         );
     }
 }

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -123,7 +123,7 @@ export class ResourceContext {
 
     private readonly resources: Map<string, IConstruct> = new Map();
 
-    constructor(public readonly scope: any, public readonly blueprintProps: EksBlueprintProps) { }
+    constructor(public readonly scope: Construct, public readonly blueprintProps: EksBlueprintProps) { }
 
     /**
      * Adds a new resource provider and specifies the name under which the provided resource will be registered,

--- a/lib/spi/types.ts
+++ b/lib/spi/types.ts
@@ -123,7 +123,7 @@ export class ResourceContext {
 
     private readonly resources: Map<string, IConstruct> = new Map();
 
-    constructor(public readonly scope: cdk.Stack, public readonly blueprintProps: EksBlueprintProps) { }
+    constructor(public readonly scope: any, public readonly blueprintProps: EksBlueprintProps) { }
 
     /**
      * Adds a new resource provider and specifies the name under which the provided resource will be registered,

--- a/lib/stacks/eks-blueprint-construct.ts
+++ b/lib/stacks/eks-blueprint-construct.ts
@@ -1,0 +1,356 @@
+import * as cdk from 'aws-cdk-lib';
+import { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { ClusterLoggingTypes as ControlPlaneLogType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
+import { Construct } from 'constructs';
+import { MngClusterProvider } from '../cluster-providers/mng-cluster-provider';
+import { VpcProvider } from '../resource-providers/vpc';
+import * as spi from '../spi';
+import * as constraints from '../utils/constraints-utils';
+import * as utils from '../utils';
+import { cloneDeep } from '../utils';
+import { IKey } from "aws-cdk-lib/aws-kms";
+import {CreateKmsKeyProvider} from "../resource-providers/kms-key";
+import { ArgoGitOpsFactory } from "../addons/argocd/argo-gitops-factory";
+
+/* Default K8s version of EKS Blueprints */
+export const DEFAULT_VERSION = KubernetesVersion.V1_29;
+
+/**
+ *  Exporting control plane log type so that customers don't have to import CDK EKS module for blueprint configuration.
+ */
+export { ControlPlaneLogType };
+
+export class EksBlueprintProps {
+    /**
+     * The id for the blueprint.
+     */
+    readonly id: string;
+
+    /**
+     * Defaults to id if not provided
+     */
+    readonly name?: string;
+
+    /**
+     * Add-ons if any.
+     */
+    readonly addOns?: Array<spi.ClusterAddOn> = [];
+
+    /**
+     * Teams if any
+     */
+    readonly teams?: Array<spi.Team> = [];
+
+    /**
+     * EC2 or Fargate are supported in the blueprint but any implementation conforming the interface
+     * will work
+     */
+    readonly clusterProvider?: spi.ClusterProvider = new MngClusterProvider();
+
+    /**
+     * Kubernetes version (must be initialized for addons to work properly)
+     */
+    readonly version?: KubernetesVersion | "auto";
+
+    /**
+     * Named resource providers to leverage for cluster resources.
+     * The resource can represent Vpc, Hosting Zones or other resources, see {@link spi.ResourceType}.
+     * VPC for the cluster can be registered under the name of 'vpc' or as a single provider of type
+     */
+    resourceProviders?: Map<string, spi.ResourceProvider> = new Map();
+
+    /**
+     * Control Plane log types to be enabled (if not passed, none)
+     * If wrong types are included, will throw an error.
+     */
+    readonly enableControlPlaneLogTypes?: ControlPlaneLogType[];
+
+    /**
+     * If set to true and no resouce provider for KMS key is defined (under GlobalResources.KmsKey),
+     * a default KMS encryption key will be used for envelope encryption of Kubernetes secrets (AWS managed new KMS key).
+     * If set to false, and no resouce provider for KMS key is defined (under GlobalResources.KmsKey), then no secrets
+     * encyrption is applied.
+     *
+     * Default is true.
+     */
+    readonly useDefaultSecretEncryption? : boolean  = true;
+
+    /**
+     * GitOps modes to be enabled. If not specified, GitOps mode is not enabled.
+     */
+    readonly enableGitOpsMode?: spi.GitOpsMode;
+}
+
+export class BlueprintPropsConstraints implements constraints.ConstraintsType<EksBlueprintProps> {
+    /**
+     * id can be no less than 1 character long, and no greater than 63 characters long.
+     * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+     */
+    id = new constraints.StringConstraint(1, 63);
+
+    /**
+     * name can be no less than 1 character long, and no greater than 63 characters long.
+     * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+     */
+    name = new constraints.StringConstraint(1, 63);
+}
+
+/**
+ * Blueprint builder implements a builder pattern that improves readability (no bloated constructors)
+ * and allows creating a blueprint in an abstract state that can be applied to various instantiations
+ * in accounts and regions.
+ */
+export class BlueprintConstructBuilder {
+
+    props: Partial<EksBlueprintProps>;
+    env: {
+        account?: string,
+        region?: string
+    };
+
+    constructor() {
+        this.props = { addOns: new Array<spi.ClusterAddOn>(), teams: new Array<spi.Team>(), resourceProviders: new Map() };
+        this.env = {
+            account: process.env.CDK_DEFAULT_ACCOUNT,
+            region: process.env.CDK_DEFAULT_REGION
+        };
+    }
+
+    public name(name: string): this {
+        this.props = { ...this.props, ...{ name } };
+        return this;
+    }
+
+    public account(account?: string): this {
+        this.env.account = account;
+        return this;
+    }
+
+    public region(region?: string): this {
+        this.env.region = region;
+        return this;
+    }
+
+    public version(version: "auto" | KubernetesVersion): this {
+        this.props = { ...this.props, ...{ version: version } };
+        return this;
+    }
+
+    public enableControlPlaneLogTypes(...types: ControlPlaneLogType[]): this {
+        this.props = { ...this.props, ...{ enableControlPlaneLogTypes: types } };
+        return this;
+    }
+
+    public enableGitOps(mode?: spi.GitOpsMode): this {
+        this.props = { ...this.props, ...{ enableGitOpsMode: mode ?? spi.GitOpsMode.APP_OF_APPS } };
+        return this;
+    }
+
+    public withBlueprintProps(props: Partial<EksBlueprintProps>): this {
+        const resourceProviders = this.props.resourceProviders!;
+        this.props = { ...this.props, ...cloneDeep(props) };
+        if (props.resourceProviders) {
+            this.props.resourceProviders = new Map([...resourceProviders!.entries(), ...props.resourceProviders.entries()]);
+        }
+        return this;
+    }
+
+    public addOns(...addOns: spi.ClusterAddOn[]): this {
+        this.props = { ...this.props, ...{ addOns: this.props.addOns?.concat(addOns) } };
+        return this;
+    }
+
+    public clusterProvider(clusterProvider: spi.ClusterProvider) {
+        this.props = { ...this.props, ...{ clusterProvider: clusterProvider } };
+        return this;
+    }
+
+    public id(id: string): this {
+        this.props = { ...this.props, ...{ id } };
+        return this;
+    }
+
+    public teams(...teams: spi.Team[]): this {
+        this.props = { ...this.props, ...{ teams: this.props.teams?.concat(teams) } };
+        return this;
+    }
+
+    public resourceProvider(name: string, provider: spi.ResourceProvider): this {
+        this.props.resourceProviders?.set(name, provider);
+        return this;
+    }
+
+    public useDefaultSecretEncryption(useDefault: boolean): this {
+        this.props = { ...this.props, ...{ useDefaultSecretEncryption: useDefault } };
+        return this;
+    }
+
+    public withEnv(env: cdk.Environment): this {
+        this.env.account = env.account;
+        this.env.region = env.region;
+        return this;
+    }
+
+}
+
+/**
+ * Entry point to the platform provisioning. Creates a CFN stack based on the provided configuration
+ * and orchestrates provisioning of add-ons, teams and post deployment hooks.
+ */
+export class EksBlueprintConstruct extends Construct {
+
+    private asyncTasks: Promise<void | Construct[]>;
+
+    private clusterInfo: spi.ClusterInfo;
+
+    constructor(scope: Construct, blueprintProps: EksBlueprintProps) {
+        super(scope, blueprintProps.id);
+        this.validateInput(blueprintProps);
+
+        const resourceContext = this.provideNamedResources(blueprintProps);
+
+        let vpcResource: IVpc | undefined = resourceContext.get(spi.GlobalResources.Vpc);
+
+        if (!vpcResource) {
+            vpcResource = resourceContext.add(spi.GlobalResources.Vpc, new VpcProvider());
+        }
+
+        let version = blueprintProps.version;
+        if (version == "auto") {
+            version = DEFAULT_VERSION;
+        }
+
+        let kmsKeyResource: IKey | undefined = resourceContext.get(spi.GlobalResources.KmsKey);
+
+        if (!kmsKeyResource && blueprintProps.useDefaultSecretEncryption != false) {
+            kmsKeyResource = resourceContext.add(spi.GlobalResources.KmsKey, new CreateKmsKeyProvider());
+        }
+
+        blueprintProps = this.resolveDynamicProxies(blueprintProps, resourceContext);
+
+        const clusterProvider = blueprintProps.clusterProvider ?? new MngClusterProvider({
+            id: `${blueprintProps.name ?? blueprintProps.id}-ng`,
+            version
+        });
+
+        this.clusterInfo = clusterProvider.createCluster(this, vpcResource!, kmsKeyResource, version, blueprintProps.enableControlPlaneLogTypes);
+        this.clusterInfo.setResourceContext(resourceContext);
+
+        if (blueprintProps.enableGitOpsMode == spi.GitOpsMode.APPLICATION) {
+            ArgoGitOpsFactory.enableGitOps();
+        } else if (blueprintProps.enableGitOpsMode == spi.GitOpsMode.APP_OF_APPS) {
+            ArgoGitOpsFactory.enableGitOpsAppOfApps();
+        }
+
+        const postDeploymentSteps = Array<spi.ClusterPostDeploy>();
+
+        for (let addOn of (blueprintProps.addOns ?? [])) { // must iterate in the strict order
+            const result = addOn.deploy(this.clusterInfo);
+            if (result) {
+                const addOnKey = utils.getAddOnNameOrId(addOn);
+                this.clusterInfo.addScheduledAddOn(addOnKey, result, utils.isOrderedAddOn(addOn));
+            }
+            const postDeploy: any = addOn;
+            if ((postDeploy as spi.ClusterPostDeploy).postDeploy !== undefined) {
+                postDeploymentSteps.push(<spi.ClusterPostDeploy>postDeploy);
+            }
+        }
+
+        const scheduledAddOns = this.clusterInfo.getAllScheduledAddons();
+        const addOnKeys = [...scheduledAddOns.keys()];
+        const promises = scheduledAddOns.values();
+
+        this.asyncTasks = Promise.all(promises).then((constructs) => {
+            constructs.forEach((construct, index) => {
+                this.clusterInfo.addProvisionedAddOn(addOnKeys[index], construct);
+            });
+
+            if (blueprintProps.teams != null) {
+                for (let team of blueprintProps.teams) {
+                    team.setup(this.clusterInfo);
+                }
+            }
+
+            for (let step of postDeploymentSteps) {
+                step.postDeploy(this.clusterInfo, blueprintProps.teams ?? []);
+            }
+        });
+
+        this.asyncTasks.catch(err => {
+            console.error(err);
+            throw new Error(err);
+        });
+    }
+
+    /**
+     * Since constructor cannot be marked as async, adding a separate method to wait
+     * for async code to finish.
+     * @returns Promise that resolves to the blueprint
+     */
+    public async waitForAsyncTasks(): Promise<EksBlueprintConstruct> {
+        if (this.asyncTasks) {
+            return this.asyncTasks.then(() => {
+                return this;
+            });
+        }
+        return Promise.resolve(this);
+    }
+
+    /**
+     * This method returns all the constructs produced by during the cluster creation (e.g. add-ons).
+     * May be used in testing for verification.
+     * @returns Async Tasks object
+     */
+    getAsyncTasks(): Promise<void | Construct[]> {
+        return this.asyncTasks;
+    }
+
+    /**
+     * This method returns all the constructs produced by during the cluster creation (e.g. add-ons).
+     * May be used in testing for verification.
+     * @returns cluster info object
+     */
+    getClusterInfo(): spi.ClusterInfo {
+        return this.clusterInfo;
+    }
+
+    private provideNamedResources(blueprintProps: EksBlueprintProps): spi.ResourceContext {
+        const result = new spi.ResourceContext(this, blueprintProps);
+
+        for (let [key, value] of blueprintProps.resourceProviders ?? []) {
+            result.add(key, value);
+        }
+
+        return result;
+    }
+
+    /**
+     * Resolves all dynamic proxies, that substitutes resource provider proxies with the resolved values.
+     * @param blueprintProps
+     * @param resourceContext
+     * @returns a copy of blueprint props with resolved values
+     */
+    private resolveDynamicProxies(blueprintProps: EksBlueprintProps, resourceContext: spi.ResourceContext) : EksBlueprintProps {
+        return utils.cloneDeep(blueprintProps, (value) => {
+            return utils.resolveTarget(value, resourceContext);
+        });
+    }
+
+    /**
+     * Validates input against basic defined constraints.
+     * @param blueprintProps
+     */
+    private validateInput(blueprintProps: EksBlueprintProps) {
+        const teamNames = new Set<string>();
+        constraints.validateConstraints(new BlueprintPropsConstraints, EksBlueprintProps.name, blueprintProps);
+        if (blueprintProps.teams) {
+            blueprintProps.teams.forEach(e => {
+                if (teamNames.has(e.name)) {
+                    throw new Error(`Team ${e.name} is registered more than once`);
+                }
+                teamNames.add(e.name);
+            });
+        }
+    }
+}
+

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -1,201 +1,23 @@
 import * as cdk from 'aws-cdk-lib';
-import { IVpc } from 'aws-cdk-lib/aws-ec2';
-import { ClusterLoggingTypes as ControlPlaneLogType, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 import { Construct } from 'constructs';
-import { MngClusterProvider } from '../cluster-providers/mng-cluster-provider';
-import { VpcProvider } from '../resource-providers/vpc';
 import * as spi from '../spi';
-import * as constraints from '../utils/constraints-utils';
 import * as utils from '../utils';
-import { cloneDeep } from '../utils';
-import { IKey } from "aws-cdk-lib/aws-kms";
-import {CreateKmsKeyProvider} from "../resource-providers/kms-key";
-import { ArgoGitOpsFactory } from "../addons/argocd/argo-gitops-factory";
-
-/* Default K8s version of EKS Blueprints */
-export const DEFAULT_VERSION = KubernetesVersion.V1_29;
-
-/**
- *  Exporting control plane log type so that customers don't have to import CDK EKS module for blueprint configuration. 
- */  
-export { ControlPlaneLogType };
-
-export class EksBlueprintProps {
-    /**
-     * The id for the blueprint.
-     */
-    readonly id: string;
-
-    /**
-     * Defaults to id if not provided
-     */
-    readonly name?: string;
-
-    /**
-     * Add-ons if any.
-     */
-    readonly addOns?: Array<spi.ClusterAddOn> = [];
-
-    /**
-     * Teams if any
-     */
-    readonly teams?: Array<spi.Team> = [];
-
-    /**
-     * EC2 or Fargate are supported in the blueprint but any implementation conforming the interface
-     * will work
-     */
-    readonly clusterProvider?: spi.ClusterProvider = new MngClusterProvider();
-
-    /**
-     * Kubernetes version (must be initialized for addons to work properly)
-     */
-    readonly version?: KubernetesVersion | "auto";
-
-    /**
-     * Named resource providers to leverage for cluster resources.
-     * The resource can represent Vpc, Hosting Zones or other resources, see {@link spi.ResourceType}.
-     * VPC for the cluster can be registered under the name of 'vpc' or as a single provider of type
-     */
-    resourceProviders?: Map<string, spi.ResourceProvider> = new Map();
-
-    /**
-     * Control Plane log types to be enabled (if not passed, none)
-     * If wrong types are included, will throw an error.
-     */
-    readonly enableControlPlaneLogTypes?: ControlPlaneLogType[];
-
-    /**
-     * If set to true and no resouce provider for KMS key is defined (under GlobalResources.KmsKey),
-     * a default KMS encryption key will be used for envelope encryption of Kubernetes secrets (AWS managed new KMS key).
-     * If set to false, and no resouce provider for KMS key is defined (under GlobalResources.KmsKey), then no secrets 
-     * encyrption is applied.
-     * 
-     * Default is true.
-     */
-    readonly useDefaultSecretEncryption? : boolean  = true;
-
-    /**
-     * GitOps modes to be enabled. If not specified, GitOps mode is not enabled.
-     */
-    readonly enableGitOpsMode?: spi.GitOpsMode;
-}
-
-export class BlueprintPropsConstraints implements constraints.ConstraintsType<EksBlueprintProps> {
-    /**
-    * id can be no less than 1 character long, and no greater than 63 characters long.
-    * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-    */
-    id = new constraints.StringConstraint(1, 63);
-
-    /**
-    * name can be no less than 1 character long, and no greater than 63 characters long.
-    * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-    */
-    name = new constraints.StringConstraint(1, 63);
-}
+import {BlueprintConstructBuilder, EksBlueprintConstruct, EksBlueprintProps} from "./eks-blueprint-construct";
 
 /**
  * Blueprint builder implements a builder pattern that improves readability (no bloated constructors)
  * and allows creating a blueprint in an abstract state that can be applied to various instantiations
  * in accounts and regions.
  */
-export class BlueprintBuilder implements spi.AsyncStackBuilder {
-
-    props: Partial<EksBlueprintProps>;
-    env: {
-        account?: string,
-        region?: string
-    };
-
+export class BlueprintBuilder extends BlueprintConstructBuilder implements spi.AsyncStackBuilder {
     constructor() {
-        this.props = { addOns: new Array<spi.ClusterAddOn>(), teams: new Array<spi.Team>(), resourceProviders: new Map() };
-        this.env = {
-            account: process.env.CDK_DEFAULT_ACCOUNT,
-            region: process.env.CDK_DEFAULT_REGION
-        };
-    }
-
-    public name(name: string): this {
-        this.props = { ...this.props, ...{ name } };
-        return this;
-    }
-
-    public account(account?: string): this {
-        this.env.account = account;
-        return this;
-    }
-
-    public region(region?: string): this {
-        this.env.region = region;
-        return this;
-    }
-
-    public version(version: "auto" | KubernetesVersion): this {
-        this.props = { ...this.props, ...{ version: version } };
-        return this;
-    }
-
-    public enableControlPlaneLogTypes(...types: ControlPlaneLogType[]): this {
-        this.props = { ...this.props, ...{ enableControlPlaneLogTypes: types } };
-        return this;
-    }
-
-    public enableGitOps(mode?: spi.GitOpsMode): this {
-        this.props = { ...this.props, ...{ enableGitOpsMode: mode ?? spi.GitOpsMode.APP_OF_APPS } };
-        return this;
-    }
-
-    public withBlueprintProps(props: Partial<EksBlueprintProps>): this {
-        const resourceProviders = this.props.resourceProviders!;
-        this.props = { ...this.props, ...cloneDeep(props) };
-        if (props.resourceProviders) {
-            this.props.resourceProviders = new Map([...resourceProviders!.entries(), ...props.resourceProviders.entries()]);
-        }
-        return this;
-    }
-
-    public addOns(...addOns: spi.ClusterAddOn[]): this {
-        this.props = { ...this.props, ...{ addOns: this.props.addOns?.concat(addOns) } };
-        return this;
-    }
-
-    public clusterProvider(clusterProvider: spi.ClusterProvider) {
-        this.props = { ...this.props, ...{ clusterProvider: clusterProvider } };
-        return this;
-    }
-
-    public id(id: string): this {
-        this.props = { ...this.props, ...{ id } };
-        return this;
-    }
-
-    public teams(...teams: spi.Team[]): this {
-        this.props = { ...this.props, ...{ teams: this.props.teams?.concat(teams) } };
-        return this;
-    }
-
-    public resourceProvider(name: string, provider: spi.ResourceProvider): this {
-        this.props.resourceProviders?.set(name, provider);
-        return this;
-    }
-
-    public useDefaultSecretEncryption(useDefault: boolean): this {
-        this.props = { ...this.props, ...{ useDefaultSecretEncryption: useDefault } };
-        return this;
+        super();
     }
 
     public clone(region?: string, account?: string): BlueprintBuilder {
         return new BlueprintBuilder().withBlueprintProps(this.props)
             .account(account ?? this.env.account).region(region ?? this.env.region);
     }
-
-    public withEnv(env: cdk.Environment): this {
-        this.env.account = env.account;
-        this.env.region = env.region;
-        return this;
-    }
-
     public build(scope: Construct, id: string, stackProps?: cdk.StackProps): EksBlueprint {
         return new EksBlueprint(scope, { ...this.props, ...{ id } },
             { ...{ env: this.env }, ...stackProps });
@@ -210,7 +32,7 @@ export class BlueprintBuilder implements spi.AsyncStackBuilder {
  * Entry point to the platform provisioning. Creates a CFN stack based on the provided configuration
  * and orchestrates provisioning of add-ons, teams and post deployment hooks.
  */
-export class EksBlueprint extends cdk.Stack {
+export class EksBlueprint extends cdk.Stack  {
 
     static readonly USAGE_ID = "qs-1s1r465hk";
 
@@ -224,81 +46,9 @@ export class EksBlueprint extends cdk.Stack {
 
     constructor(scope: Construct, blueprintProps: EksBlueprintProps, props?: cdk.StackProps) {
         super(scope, blueprintProps.id, utils.withUsageTracking(EksBlueprint.USAGE_ID, props));
-        this.validateInput(blueprintProps);
-
-        const resourceContext = this.provideNamedResources(blueprintProps);
-
-        let vpcResource: IVpc | undefined = resourceContext.get(spi.GlobalResources.Vpc);
-
-        if (!vpcResource) {
-            vpcResource = resourceContext.add(spi.GlobalResources.Vpc, new VpcProvider());
-        }
-
-        let version = blueprintProps.version;
-        if (version == "auto") {
-            version = DEFAULT_VERSION;
-        }
-
-        let kmsKeyResource: IKey | undefined = resourceContext.get(spi.GlobalResources.KmsKey);
-
-        if (!kmsKeyResource && blueprintProps.useDefaultSecretEncryption != false) {
-            kmsKeyResource = resourceContext.add(spi.GlobalResources.KmsKey, new CreateKmsKeyProvider());
-        }
-
-        blueprintProps = this.resolveDynamicProxies(blueprintProps, resourceContext);
-
-        const clusterProvider = blueprintProps.clusterProvider ?? new MngClusterProvider({
-            id: `${blueprintProps.name ?? blueprintProps.id}-ng`,
-            version
-        });
-
-        this.clusterInfo = clusterProvider.createCluster(this, vpcResource!, kmsKeyResource, version, blueprintProps.enableControlPlaneLogTypes);
-        this.clusterInfo.setResourceContext(resourceContext);
-
-        if (blueprintProps.enableGitOpsMode == spi.GitOpsMode.APPLICATION) {
-            ArgoGitOpsFactory.enableGitOps();
-        } else if (blueprintProps.enableGitOpsMode == spi.GitOpsMode.APP_OF_APPS) {
-            ArgoGitOpsFactory.enableGitOpsAppOfApps();
-        }
-
-        const postDeploymentSteps = Array<spi.ClusterPostDeploy>();
-
-        for (let addOn of (blueprintProps.addOns ?? [])) { // must iterate in the strict order
-            const result = addOn.deploy(this.clusterInfo);
-            if (result) {
-                const addOnKey = utils.getAddOnNameOrId(addOn);
-                this.clusterInfo.addScheduledAddOn(addOnKey, result, utils.isOrderedAddOn(addOn));
-            }
-            const postDeploy: any = addOn;
-            if ((postDeploy as spi.ClusterPostDeploy).postDeploy !== undefined) {
-                postDeploymentSteps.push(<spi.ClusterPostDeploy>postDeploy);
-            }
-        }
-
-        const scheduledAddOns = this.clusterInfo.getAllScheduledAddons();
-        const addOnKeys = [...scheduledAddOns.keys()];
-        const promises = scheduledAddOns.values();
-
-        this.asyncTasks = Promise.all(promises).then((constructs) => {
-            constructs.forEach((construct, index) => {
-                this.clusterInfo.addProvisionedAddOn(addOnKeys[index], construct);
-            });
-
-            if (blueprintProps.teams != null) {
-                for (let team of blueprintProps.teams) {
-                    team.setup(this.clusterInfo);
-                }
-            }
-
-            for (let step of postDeploymentSteps) {
-                step.postDeploy(this.clusterInfo, blueprintProps.teams ?? []);
-            }
-        });
-
-        this.asyncTasks.catch(err => {
-            console.error(err);
-            throw new Error(err);
-        });
+        const eksBlueprintConstruct = new EksBlueprintConstruct(this, blueprintProps);
+        this.clusterInfo = eksBlueprintConstruct.getClusterInfo();
+        this.asyncTasks = eksBlueprintConstruct.getAsyncTasks();
     }
 
     /**
@@ -322,45 +72,6 @@ export class EksBlueprint extends cdk.Stack {
      */
     getClusterInfo(): spi.ClusterInfo {
         return this.clusterInfo;
-    }
-
-    private provideNamedResources(blueprintProps: EksBlueprintProps): spi.ResourceContext {
-        const result = new spi.ResourceContext(this, blueprintProps);
-
-        for (let [key, value] of blueprintProps.resourceProviders ?? []) {
-            result.add(key, value);
-        }
-
-        return result;
-    }
-
-    /**
-     * Resolves all dynamic proxies, that substitutes resource provider proxies with the resolved values. 
-     * @param blueprintProps 
-     * @param resourceContext 
-     * @returns a copy of blueprint props with resolved values
-     */
-    private resolveDynamicProxies(blueprintProps: EksBlueprintProps, resourceContext: spi.ResourceContext) : EksBlueprintProps {
-        return utils.cloneDeep(blueprintProps, (value) => {
-            return utils.resolveTarget(value, resourceContext);
-        });
-    }
-
-    /**
-     * Validates input against basic defined constraints.
-     * @param blueprintProps 
-     */
-    private validateInput(blueprintProps: EksBlueprintProps) {
-        const teamNames = new Set<string>();
-        constraints.validateConstraints(new BlueprintPropsConstraints, EksBlueprintProps.name, blueprintProps);
-        if (blueprintProps.teams) {
-            blueprintProps.teams.forEach(e => {
-                if (teamNames.has(e.name)) {
-                    throw new Error(`Team ${e.name} is registered more than once`);
-                }
-                teamNames.add(e.name);
-            });
-        }
     }
 }
 

--- a/lib/stacks/eks-blueprint-stack.ts
+++ b/lib/stacks/eks-blueprint-stack.ts
@@ -32,7 +32,7 @@ export class BlueprintBuilder extends BlueprintConstructBuilder implements spi.A
  * Entry point to the platform provisioning. Creates a CFN stack based on the provided configuration
  * and orchestrates provisioning of add-ons, teams and post deployment hooks.
  */
-export class EksBlueprint extends cdk.Stack  {
+export class EksBlueprint extends cdk.Stack {
 
     static readonly USAGE_ID = "qs-1s1r465hk";
 

--- a/lib/stacks/index.ts
+++ b/lib/stacks/index.ts
@@ -1,1 +1,2 @@
 export * from './eks-blueprint-stack';
+export * from './eks-blueprint-construct';

--- a/test/resource-providers/efs.test.ts
+++ b/test/resource-providers/efs.test.ts
@@ -124,6 +124,6 @@ describe("EfsFileSystemProvider", () => {
     const template = Template.fromStack(stack);
 
     // Then
-    template.hasOutput("EfsFileSystemId", { Value: "fs-12345678" });
+    template.hasOutput("*", { Value: "fs-12345678" });
   });
 });

--- a/test/resource-providers/efs.test.ts
+++ b/test/resource-providers/efs.test.ts
@@ -2,7 +2,6 @@ import { App } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as blueprints from "../../lib";
 import { GlobalResources } from "../../lib";
-import {writeFileSync} from "fs";
 
 describe("EfsFileSystemProvider", () => {
   test("Stack is created with EFS file system with no encryption", () => {

--- a/test/resource-providers/s3.test.ts
+++ b/test/resource-providers/s3.test.ts
@@ -3,7 +3,6 @@ import { Template } from "aws-cdk-lib/assertions";
 import * as blueprints from "../../lib";
 import {EksBlueprintConstruct, GlobalResources} from "../../lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import {writeFileSync} from "fs";
 
 describe("S3BucketProvider", () => {
   test("Stack is created with a new S3 Bucket", () => {
@@ -44,7 +43,7 @@ describe("S3BucketProvider", () => {
       .region("us-east-1")
       .version("auto")
       .build(app, "east-test-1");
-     const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
+    const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
     const bucket = <s3.IBucket>eksBlueprintConstruct.node.tryFindChild('imported-s3-bucket');
     expect(bucket.bucketName == 'my-s3-imported-bucket-name');
   });

--- a/test/resource-providers/s3.test.ts
+++ b/test/resource-providers/s3.test.ts
@@ -1,7 +1,7 @@
 import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as blueprints from "../../lib";
-import { GlobalResources } from "../../lib";
+import {EksBlueprintConstruct, GlobalResources} from "../../lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
 
 describe("S3BucketProvider", () => {
@@ -43,8 +43,8 @@ describe("S3BucketProvider", () => {
       .region("us-east-1")
       .version("auto")
       .build(app, "east-test-1");
-
-    const bucket = <s3.IBucket>stack.node.tryFindChild('imported-s3-bucket');
+     const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
+    const bucket = <s3.IBucket>eksBlueprintConstruct.node.tryFindChild('imported-s3-bucket');
     expect(bucket.bucketName == 'my-s3-imported-bucket-name');
   });
 });


### PR DESCRIPTION
Description of changes: Currently, EKS blueprint can be used by only cdk.stack users or the users who relies on stack derivates. All other users cannot use this package. So, this Generic construct will help the users of any kind to use eks blueprint code. 

Example: 
In our company, we use different stack named PipelineStack which is not able to use cdk.stack to deploy the resources created by the blueprint. Which resulted in writing our own blueprint/blueprint builder code. The current change will help to use the eks blueprint code directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
