### PR TITLE
handle stringification the same way for all vpc-cni configuration pro…

### DIFF
--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -401,19 +401,19 @@ export class VpcCniAddOn extends CoreAddOn {
   }
 }
 
-  /**
-   * Iterates over all values including nested child objects, removes undefined entries and stringifies the remaining if they are not already strings
-   */
+/**
+ * Iterates over all values including nested child objects, removes undefined entries and stringifies the remaining if they are not already strings
+ */
 function ConvertPropertiesToString(helmValues: Values): void {
   Object.keys(helmValues).forEach(key => {
     if (helmValues[key] === undefined) {
-      delete helmValues[key]
+      delete helmValues[key];
     }
     else if (typeof helmValues[key] === 'object'){
       ConvertPropertiesToString(helmValues[key]);
     }
     else if (typeof helmValues[key] !== 'string'){
-      helmValues[key] = JSON.stringify(helmValues[key])
+      helmValues[key] = JSON.stringify(helmValues[key]);
     }
   });
 }

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -402,7 +402,7 @@ export class VpcCniAddOn extends CoreAddOn {
 }
 
   /**
-   * Iterates over all Values including nested child objects, removes undefined entries and stringifies the remaining if they are not already strings
+   * Iterates over all values including nested child objects, removes undefined entries and stringifies the remaining if they are not already strings
    */
 function ConvertPropertiesToString(helmValues: Values): void {
   Object.keys(helmValues).forEach(key => {

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -401,6 +401,23 @@ export class VpcCniAddOn extends CoreAddOn {
   }
 }
 
+  /**
+   * Iterates over all Values including nested child objects, removes undefined entries and stringifies the remaining if they are not already strings
+   */
+function ConvertPropertiesToString(helmValues: Values): void {
+  Object.keys(helmValues).forEach(key => {
+    if (helmValues[key] === undefined) {
+      delete helmValues[key]
+    }
+    else if (typeof helmValues[key] === 'object'){
+      ConvertPropertiesToString(helmValues[key]);
+    }
+    else if (typeof helmValues[key] !== 'string'){
+      helmValues[key] = JSON.stringify(helmValues[key])
+    }
+  });
+}
+
 function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
   if (props === null) {
     return {};
@@ -449,19 +466,11 @@ function populateVpcCniConfigurationValues(props?: VpcCniAddOnProps): Values {
       WARM_IP_TARGET: props?.warmIpTarget,
       WARM_PREFIX_TARGET: props?.warmPrefixTarget,
     },
-    enableNetworkPolicy: JSON.stringify(props?.enableNetworkPolicy),
-    enableWindowsIpam: JSON.stringify(props?.enableWindowsIpam)
+    enableNetworkPolicy: props?.enableNetworkPolicy,
+    enableWindowsIpam: props?.enableWindowsIpam
   };
 
-  // clean up all undefined
-  const values = result.env;
-  Object.keys(values).forEach(key => values[key] === undefined ? delete values[key] : {});
-  Object.keys(values).forEach(key => values[key] = typeof values[key] !== 'string' ? JSON.stringify(values[key]) : values[key]);
-
-  // clean up all undefined on Init env
-  const initValues = result.init.env;
-  Object.keys(initValues).forEach(key => initValues[key] === undefined ? delete initValues[key] : {});
-  Object.keys(initValues).forEach(key => initValues[key] = typeof initValues[key] !== 'string' ? JSON.stringify(initValues[key]) : initValues[key]);
+  ConvertPropertiesToString(result);
 
   return result;
 }


### PR DESCRIPTION
A finding of #1044 was that the way the configuration properties for the vpc-cni plugin are converted to strings is not handled in the same way for all properties.

Configuration for the vpc-cni core addon is defined as following structure:

```
  const result: Values = {
    init: {
      env: {
        DISABLE_TCP_EARLY_DEMUX: props?.disableTcpEarlyDemux,
        ENABLE_V6_EGRESS: props?.enableV6Egress,
      }
    },
    env: {
      AWS_EC2_ENDPOINT: props?.awsEc2Endpoint,
      ADDITIONAL_ENI_TAGS: props?.additionalEniTags,
      .. some more properties
    },
    enableNetworkPolicy: props?.enableNetworkPolicy,
    enableWindowsIpam: props?.enableWindowsIpam
  };
```

Before that configuration is passed to the core addon undefined properties are removed and non-string properties are converted into strings by calling JSON.stringify().

For the "env" and "init.env" subobjects this is done in line 456 and 461 in a loop that iterates over all properties of this child objects, for the properties of the main object however JSON.stringify() is called when assigning the values in line 469 and 470.


This pull request changes that in a way that there is a recursive function "ConvertPropertiesToString" that handles the functionality described above by iterating over the whole configuration object including the embeded subobjects.


I verified that this code change does not introduce any functional changes by comparing the generated cloud formation output for different sets of parameters generated with and without this change and assure they are equal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
