### PR TITLE
Additional Settings to VpcCniAddOn (duplicate)

### DIFF
--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -298,14 +298,14 @@ export interface VpcCniAddOnProps {
   enableWindowsIpam?: boolean;
 
   /**
-   * Enable prefix delegation for windows
+   * Enable prefix delegation for Windows nodes
    */
   enableWindowsPrefixDelegation?: boolean;
 
   /**
    * `warm-prefix-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of free IPv4(/28) prefixes that the ipamd daemon
-   * should attempt to keep available for pod assignment on the node.
+   * should attempt to keep available for pod assignment on Windows nodes.
    */
   warmWindowsPrefixTarget?: number;
 
@@ -319,7 +319,7 @@ export interface VpcCniAddOnProps {
   /**
    * `minimum-ip-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of total IP addresses that the ipamd
-   * daemon should attempt to allocate for pod assignment on a Window nodes.
+   * daemon should attempt to allocate for pod assignment on a Windows nodes.
    */
   minimumWindowsIPTarget?: number;
 

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -298,6 +298,37 @@ export interface VpcCniAddOnProps {
   enableWindowsIpam?: boolean;
 
   /**
+   * Enable prefix delegation for windows
+   */
+  enableWindowsPrefixDelegation?: boolean;
+
+  /**
+   * `warm-prefix-target` value in amazon-vpc-cni config map. Format integer.
+   * Specifies the number of free IPv4(/28) prefixes that the ipamd daemon
+   * should attempt to keep available for pod assignment on the node.
+   */
+  warmWindowsPrefixTarget?: boolean;
+
+  /**
+   * `warm-ip-target` value in amazon-vpc-cni config map. Format integer.
+   * Specifies the number of free IP addresses that the ipamd daemon
+   * should attempt to keep available for pod assignment on Windows nodes.
+   */
+  warmWindowsIPTarget?: boolean;
+
+  /**
+   * `minimum-ip-target` value in amazon-vpc-cni config map. Format integer.
+   * Specifies the number of total IP addresses that the ipamd
+   * daemon should attempt to allocate for pod assignment on a Window nodes.
+   */
+  minimumWindowsIPTarget?: boolean;
+
+  /**
+   * `branch-eni-cooldown` value in amazon-vpc-cni config map. Format integer.
+   */
+  branchENICooldown?: boolean;
+
+  /**
    * Version of the add-on to use. Must match the version of the cluster where it
    * will be deployed.
    */
@@ -450,7 +481,12 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       WARM_PREFIX_TARGET: props?.warmPrefixTarget,
     },
     enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
-    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam)
+    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam),
+    enableWindowsPrefixDelegation: JSON.stringify(props?.enableWindowsPrefixDelegation),
+    warmWindowsPrefixTarget: JSON.stringify(props?.warmWindowsPrefixTarget),
+    warmWindowsIPTarget: JSON.stringify(props?.warmWindowsIPTarget),
+    minimumWindowsIPTarget: JSON.stringify(props?.minimumWindowsIPTarget),
+    branchENICooldown: JSON.stringify(props?.branchENICooldown)
   };
 
   // clean up all undefined

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -307,26 +307,26 @@ export interface VpcCniAddOnProps {
    * Specifies the number of free IPv4(/28) prefixes that the ipamd daemon
    * should attempt to keep available for pod assignment on the node.
    */
-  warmWindowsPrefixTarget?: boolean;
+  warmWindowsPrefixTarget?: number;
 
   /**
    * `warm-ip-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of free IP addresses that the ipamd daemon
    * should attempt to keep available for pod assignment on Windows nodes.
    */
-  warmWindowsIPTarget?: boolean;
+  warmWindowsIPTarget?: number;
 
   /**
    * `minimum-ip-target` value in amazon-vpc-cni config map. Format integer.
    * Specifies the number of total IP addresses that the ipamd
    * daemon should attempt to allocate for pod assignment on a Window nodes.
    */
-  minimumWindowsIPTarget?: boolean;
+  minimumWindowsIPTarget?: number;
 
   /**
    * `branch-eni-cooldown` value in amazon-vpc-cni config map. Format integer.
    */
-  branchENICooldown?: boolean;
+  branchENICooldown?: number;
 
   /**
    * Version of the add-on to use. Must match the version of the cluster where it

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -483,10 +483,10 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
     enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
     enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam),
     enableWindowsPrefixDelegation: JSON.stringify(props?.enableWindowsPrefixDelegation),
-    warmWindowsPrefixTarget: JSON.stringify(props?.warmWindowsPrefixTarget),
-    warmWindowsIPTarget: JSON.stringify(props?.warmWindowsIPTarget),
-    minimumWindowsIPTarget: JSON.stringify(props?.minimumWindowsIPTarget),
-    branchENICooldown: JSON.stringify(props?.branchENICooldown)
+    warmWindowsPrefixTarget: props?.warmWindowsPrefixTarget,
+    warmWindowsIPTarget: props?.warmWindowsIPTarget,
+    minimumWindowsIPTarget: props?.minimumWindowsIPTarget,
+    branchENICooldown: props?.branchENICooldown
   };
 
   // clean up all undefined


### PR DESCRIPTION
This PR adds support to provide values for certain settings of the VpcCniAddOn that were introduced in amazon-vpc-cni-k8s [v1.16.0](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.16.0) in PR [additional settings to the helm chart](https://github.com/aws/amazon-vpc-cni-k8s/pull/2715)

- enable-windows-prefix-delegation
- warm-prefix-target
- warm-ip-target
- minimum-ip-target
- branch-eni-cooldown

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.