### PR TITLE
[KEDA] Update helm values to work from v2.14.0

### DIFF
--- a/lib/addons/keda/index.ts
+++ b/lib/addons/keda/index.ts
@@ -25,16 +25,22 @@ export interface KedaAddOnProps extends HelmAddOnUserProps {
     /**
      * securityContext: fsGroup
      * Check the workaround for SQS Scalar with IRSA https://github.com/kedacore/keda/issues/837#issuecomment-789037326
+     *
+     * @deprecated Has no effect for version 2.14 and above. Update podSecurityContext.operator.fsGroup in Values instead. KEDA-is-secure-by-default with fsGroup: 1000
      */
     podSecurityContextFsGroup?: number;
     /**
      * securityContext:runAsGroup
      * Check the workaround for SQS Scalar with IRSA https://github.com/kedacore/keda/issues/837#issuecomment-789037326
+     *
+     * @deprecated Has no effect for version 2.14 and above. Update podSecurityContext.operator.runAsGroup in Values instead. KEDA-is-secure-by-default with runAsGroup: 1000
      */
     securityContextRunAsGroup?: number;
     /**
      * securityContext:runAsUser
      * Check the workaround for SQS Scalar with IRSA https://github.com/kedacore/keda/issues/837#issuecomment-789037326
+     *
+     * @deprecated Has no effect for version 2.14 and above. Update podSecurityContext.operator.runAsUser in Values instead. KEDA-is-secure-by-default with runAsUser: 1000
      */
     securityContextRunAsUser?: number;
     /**


### PR DESCRIPTION
*Issue:*
Since v2.14.0, [#625](https://github.com/kedacore/charts/pull/625/files#diff-3b4e4c10436059483f20fa5b4b2e507a0bcead63f71af2c02ca41dbff3c8b3ad) updates some Helm chart values that are not backward compatible with the old settings. The serviceAccount has been separated per service, such as operator, metricServer, and webhooks.This causes the upgrade to v2.14.0+ to recreate the new operator serviceAccount without the IAM role annotation

*Description of changes:*
- Update version to current latest v2.14.2
- Move creating namespace out of `irsaRole` condition check to avoid CDK delete `keda` namespace if we change irsaRole[] to empty
- Remove workaround for SQS Scalar https://github.com/kedacore/keda/issues/837 as KEDA-is-secure-by-default
- Update  `serviceAccount` to `serviceAccount.operator`
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
