### PR TITLE
Additional Settings to VpcCniAddOn

### DIFF
--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -432,19 +432,16 @@ export class VpcCniAddOn extends CoreAddOn {
   }
 }
 
-/**
- * Iterates over all values including nested child objects, removes undefined entries and stringifies the remaining if they are not already strings
- */
-function ConvertPropertiesToString(helmValues: Values): void {
+  /**
+   * Iterates over all Values including nested child objects and removes undefined entries
+   */
+function RemoveUndefined(helmValues: Values): void {
   Object.keys(helmValues).forEach(key => {
     if (helmValues[key] === undefined) {
       delete helmValues[key];
     }
     else if (typeof helmValues[key] === 'object'){
-      ConvertPropertiesToString(helmValues[key]);
-    }
-    else if (typeof helmValues[key] !== 'string'){
-      helmValues[key] = JSON.stringify(helmValues[key]);
+      RemoveUndefined(helmValues[key]);
     }
   });
 }
@@ -457,56 +454,56 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
   const result: Values = {
     init: {
       env: {
-        DISABLE_TCP_EARLY_DEMUX: props?.disableTcpEarlyDemux,
-        ENABLE_V6_EGRESS: props?.enableV6Egress,
+        DISABLE_TCP_EARLY_DEMUX: JSON.stringify(props?.disableTcpEarlyDemux), // format: boolean, type: string
+        ENABLE_V6_EGRESS: JSON.stringify(props?.enableV6Egress), // format: boolean, type: string
       }
     },
     env: {
-      AWS_EC2_ENDPOINT: props?.awsEc2Endpoint,
-      ADDITIONAL_ENI_TAGS: props?.additionalEniTags,
-      ANNOTATE_POD_IP: props?.annotatePodIp,
-      AWS_EXTERNAL_SERVICE_CIDR: props?.awsExternalServiceCidrs,
-      AWS_MANAGE_ENIS_NON_SCHEDULABLE: props?.awsManageEnisNonSchedulable,
-      AWS_VPC_CNI_NODE_PORT_SUPPORT: props?.awsVpcCniNodePortSupport,
-      AWS_VPC_ENI_MTU: props?.awsVpcEniMtu,
-      AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: props?.awsVpcK8sCniCustomNetworkCfg,
-      AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS: props?.awsVpcK8sExcludeSnatCidrs,
-      ENI_CONFIG_LABEL_DEF: props?.eniConfigLabelDef,
-      ENI_CONFIG_ANNOTATION_DEF: props?.eniConfigAnnotationDef,
-      AWS_VPC_K8S_CNI_EXTERNALSNAT: props?.awsVpcK8sCniExternalSnat,
-      AWS_VPC_K8S_CNI_LOGLEVEL: props?.awsVpcK8sCniLogLevel,
-      AWS_VPC_K8S_CNI_LOG_FILE: props?.awsVpcK8sCniLogFile,
-      AWS_VPC_K8S_CNI_RANDOMIZESNAT: props?.awsVpcK8sCniRandomizeSnat,
-      AWS_VPC_K8S_CNI_VETHPREFIX: props?.awsVpcK8sCniVethPrefix,
-      AWS_VPC_K8S_PLUGIN_LOG_FILE: props?.awsVpcK8sPluginLogFile,
-      AWS_VPC_K8S_PLUGIN_LOG_LEVEL: props?.awsVpcK8sPluginLogLevel,
-      CLUSTER_ENDPOINT: props?.clusterEndpoint,
-      DISABLE_LEAKED_ENI_CLEANUP: props?.disableLeakedEniCleanup,
-      DISABLE_INTROSPECTION: props?.disableIntrospection,
-      DISABLE_METRICS: props?.disableMetrics,
-      DISABLE_NETWORK_RESOURCE_PROVISIONING: props?.disablenetworkResourceProvisioning,
-      ENABLE_BANDWIDTH_PLUGIN: props?.enableBandwidthPlugin,
-      ENABLE_NFTABLES: props?.enableNftables,
-      ENABLE_POD_ENI: props?.enablePodEni,
-      ENABLE_PREFIX_DELEGATION: props?.enablePrefixDelegation,
-      INTROSPECTION_BIND_ADDRESS: props?.introspectionBindAddress,
-      MAX_ENI: props?.maxEni,
-      MINIMUM_IP_TARGET: props?.minimumIpTarget,
-      POD_SECURITY_GROUP_ENFORCING_MODE: props?.podSecurityGroupEnforcingMode,
-      WARM_ENI_TARGET: props?.warmEniTarget,
-      WARM_IP_TARGET: props?.warmIpTarget,
-      WARM_PREFIX_TARGET: props?.warmPrefixTarget,
+      AWS_EC2_ENDPOINT: props?.awsEc2Endpoint, // type: string
+      ADDITIONAL_ENI_TAGS: props?.additionalEniTags, // type: string
+      ANNOTATE_POD_IP: JSON.stringify(props?.annotatePodIp), // format: boolean, type: string
+      AWS_EXTERNAL_SERVICE_CIDR: props?.awsExternalServiceCidrs, // type: string
+      AWS_MANAGE_ENIS_NON_SCHEDULABLE: JSON.stringify(props?.awsManageEnisNonSchedulable), // format: boolean, type: string
+      AWS_VPC_CNI_NODE_PORT_SUPPORT: JSON.stringify(props?.awsVpcCniNodePortSupport), // format: boolean, type: string
+      AWS_VPC_ENI_MTU: JSON.stringify(props?.awsVpcEniMtu), // format: integer, type: string
+      AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: JSON.stringify(props?.awsVpcK8sCniCustomNetworkCfg), // format: boolean, type: string
+      AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS: props?.awsVpcK8sExcludeSnatCidrs, // type: string
+      ENI_CONFIG_LABEL_DEF: props?.eniConfigLabelDef, // type: string
+      ENI_CONFIG_ANNOTATION_DEF: props?.eniConfigAnnotationDef, // type: string
+      AWS_VPC_K8S_CNI_EXTERNALSNAT: JSON.stringify(props?.awsVpcK8sCniExternalSnat), // format: boolean, type: string
+      AWS_VPC_K8S_CNI_LOGLEVEL: props?.awsVpcK8sCniLogLevel, // type: string
+      AWS_VPC_K8S_CNI_LOG_FILE: props?.awsVpcK8sCniLogFile, // type: string
+      AWS_VPC_K8S_CNI_RANDOMIZESNAT: props?.awsVpcK8sCniRandomizeSnat, // type: string
+      AWS_VPC_K8S_CNI_VETHPREFIX: props?.awsVpcK8sCniVethPrefix, // type: string
+      AWS_VPC_K8S_PLUGIN_LOG_FILE: props?.awsVpcK8sPluginLogFile, // type: string
+      AWS_VPC_K8S_PLUGIN_LOG_LEVEL: props?.awsVpcK8sPluginLogLevel, // type: string
+      CLUSTER_ENDPOINT: props?.clusterEndpoint, // type: string
+      DISABLE_LEAKED_ENI_CLEANUP: JSON.stringify(props?.disableLeakedEniCleanup), // format: boolean, type: string
+      DISABLE_INTROSPECTION: JSON.stringify(props?.disableIntrospection), // format: boolean, type: string
+      DISABLE_METRICS: JSON.stringify(props?.disableMetrics), // format: boolean, type: string
+      DISABLE_NETWORK_RESOURCE_PROVISIONING: JSON.stringify(props?.disablenetworkResourceProvisioning), // format: boolean, type: string
+      ENABLE_BANDWIDTH_PLUGIN: JSON.stringify(props?.enableBandwidthPlugin), // format: boolean, type: string
+      ENABLE_NFTABLES: JSON.stringify(props?.enableNftables), // format: boolean, type: string
+      ENABLE_POD_ENI: JSON.stringify(props?.enablePodEni), // format: boolean, type: string
+      ENABLE_PREFIX_DELEGATION: JSON.stringify(props?.enablePrefixDelegation), // format: boolean, type: string
+      INTROSPECTION_BIND_ADDRESS: props?.introspectionBindAddress, // type: string
+      MAX_ENI: JSON.stringify(props?.maxEni), // format: integer, type: string
+      MINIMUM_IP_TARGET: JSON.stringify(props?.minimumIpTarget), // format: integer, type: string
+      POD_SECURITY_GROUP_ENFORCING_MODE: props?.podSecurityGroupEnforcingMode, // type: string
+      WARM_ENI_TARGET: JSON.stringify(props?.warmEniTarget), // format: integer, type: string
+      WARM_IP_TARGET: JSON.stringify(props?.warmIpTarget), // format: integer, type: string
+      WARM_PREFIX_TARGET: JSON.stringify(props?.warmPrefixTarget), // format: integer, type: string
     },
-    enableNetworkPolicy: props?.enableNetworkPolicy,
-    enableWindowsIpam: props?.enableWindowsIpam,
-    enableWindowsPrefixDelegation: props?.enableWindowsPrefixDelegation,
-    warmWindowsPrefixTarget: props?.warmWindowsPrefixTarget,
-    warmWindowsIPTarget: props?.warmWindowsIPTarget,
-    minimumWindowsIPTarget: props?.minimumWindowsIPTarget,
-    branchENICooldown: props?.branchENICooldown,
+    enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy), // format: boolean, type: string
+    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam), // format: boolean, type: string
+    enableWindowsPrefixDelegation: JSON.stringify(props?.enableWindowsPrefixDelegation), // format: boolean, type: string
+    warmWindowsPrefixTarget: props?.warmWindowsPrefixTarget, // type: integer
+    warmWindowsIPTarget: props?.warmWindowsIPTarget, // type: integer
+    minimumWindowsIPTarget: props?.minimumWindowsIPTarget, // type: integer
+    branchENICooldown: props?.branchENICooldown, // type: integer
   };
 
-  ConvertPropertiesToString(result);
+  RemoveUndefined(result);
 
   return result;
 }

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -298,14 +298,14 @@ export interface VpcCniAddOnProps {
   enableWindowsIpam?: boolean;
 
   /**
-   * Enable prefix delegation for windows
+   * Enable prefix delegation for Windows nodes
    */
   enableWindowsPrefixDelegation?: boolean;
 
   /**
    * `warm-prefix-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of free IPv4(/28) prefixes that the ipamd daemon
-   * should attempt to keep available for pod assignment on the node.
+   * should attempt to keep available for pod assignment on Windows nodes.
    */
   warmWindowsPrefixTarget?: number;
 
@@ -319,7 +319,7 @@ export interface VpcCniAddOnProps {
   /**
    * `minimum-ip-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of total IP addresses that the ipamd
-   * daemon should attempt to allocate for pod assignment on a Window nodes.
+   * daemon should attempt to allocate for pod assignment on a Windows nodes.
    */
   minimumWindowsIPTarget?: number;
 

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -298,6 +298,37 @@ export interface VpcCniAddOnProps {
   enableWindowsIpam?: boolean;
 
   /**
+   * Enable prefix delegation for windows
+   */
+  enableWindowsPrefixDelegation?: boolean;
+
+  /**
+   * `warm-prefix-target` value in amazon-vpc-cni config map. Format integer.
+   * Specifies the number of free IPv4(/28) prefixes that the ipamd daemon
+   * should attempt to keep available for pod assignment on the node.
+   */
+  warmWindowsPrefixTarget?: boolean;
+
+  /**
+   * `warm-ip-target` value in amazon-vpc-cni config map. Format integer.
+   * Specifies the number of free IP addresses that the ipamd daemon
+   * should attempt to keep available for pod assignment on Windows nodes.
+   */
+  warmWindowsIPTarget?: boolean;
+
+  /**
+   * `minimum-ip-target` value in amazon-vpc-cni config map. Format integer.
+   * Specifies the number of total IP addresses that the ipamd
+   * daemon should attempt to allocate for pod assignment on a Window nodes.
+   */
+  minimumWindowsIPTarget?: boolean;
+
+  /**
+   * `branch-eni-cooldown` value in amazon-vpc-cni config map. Format integer.
+   */
+  branchENICooldown?: boolean;
+
+  /**
    * Version of the add-on to use. Must match the version of the cluster where it
    * will be deployed.
    */
@@ -450,7 +481,12 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       WARM_PREFIX_TARGET: props?.warmPrefixTarget,
     },
     enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
-    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam)
+    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam),
+    enableWindowsPrefixDelegation: JSON.stringify(props?.enableWindowsPrefixDelegation),
+    warmWindowsPrefixTarget: JSON.stringify(props?.warmWindowsPrefixTarget),
+    warmWindowsIPTarget: JSON.stringify(props?.warmWindowsIPTarget),
+    minimumWindowsIPTarget: JSON.stringify(props?.minimumWindowsIPTarget),
+    branchENICooldown: JSON.stringify(props?.branchENICooldown)
   };
 
   // clean up all undefined

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -432,9 +432,9 @@ export class VpcCniAddOn extends CoreAddOn {
   }
 }
 
-  /**
-   * Iterates over all Values including nested child objects and removes undefined entries
-   */
+/**
+ * Iterates over all Values including nested child objects and removes undefined entries
+ */
 function RemoveUndefined(helmValues: Values): void {
   Object.keys(helmValues).forEach(key => {
     if (helmValues[key] === undefined) {

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -307,26 +307,26 @@ export interface VpcCniAddOnProps {
    * Specifies the number of free IPv4(/28) prefixes that the ipamd daemon
    * should attempt to keep available for pod assignment on the node.
    */
-  warmWindowsPrefixTarget?: boolean;
+  warmWindowsPrefixTarget?: number;
 
   /**
    * `warm-ip-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of free IP addresses that the ipamd daemon
    * should attempt to keep available for pod assignment on Windows nodes.
    */
-  warmWindowsIPTarget?: boolean;
+  warmWindowsIPTarget?: number;
 
   /**
    * `minimum-ip-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of total IP addresses that the ipamd
    * daemon should attempt to allocate for pod assignment on a Window nodes.
    */
-  minimumWindowsIPTarget?: boolean;
+  minimumWindowsIPTarget?: number;
 
   /**
    * `branch-eni-cooldown` value in amazon-vpc-cni config map. Format integer.
    */
-  branchENICooldown?: boolean;
+  branchENICooldown?: number;
 
   /**
    * Version of the add-on to use. Must match the version of the cluster where it

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -483,10 +483,10 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
     enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
     enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam),
     enableWindowsPrefixDelegation: JSON.stringify(props?.enableWindowsPrefixDelegation),
-    warmWindowsPrefixTarget: JSON.stringify(props?.warmWindowsPrefixTarget),
-    warmWindowsIPTarget: JSON.stringify(props?.warmWindowsIPTarget),
-    minimumWindowsIPTarget: JSON.stringify(props?.minimumWindowsIPTarget),
-    branchENICooldown: JSON.stringify(props?.branchENICooldown)
+    warmWindowsPrefixTarget: props?.warmWindowsPrefixTarget,
+    warmWindowsIPTarget: props?.warmWindowsIPTarget,
+    minimumWindowsIPTarget: props?.minimumWindowsIPTarget,
+    branchENICooldown: props?.branchENICooldown
   };
 
   // clean up all undefined


### PR DESCRIPTION
This PR adds support to provide values for certain settings of the VpcCniAddOn that were introduced in amazon-vpc-cni-k8s [v1.16.0](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.16.0) in PR [additional settings to the helm chart](https://github.com/aws/amazon-vpc-cni-k8s/pull/2715)

- enable-windows-prefix-delegation
- warm-prefix-target
- warm-ip-target
- minimum-ip-target
- branch-eni-cooldown


I verified that this code change does not introduce any functional changes for the already existing vpc-cni settings by comparing the generated cloud formation output for different sets of parameters generated with and without this change and assure they are equal. For the newly introduced vpc-cni settings I tested that they are deployed to an eks ckuster as desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
