### PR TITLE
[Karpenter] Pod Identity Supports

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -1,18 +1,18 @@
+import * as assert from "assert";
+import { CfnOutput, Duration, Names } from 'aws-cdk-lib';
+import { Cluster, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
+import { Rule } from 'aws-cdk-lib/aws-events';
+import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { Construct } from "constructs";
+import * as semver from 'semver';
 import { merge } from 'ts-deepmerge';
-import { ClusterInfo, Values, BlockDeviceMapping, Taint, Sec, Min, Hour } from '../../spi';
+import * as md5 from 'ts-md5';
+import { BlockDeviceMapping, ClusterInfo, Hour, Min, Sec, Taint, Values } from '../../spi';
 import * as utils from '../../utils';
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '../helm-addon';
 import { KarpenterControllerPolicy, KarpenterControllerPolicyBeta } from './iam';
-import { CfnOutput, Duration, Names } from 'aws-cdk-lib';
-import * as md5 from 'ts-md5';
-import * as semver from 'semver';
-import * as assert from "assert";
-import * as sqs from 'aws-cdk-lib/aws-sqs';
-import { Rule } from 'aws-cdk-lib/aws-events';
-import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
-import { Cluster, KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
 class versionMap {
     private static readonly versionMap: Map<string, string> = new Map([
@@ -275,6 +275,19 @@ export interface KarpenterAddOnProps extends HelmAddOnUserProps {
      * Timeout duration while installing karpenter helm chart using addHelmChart API
      */
     helmChartTimeout?: Duration,
+
+    /**
+     * Use Pod Identity.
+     * To use EKS Pod Identities
+     *  - The cluster must have Kubernetes version 1.24 or later
+     *  - Karpenter Pods must be assigned to Linux Amazon EC2 instances
+     *  - Karpenter version supports Pod Identity (v0.35.0 or later) see https://docs.aws.amazon.com/eks/latest/userguide/pod-identity.html
+     *
+     * @see https://docs.aws.amazon.com/eks/latest/userguide/pod-identity.html
+     *
+     * @default false
+     */
+    podIdentity?: boolean,
 }
 
 const KARPENTER = 'karpenter';
@@ -321,6 +334,8 @@ export class KarpenterAddOn extends HelmAddOn {
 
         const interruption = this.options.interruptionHandling || false;
         const installCRDs = this.options.installCRDs || false;
+
+        const podIdentity = this.options.podIdentity || false;
 
         // NodePool variables
         const labels = this.options.nodePoolSpec?.labels || {};
@@ -446,7 +461,16 @@ export class KarpenterAddOn extends HelmAddOn {
 
         // Create Namespace
         const ns = utils.createNamespace(this.options.namespace!, cluster, true, true);
-        const sa = utils.createServiceAccount(cluster, RELEASE, this.options.namespace!, karpenterPolicyDocument);
+
+        let sa: any;
+        let saAnnotation: any;
+        if (podIdentity && semver.gte(`${clusterInfo.version.version}.0`, '1.24.0') && semver.gte(version, "v0.35.0")){
+          sa = utils.podIdentityAssociation(cluster, RELEASE, this.options.namespace!, karpenterPolicyDocument);
+          saAnnotation = {};
+        } else {
+          sa = utils.createServiceAccount(cluster, RELEASE, this.options.namespace!, karpenterPolicyDocument);
+          saAnnotation = {"eks.amazonaws.com/role-arn": sa.role.roleArn};
+        }
         sa.node.addDependency(ns);
 
         // Create global helm values based on v1beta1 migration as shown below:
@@ -473,13 +497,12 @@ export class KarpenterAddOn extends HelmAddOn {
             utils.setPath(values, "settings", merge(globalSettings, values?.settings ?? {}));
         }
 
+        // Let Helm create the service account if using pod identity
         const saValues = {
             serviceAccount: {
-                create: false,
+                create: podIdentity ? 'true' : 'false',
                 name: RELEASE,
-                annotations: {
-                    "eks.amazonaws.com/role-arn": sa.role.roleArn,
-                }
+                annotations: saAnnotation,
             }
         };
 
@@ -495,17 +518,17 @@ export class KarpenterAddOn extends HelmAddOn {
         }
 
         if (semver.gte(version, "0.32.0") && installCRDs){
-            const CRDs =[ 
+            const CRDs =[
                 [ "karpentersh-nodepool-beta1-crd", `https://raw.githubusercontent.com/aws/karpenter/${version}/pkg/apis/crds/karpenter.sh_nodepools.yaml` ],
                 [ "karpentersh-nodeclaims-beta1-crd", `https://raw.githubusercontent.com/aws/karpenter/${version}/pkg/apis/crds/karpenter.sh_nodeclaims.yaml`],
                 [ "karpenterk8s-ec2nodeclasses-beta1-crd", `https://raw.githubusercontent.com/aws/karpenter/${version}/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml`],
             ];
-            
+
             // loop over the CRD's and load the yaml and deploy the manifest
             for (const [crdName, crdUrl] of CRDs) {
                 const crdManifest = utils.loadExternalYaml(crdUrl);
                 const manifest = cluster.addManifest(crdName, crdManifest);
-                
+
                 // We want these installed before the karpenterChart, or helm will timeout waiting for it to stabilize
                 karpenterChart.node.addDependency(manifest);
             }

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -500,7 +500,7 @@ export class KarpenterAddOn extends HelmAddOn {
         // Let Helm create the service account if using pod identity
         const saValues = {
             serviceAccount: {
-                create: podIdentity ? 'true' : 'false',
+                create: podIdentity,
                 name: RELEASE,
                 annotations: saAnnotation,
             }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -6,6 +6,7 @@ export * from './context-utils';
 export * from './log-utils';
 export * from './namespace-utils';
 export * from './object-utils';
+export * from './pod-identity-utils';
 export * from './proxy-utils';
 export * from './registry-utils';
 export * from './sa-utils';

--- a/lib/utils/pod-identity-utils.ts
+++ b/lib/utils/pod-identity-utils.ts
@@ -1,0 +1,45 @@
+import { CfnPodIdentityAssociation, ICluster } from "aws-cdk-lib/aws-eks";
+import * as iam from "aws-cdk-lib/aws-iam";
+
+/**
+ * Creates IAM role and EKS Pod Identity association
+ * @param clusterInfo
+ * @param name
+ * @param namespace
+ * @param policyDocument
+ *
+ * @returns podIdentityAssociation
+ */
+export function podIdentityAssociation(
+  cluster: ICluster,
+  name: string,
+  namespace: string,
+  policyDocument: iam.PolicyDocument
+): CfnPodIdentityAssociation {
+  const policy = new iam.ManagedPolicy(cluster, `${name}-managed-policy`, {
+    document: policyDocument,
+  });
+
+  const role = new iam.Role(cluster, `${name}-role`, {
+    assumedBy: new iam.ServicePrincipal("pods.eks.amazonaws.com"),
+  });
+  role.assumeRolePolicy?.addStatements(
+    new iam.PolicyStatement({
+      sid: "AllowEksAuthToAssumeRoleForPodIdentity",
+      actions: [
+        "sts:AssumeRole",
+        "sts:TagSession"
+      ],
+      principals: [new iam.ServicePrincipal("pods.eks.amazonaws.com")],
+    })
+  );
+  role.addManagedPolicy(policy);
+
+  const podIdentityAssociation = new CfnPodIdentityAssociation(cluster, `${name}-pod-identity-association`, {
+    clusterName: cluster.clusterName,
+    namespace,
+    roleArn: role.roleArn,
+    serviceAccount: name,
+  });
+  return podIdentityAssociation;
+}


### PR DESCRIPTION
*Issue:*
**Pod Identity Supports Notice**
Karpenter now supports using [Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to authenticate AWS SDK to make API requests to AWS services using AWS Identity and Access Management (IAM) permissions.

*Description of changes:*
- Introduce option to enable Pod Identity, this replaces IRSA method to manage credentials for Karpenter controller.
- Resources created for using Pod Identity
   - IAM role with service principle `pods.eks.amazonaws.com` and allow actions `sts:AssumeRole` and `sts:TagSession`
   - Pod Identity associations
   - Service account created by Helm chart without `eks.amazonaws.com/role-arn` annotation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
