### PR TITLE
feat(generic-cluster-provider):  support kubectl lambda layer v1.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ aws --version
 Install CDK matching the current version of the Blueprints QuickStart (which can be found in package.json).
 
 ```bash
-npm install -g aws-cdk@2.133.0
+npm install -g aws-cdk@2.145.0
 ```
 
 Verify the installation.
 
 ```bash
 cdk --version
-# must output 2.133.0
+# must output 2.145.0
 ```
 
 Create a new CDK project. We use `typescript` for this example.

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,14 +44,14 @@ aws --version
 Install CDK matching the current version of the Blueprints QuickStart (which can be found in package.json).
 
 ```bash
-npm install -g aws-cdk@2.133.0
+npm install -g aws-cdk@2.145.0
 ```
 
 Verify the installation.
 
 ```bash
 cdk --version
-# must output 2.133.0
+# must output 2.145.0
 ```
 
 Create a new CDK project. We use `typescript` for this example.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,8 @@ Create a directory that represents you project (e.g. `my-blueprints`) and then c
 ```bash
 npm install -g n # may require sudo
 n stable # may require sudo 
-npm install -g aws-cdk@2.133.0 # may require sudo (Ubuntu) depending on configuration
-cdk --version # must produce 2.133.0
+npm install -g aws-cdk@2.145.0 # may require sudo (Ubuntu) depending on configuration
+cdk --version # must produce 2.145.0
 mkdir my-blueprints
 cd my-blueprints
 cdk init app --language typescript
@@ -48,16 +48,16 @@ npm ERR! code ERESOLVE
 npm ERR! ERESOLVE unable to resolve dependency tree
 npm ERR! 
 npm ERR! While resolving: my-blueprint@0.1.0
-npm ERR! Found: aws-cdk-lib@2.130.0
+npm ERR! Found: aws-cdk-lib@2.133.0
 npm ERR! node_modules/aws-cdk-lib
-npm ERR!   aws-cdk-lib@"2.130.0" from the root project
+npm ERR!   aws-cdk-lib@"2.133.0" from the root project
 npm ERR! 
 npm ERR! Could not resolve dependency:
-npm ERR! peer bundled aws-cdk-lib@"2.133.0" from @aws-quickstart/eks-blueprints@1.14.0
+npm ERR! peer bundled aws-cdk-lib@"2.145.0" from @aws-quickstart/eks-blueprints@1.14.0
 npm ERR! node_modules/@aws-quickstart/eks-blueprint
 ```
 
-This message means that the version of CDK that the customer is using is different from the version of CDK used in EKS Blueprints. Locate the line `peer bundled` and check the expected version of the CDK. Make sure that in your `package.json` the version is set to the expected. In this example, `package.json` contained `"aws-cdk-lib": "2.130.0"`, while the expected version was `2.133.0`.
+This message means that the version of CDK that the customer is using is different from the version of CDK used in EKS Blueprints. Locate the line `peer bundled` and check the expected version of the CDK. Make sure that in your `package.json` the version is set to the expected. In this example, `package.json` contained `"aws-cdk-lib": "2.133.0"`, while the expected version was `2.145.0`.
 
 **Note**: after the initial installation, upgrading the version of CDK to an incompatible higher/lower version will produce a warning, but will succeed. For community support (submitting GitHub issues) please make sure you have a matching version configured.
 
@@ -66,7 +66,7 @@ Example warning:
 ```
 npm WARN 
 npm WARN Could not resolve dependency:
-npm WARN peer bundled aws-cdk-lib@"2.133.0" from @aws-quickstart/eks-blueprints@1.14.0
+npm WARN peer bundled aws-cdk-lib@"2.145.0" from @aws-quickstart/eks-blueprints@1.14.0
 ```
 
 ## Deploy EKS Clusters

--- a/docs/internal/ci.md
+++ b/docs/internal/ci.md
@@ -19,7 +19,7 @@ cd cdk-eks-blueprints
 Install CDK (please review and install any missing [pre-requisites](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) for your environment)
 
 ```sh
-npm install -g aws-cdk@2.133.0
+npm install -g aws-cdk@2.145.0
 ```
 
 Install the dependencies for this project.

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -6,6 +6,7 @@ import { KubectlV26Layer } from "@aws-cdk/lambda-layer-kubectl-v26";
 import { KubectlV27Layer } from "@aws-cdk/lambda-layer-kubectl-v27";
 import { KubectlV28Layer } from "@aws-cdk/lambda-layer-kubectl-v28";
 import { KubectlV29Layer } from "@aws-cdk/lambda-layer-kubectl-v29";
+import { KubectlV30Layer } from "@aws-cdk/lambda-layer-kubectl-v30";
 import { Tags } from "aws-cdk-lib";
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -46,13 +47,15 @@ export function selectKubectlLayer(scope: Construct, version: eks.KubernetesVers
             return new KubectlV28Layer(scope, "kubectllayer28");
         case "1.29":
             return new KubectlV29Layer(scope, "kubectllayer29");
+        case "1.30":
+            return new KubectlV30Layer(scope, "kubectllayer30");
     
     }
     
     const minor = version.version.split('.')[1];
 
-    if(minor && parseInt(minor, 10) > 29) {
-        return new KubectlV29Layer(scope, "kubectllayer29"); // for all versions above 1.29 use 1.29 kubectl (unless explicitly supported in CDK)
+    if(minor && parseInt(minor, 10) > 30) {
+        return new KubectlV30Layer(scope, "kubectllayer30"); // for all versions above 1.30 use 1.30 kubectl (unless explicitly supported in CDK)
     }
     return undefined;
 }
@@ -255,7 +258,7 @@ export class GenericClusterProvider implements ClusterProvider {
         if(!kubernetesVersion && !this.props.version) {
             throw new Error("Version was not specified by cluster builder or in cluster provider props, must be specified in one of these");
         }
-        const version: eks.KubernetesVersion = kubernetesVersion || this.props.version || eks.KubernetesVersion.V1_28;
+        const version: eks.KubernetesVersion = kubernetesVersion || this.props.version || eks.KubernetesVersion.V1_30;
 
         const privateCluster = this.props.privateCluster ?? utils.valueFromContext(scope, constants.PRIVATE_CLUSTER, false);
         const endpointAccess = (privateCluster === true) ? eks.EndpointAccess.PRIVATE : eks.EndpointAccess.PUBLIC_AND_PRIVATE;

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -7,6 +7,7 @@ import { KubectlV27Layer } from "@aws-cdk/lambda-layer-kubectl-v27";
 import { KubectlV28Layer } from "@aws-cdk/lambda-layer-kubectl-v28";
 import { KubectlV29Layer } from "@aws-cdk/lambda-layer-kubectl-v29";
 import { KubectlV30Layer } from "@aws-cdk/lambda-layer-kubectl-v30";
+
 import { Tags } from "aws-cdk-lib";
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from "aws-cdk-lib/aws-ec2";

--- a/lib/pipelines/code-pipeline.ts
+++ b/lib/pipelines/code-pipeline.ts
@@ -457,7 +457,7 @@ class CodePipeline {
               primaryOutputDirectory: `${path}/cdk.out`,
               installCommands: [
                 'n stable',
-                'npm install -g aws-cdk@2.133.0',
+                'npm install -g aws-cdk@2.145.0',
                 `cd $CODEBUILD_SRC_DIR/${path} && npm install`
               ],
               commands: [`cd $CODEBUILD_SRC_DIR/${path}`, 'npm run build', 'npx cdk synth ' + app]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "dependencies": {
         "@aws-cdk/lambda-layer-kubectl-v27": "^2.1.0",
         "@aws-cdk/lambda-layer-kubectl-v28": "^2.2.0",
-        "@aws-cdk/lambda-layer-kubectl-v29": "^2.0.0",
+        "@aws-cdk/lambda-layer-kubectl-v29": "^2.1.0",
+        "@aws-cdk/lambda-layer-kubectl-v30": "^2.0.0",
         "@aws-sdk/client-eks": "^3.529.1",
         "@aws-sdk/client-secrets-manager": "^3.529.1",
         "@types/assert": "^1.5.10",
@@ -72,7 +73,7 @@
         "semver": "^7.6.0"
     },
     "peerDependencies": {
-        "aws-cdk-lib": "2.133.0",
-        "aws-cdk": "2.133.0"
+        "aws-cdk-lib": "2.145.0",
+        "aws-cdk": "2.145.0"
     }
 }

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -250,54 +250,54 @@ test("Asg cluster provider correctly initializes self-managed node group", () =>
     expect(blueprint.getClusterInfo().autoscalingGroups!.length).toBe(1);
 });
 
-test("Kubectl layer is correctly injected for EKS version 1.26", () => {
+test("Kubectl layer is correctly injected for EKS version 1.30", () => {
 
     const app = new cdk.App();
 
     const stack = blueprints.EksBlueprint.builder()
         .account('123456789').region('us-west-2')
-        .version(KubernetesVersion.V1_26).build(app, "stack-126");
+        .version(KubernetesVersion.V1_30).build(app, "stack-130");
     
     const template = Template.fromStack(stack);
 
     template.hasResource("AWS::Lambda::LayerVersion", {
         Properties: {
-          Description: Match.stringLikeRegexp("/opt/kubectl/kubectl 1.26"),
+          Description: Match.stringLikeRegexp("/opt/kubectl/kubectl 1.30"),
         },
       });
 });
 
 
-test("Kubectl layer is correctly injected for EKS version 1.25", () => {
+test("Kubectl layer is correctly injected for EKS version 1.29", () => {
 
     const app = new cdk.App();
 
     const stack = blueprints.EksBlueprint.builder()
       .account('123456789').region('us-west-2')
-      .version(KubernetesVersion.V1_25).build(app, "stack-125");
+      .version(KubernetesVersion.V1_29).build(app, "stack-129");
 
     const template = Template.fromStack(stack);
 
     template.hasResource("AWS::Lambda::LayerVersion", {
         Properties: {
-            Description: Match.stringLikeRegexp("/opt/kubectl/kubectl 1.25"),
+            Description: Match.stringLikeRegexp("/opt/kubectl/kubectl 1.29"),
         },
     });
 });
 
-test("Kubectl layer is correctly injected for EKS version 1.24", () => {
+test("Kubectl layer is correctly injected for EKS version 1.28", () => {
 
     const app = new cdk.App();
 
     const stack = blueprints.EksBlueprint.builder()
       .account('123456789').region('us-west-2')
-      .version(KubernetesVersion.V1_24).build(app, "stack-124");
+      .version(KubernetesVersion.V1_28).build(app, "stack-128");
 
     const template = Template.fromStack(stack);
 
     template.hasResource("AWS::Lambda::LayerVersion", {
         Properties: {
-            Description: Match.stringLikeRegexp("/opt/kubectl/kubectl 1.24"),
+            Description: Match.stringLikeRegexp("/opt/kubectl/kubectl 1.28"),
         },
     });
 });
@@ -339,10 +339,10 @@ test("Kubernetes Version gets set correctly in NodeGroup", () => {
     const app = new cdk.App();
     const stack = blueprints.EksBlueprint.builder()
     .account('123456789').region('us-west-2')
-    .clusterProvider(new MngClusterProvider({version: KubernetesVersion.V1_28}))
+    .clusterProvider(new MngClusterProvider({version: KubernetesVersion.V1_30}))
     .build(app, "stack-auto");
 
-    expect(stack.getClusterInfo().version.version).toBe("1.28");
+    expect(stack.getClusterInfo().version.version).toBe("1.30");
 });
 
 test("Import cluster provider can use output values from other stacks as params", () => {

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -432,7 +432,7 @@ test("Building blueprint with builder properly clones properties", () => {
     expect(blueprint.props.addOns).toHaveLength(1);
 
     blueprint.withBlueprintProps({
-        version: KubernetesVersion.V1_25
+        version: KubernetesVersion.V1_30
     });
 
     expect(blueprint.props.addOns).toHaveLength(1);
@@ -455,7 +455,7 @@ test("Building blueprint with version correctly passes k8s version to the cluste
     expect(blueprint.props.addOns).toHaveLength(1);
 
     blueprint.withBlueprintProps({
-        version: KubernetesVersion.V1_25
+        version: KubernetesVersion.V1_30
     });
 
     const stack = blueprint.build(app, "builder-version-test1");


### PR DESCRIPTION
*Issue #, if available:* Fixes [#1021](https://github.com/aws-quickstart/cdk-eks-blueprints/issues/1021)

*Description of changes:* 
Added tests for 1.30
cdk version update to 2.145.0
cleaned up old versions from 1.25 to 1.30


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
