### PR TITLE
IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ cdk init app --language typescript
 cdk bootstrap aws://<AWS_ACCOUNT_ID>/<AWS_REGION>
 ```
 
-### Usage
+### Usage for IPv4 cluster
 
-Run the following command to install the `eks-blueprints` dependency in your project.
+Run the following command to install the `eks-blueprints` dependency in your project. By default, blueprints creates IPv4 cluster.
 
 ```sh
 npm i @aws-quickstart/eks-blueprints
@@ -108,18 +108,71 @@ const stack = blueprints.EksBlueprint.builder()
     .account(account)
     .region(region)
     .addOns(...addOns)
-    .build(app, 'eks-blueprint');
+    .build(app, 'eks-blueprint-ipv4');
 // do something with stack or drop this variable
+```
+
+
+### Usage for IPv6 cluster
+
+Run the following command to install the `eks-blueprints` dependency in your project. This example creates Ipv6 cluster.
+
+#### Note: ipFamily has been introduced to support ipv6 cluster.
+
+At time of creation, if VPC is not provided to EKS blueprints. It will automatically divide the provided VPC CIDR range, and create public and private subnets per Availability Zone.
+Network routing for the public subnets will be configured to allow outbound access directly via an Internet Gateway.
+Network routing for the private subnets will be configured to allow outbound access via a one NAT Gateway to reduce the cost.
+IPv6 does not require NAT for pod to pod communication. By default, we are creating one NAT for cluster communications outside endpoints if any.
+
+```typescript
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+const app = new cdk.App();
+
+// AddOns for the cluster. For ipv6 cluster, we haven't tested with all the addons except for the below addons.
+const addOns: Array<blueprints.ClusterAddOn> = [
+    new blueprints.addons.VpcCniAddOn(),
+    new blueprints.addons.KarpenterAddOn(),
+    new blueprints.addons.SecretsStoreAddOn()
+];
+
+const account = 'XXXXXXXXXXXXX';
+const region = 'us-east-2';
+const ipFamily = IpFamily.IP_V6; //IpFamily.IP_V6 isquavelent to "ipv6"
+
+const stack = blueprints.EksBlueprint.builder()
+    .account(account)
+    .region(region)
+    .ipFamily(ipFamily)
+    .addOns(...addOns)
+    .build(app, 'eks-blueprint-ipv6');
+
 ```
 
 Note: if the account/region combination used in the code example above is different from the initial combination used with `cdk bootstrap`, you will need to perform `cdk bootstrap` again to avoid error.
 
 Please reference [CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html) usage doc for detail.
 
-Deploy the stack using the following command
+List the stacks using the following command
 
 ```sh
-cdk deploy
+cdk list 
+```
+Example output for `cdk list`:
+```sh
+eks-blueprint-ipv4
+eks-blueprint-ipv6
+```
+
+Deploy the stack using the following command
+```sh
+cdk deploy <stack-name>
+```
+Example to deploy IPv6 cluster:
+```sh
+cdk deploy eks-blueprint-ipv6
 ```
 
 This will provision the following:

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
-import BlueprintConstruct from '../examples/blueprint-construct';
 import BlueprintIPV6Construct from '../examples/blueprint-ipv6-construct';
+import BlueprintIPv4Construct from "../examples/blueprint-ipv4-construct";
 
 const app = new cdk.App();
 
@@ -9,7 +9,7 @@ const account = process.env.CDK_DEFAULT_ACCOUNT;
 const region = process.env.CDK_DEFAULT_REGION;
 const props = { env: { account, region } };
 
-new BlueprintConstruct(app, props);
+new BlueprintIPv4Construct(app, props);
 
 // Create ipv6 cluster
 new BlueprintIPV6Construct(app, props);

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import BlueprintConstruct from '../examples/blueprint-construct';
+import BlueprintIPV6Construct from '../examples/blueprint-ipv6-construct';
 
 const app = new cdk.App();
 
@@ -9,3 +10,6 @@ const region = process.env.CDK_DEFAULT_REGION;
 const props = { env: { account, region } };
 
 new BlueprintConstruct(app, props);
+
+// Create ipv6 cluster
+new BlueprintIPV6Construct(app, props);

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -7,9 +7,10 @@ const app = new cdk.App();
 
 const account = process.env.CDK_DEFAULT_ACCOUNT;
 const region = process.env.CDK_DEFAULT_REGION;
-const props = { env: { account, region } };
-
+let props = { env: { account, region } };
 new BlueprintIPv4Construct(app, props);
 
+// Deploying IPV6 cluster in us-east-2 region. Assuming IPV4 cluster will be deployed to another region.
+props = { env: { account,  region: "us-east-2" } };
 // Create ipv6 cluster
 new BlueprintIPV6Construct(app, props);

--- a/examples/blueprint-ipv4-construct/index.ts
+++ b/examples/blueprint-ipv4-construct/index.ts
@@ -1,0 +1,37 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from "constructs";
+import * as blueprints from '../../lib';
+import BlueprintConstruct from "../blueprint-construct";
+
+const blueprintID = 'blueprint-construct-dev';
+
+export interface BlueprintConstructProps {
+    /**
+     * Id
+     */
+    id: string
+}
+
+export default class BlueprintIPv4Construct extends BlueprintConstruct {
+    constructor(scope: Construct, props: cdk.StackProps) {
+        super(scope, props);
+
+        blueprints.EksBlueprint.builder()
+            .addOns(...this.addOns)
+            .resourceProvider(blueprints.GlobalResources.Vpc, new blueprints.VpcProvider(undefined, {
+                primaryCidr: "10.2.0.0/16",
+                secondaryCidr: "100.64.0.0/16",
+                secondarySubnetCidrs: ["100.64.0.0/24","100.64.1.0/24","100.64.2.0/24"]
+            }))
+            .resourceProvider("node-role", this.nodeRole)
+            .resourceProvider('apache-airflow-s3-bucket-provider', this.apacheAirflowS3Bucket)
+            .resourceProvider('apache-airflow-efs-provider', this.apacheAirflowEfs)
+            .clusterProvider(this.clusterProvider)
+            .resourceProvider(this.ampWorkspaceName, new blueprints.CreateAmpProvider(this.ampWorkspaceName, this.ampWorkspaceName))
+            .teams(...this.teams, new blueprints.EmrEksTeam(this.dataTeam), new blueprints.BatchEksTeam(this.batchTeam))
+            .enableControlPlaneLogTypes(blueprints.ControlPlaneLogType.API)
+            .build(scope, blueprintID, props);
+
+    }
+}
+

--- a/examples/blueprint-ipv6-construct/index.ts
+++ b/examples/blueprint-ipv6-construct/index.ts
@@ -1,0 +1,233 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { CapacityType, KubernetesVersion, NodegroupAmiType, IpFamily } from 'aws-cdk-lib/aws-eks';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from "constructs";
+import * as blueprints from '../../lib';
+import { logger, userLog } from '../../lib/utils';
+import * as team from '../teams';
+
+const burnhamManifestDir = './examples/teams/team-burnham/';
+const rikerManifestDir = './examples/teams/team-riker/';
+const teamManifestDirList = [burnhamManifestDir, rikerManifestDir];
+const blueprintID = 'blueprint-ipv6-construct-dev';
+
+export interface BlueprintIPv6ConstructProps {
+    /**
+     * Id
+     */
+    id: string
+}
+
+/*
+** This class is modification of ../blueprint-contruct/index.ts
+** To have IPv6 configurations, BlueprintConstruct has been replicated and updated to BlueprintIPV6Construct.
+ */
+export default class BlueprintIPV6Construct {
+    constructor(scope: Construct, props: cdk.StackProps) {
+
+        blueprints.HelmAddOn.validateHelmVersions = true;
+        blueprints.HelmAddOn.failOnVersionValidation = false;
+        logger.settings.minLevel = 3; // info
+        userLog.settings.minLevel = 2; // debug
+
+        const teams: Array<blueprints.Team> = [
+            new team.TeamTroi,
+            new team.TeamRiker(scope, teamManifestDirList[1]),
+            new team.TeamBurnham(scope, teamManifestDirList[0]),
+            new team.TeamPlatform(process.env.CDK_DEFAULT_ACCOUNT!)
+        ];
+
+        const nodeRole = new blueprints.CreateIPv6NodeRoleProvider("blueprint-node-role", new iam.ServicePrincipal("ec2.amazonaws.com"),
+            [
+                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
+                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
+                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore")
+            ]);
+
+        const nodeClassSpec: blueprints.Ec2NodeClassSpec = {
+            amiFamily: "AL2",
+            subnetSelectorTerms: [{ tags: { "Name": `${blueprintID}/${blueprintID}/${blueprintID}-vpc/PrivateSubnet*` }}],
+            securityGroupSelectorTerms: [{ tags: { "aws:eks:cluster-name": `${blueprintID}` }}],
+        };
+
+        const nodePoolSpec: blueprints.NodePoolSpec = {
+            labels: {
+                type: "karpenter-test"
+            },
+            annotations: {
+                "eks-blueprints/owner": "bugatha"
+            },
+            requirements: [
+                { key: 'node.kubernetes.io/instance-type', operator: 'In', values: ["c5.large", "m5.large", "r5.large", "m5.xlarge"] },
+                { key: 'topology.kubernetes.io/zone', operator: 'In', values: [`${props?.env?.region}a`,`${props?.env?.region}b`]},
+                { key: 'kubernetes.io/arch', operator: 'In', values: ['amd64','arm64']},
+                { key: 'karpenter.sh/capacity-type', operator: 'In', values: ['on-demand']},
+            ],
+            disruption: {
+                consolidationPolicy: "WhenEmpty",
+                consolidateAfter: "30s",
+                expireAfter: "20m",
+            }
+        };
+
+        const addOns: Array<blueprints.ClusterAddOn> = [
+            new blueprints.addons.KarpenterAddOn({
+                version: "v0.34.5",
+                nodePoolSpec: nodePoolSpec,
+                ec2NodeClassSpec: nodeClassSpec,
+                interruptionHandling: true,
+            }),
+            new blueprints.addons.SecretsStoreAddOn(),
+        ];
+
+        // Instantiated to for helm version check.
+        new blueprints.ExternalDnsAddOn({
+            hostedZoneResources: [ blueprints.GlobalResources.HostedZone ]
+        });
+
+        const clusterProvider = new blueprints.GenericClusterProvider({
+            version: KubernetesVersion.V1_29,
+            tags: {
+                "Name": "blueprints-example-cluster",
+                "Type": "generic-cluster"
+            },
+            mastersRole: blueprints.getResource(context => {
+                return new iam.Role(context.scope, 'AdminRole', { assumedBy: new iam.AccountRootPrincipal() });
+            }),
+            managedNodeGroups: [
+                addGenericNodeGroup(),
+                addCustomNodeGroup(),
+                addWindowsNodeGroup(), //  commented out to check the impact on e2e
+                addGpuNodeGroup()
+            ]
+        });
+
+        blueprints.EksBlueprint.builder()
+            .addOns(...addOns)
+            .resourceProvider(blueprints.GlobalResources.Vpc, new blueprints.VpcProvider(undefined))
+            .resourceProvider("node-role", nodeRole)
+            .withBlueprintProps({
+                ipFamily: IpFamily.IP_V6,
+            })
+            .clusterProvider(clusterProvider)
+            .teams(...teams)
+            .build(scope, blueprintID, props);
+
+    }
+}
+
+function addGenericNodeGroup(): blueprints.ManagedNodeGroup {
+
+    return {
+        id: "mng1",
+        amiType: NodegroupAmiType.AL2_X86_64,
+        instanceTypes: [new ec2.InstanceType('m5.4xlarge')],
+        desiredSize: 2,
+        maxSize: 3,
+        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
+        nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+        launchTemplate: {
+            // You can pass Custom Tags to Launch Templates which gets Propogated to worker nodes.
+            tags: {
+                "Name": "Mng1",
+                "Type": "Managed-Node-Group",
+                "LaunchTemplate": "Custom",
+                "Instance": "ONDEMAND"
+            },
+            requireImdsv2: false
+        }
+    };
+}
+
+function addCustomNodeGroup(): blueprints.ManagedNodeGroup {
+
+    const userData = ec2.UserData.forLinux();
+    userData.addCommands(`/etc/eks/bootstrap.sh ${blueprintID}`);
+
+    return {
+        id: "mng2-customami",
+        amiType: NodegroupAmiType.AL2_X86_64,
+        instanceTypes: [new ec2.InstanceType('t3.large')],
+        nodeGroupCapacityType: CapacityType.SPOT,
+        desiredSize: 0,
+        minSize: 0,
+        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
+        launchTemplate: {
+            tags: {
+                "Name": "Mng2",
+                "Type": "Managed-Node-Group",
+                "LaunchTemplate": "Custom",
+                "Instance": "SPOT"
+            },
+            machineImage: ec2.MachineImage.genericLinux({
+                'eu-west-1': 'ami-00805477850d62b8c',
+                'us-east-1': 'ami-08e520f5673ee0894',
+                'us-west-2': 'ami-0403ff342ceb30967',
+                'us-east-2': 'ami-07109d69738d6e1ee',
+                'us-west-1': 'ami-07bda4b61dc470985',
+                'us-gov-west-1': 'ami-0e9ebbf0d3f263e9b',
+                'us-gov-east-1':'ami-033eb9bc6daf8bfb1'
+            }),
+            userData: userData,
+        }
+    };
+}
+
+function addWindowsNodeGroup(): blueprints.ManagedNodeGroup {
+
+    return {
+        id: "mng3-windowsami",
+        amiType: NodegroupAmiType.WINDOWS_CORE_2019_X86_64,
+        instanceTypes: [new ec2.InstanceType('m5.4xlarge')],
+        desiredSize: 0,
+        minSize: 0,
+        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
+        diskSize: 50,
+        tags: {
+            "Name": "Mng3",
+            "Type": "Managed-WindowsNode-Group",
+            "LaunchTemplate": "WindowsLT",
+            "kubernetes.io/cluster/blueprint-ipv6-construct-dev": "owned"
+        }
+    };
+}
+
+function addGpuNodeGroup(): blueprints.ManagedNodeGroup {
+
+    return {
+        id: "mng-linux-gpu",
+        amiType: NodegroupAmiType.AL2_X86_64_GPU,
+        instanceTypes: [new ec2.InstanceType('g5.xlarge')],
+        desiredSize: 0,
+        minSize: 0,
+        maxSize: 1,
+        nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+        launchTemplate: {
+            tags: {
+                "Name": "Mng-linux-Gpu",
+                "Type": "Managed-linux-Gpu-Node-Group",
+                "LaunchTemplate": "Linux-Launch-Template",
+            },
+            requireImdsv2: false
+        }
+    };
+}
+
+export function addInferentiaNodeGroup(): blueprints.ManagedNodeGroup {
+
+    return {
+        id: "mng4-inferentia",
+        instanceTypes: [new ec2.InstanceType('inf1.2xlarge')],
+        desiredSize: 1,
+        minSize: 1,
+        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
+        diskSize: 50,
+        tags: {
+            "Name": "Mng4",
+            "Type": "Managed-InferentiaNode-Group",
+            "LaunchTemplate": "Inferentia",
+            "kubernetes.io/cluster/blueprint-ipv6-construct-dev": "owned"
+        }
+    };
+}

--- a/examples/blueprint-ipv6-construct/index.ts
+++ b/examples/blueprint-ipv6-construct/index.ts
@@ -1,15 +1,14 @@
 import * as cdk from 'aws-cdk-lib';
-import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { CapacityType, KubernetesVersion, NodegroupAmiType, IpFamily } from 'aws-cdk-lib/aws-eks';
-import * as iam from 'aws-cdk-lib/aws-iam';
+import { IpFamily } from 'aws-cdk-lib/aws-eks';
 import { Construct } from "constructs";
 import * as blueprints from '../../lib';
-import { logger, userLog } from '../../lib/utils';
-import * as team from '../teams';
+import BlueprintConstruct, {
+    addGenericNodeGroup,
+    addGpuNodeGroup,
+    addWindowsNodeGroup,
+    getClusterProvider
+} from "../blueprint-construct";
 
-const burnhamManifestDir = './examples/teams/team-burnham/';
-const rikerManifestDir = './examples/teams/team-riker/';
-const teamManifestDirList = [burnhamManifestDir, rikerManifestDir];
 const blueprintID = 'blueprint-ipv6-construct-dev';
 
 export interface BlueprintIPv6ConstructProps {
@@ -23,59 +22,23 @@ export interface BlueprintIPv6ConstructProps {
 ** This class is modification of ../blueprint-contruct/index.ts
 ** To have IPv6 configurations, BlueprintConstruct has been replicated and updated to BlueprintIPV6Construct.
  */
-export default class BlueprintIPV6Construct {
+export default class BlueprintIPV6Construct extends BlueprintConstruct {
     constructor(scope: Construct, props: cdk.StackProps) {
+        super(scope, props);
 
-        blueprints.HelmAddOn.validateHelmVersions = true;
-        blueprints.HelmAddOn.failOnVersionValidation = false;
-        logger.settings.minLevel = 3; // info
-        userLog.settings.minLevel = 2; // debug
-
-        const teams: Array<blueprints.Team> = [
-            new team.TeamTroi,
-            new team.TeamRiker(scope, teamManifestDirList[1]),
-            new team.TeamBurnham(scope, teamManifestDirList[0]),
-            new team.TeamPlatform(process.env.CDK_DEFAULT_ACCOUNT!)
-        ];
-
-        const nodeRole = new blueprints.CreateIPv6NodeRoleProvider("blueprint-node-role", new iam.ServicePrincipal("ec2.amazonaws.com"),
-            [
-                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
-                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
-                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore")
-            ]);
-
-        const nodeClassSpec: blueprints.Ec2NodeClassSpec = {
-            amiFamily: "AL2",
-            subnetSelectorTerms: [{ tags: { "Name": `${blueprintID}/${blueprintID}/${blueprintID}-vpc/PrivateSubnet*` }}],
-            securityGroupSelectorTerms: [{ tags: { "aws:eks:cluster-name": `${blueprintID}` }}],
-        };
-
-        const nodePoolSpec: blueprints.NodePoolSpec = {
-            labels: {
-                type: "karpenter-test"
-            },
-            annotations: {
-                "eks-blueprints/owner": "bugatha"
-            },
-            requirements: [
-                { key: 'node.kubernetes.io/instance-type', operator: 'In', values: ["c5.large", "m5.large", "r5.large", "m5.xlarge"] },
-                { key: 'topology.kubernetes.io/zone', operator: 'In', values: [`${props?.env?.region}a`,`${props?.env?.region}b`]},
-                { key: 'kubernetes.io/arch', operator: 'In', values: ['amd64','arm64']},
-                { key: 'karpenter.sh/capacity-type', operator: 'In', values: ['on-demand']},
-            ],
-            disruption: {
-                consolidationPolicy: "WhenEmpty",
-                consolidateAfter: "30s",
-                expireAfter: "20m",
-            }
-        };
+        const nodeRole = new blueprints.CreateIPv6NodeRoleProvider("blueprint-node-role");
+        // Excluded addCustomNodeGroup compared to IPV4 cluster. As it is not yet supported for IPV6 cluster.
+        this.clusterProvider = getClusterProvider([
+            addGenericNodeGroup(),
+            addWindowsNodeGroup(), //  commented out to check the impact on e2e
+            addGpuNodeGroup()
+        ]);
 
         const addOns: Array<blueprints.ClusterAddOn> = [
             new blueprints.addons.KarpenterAddOn({
                 version: "v0.34.5",
-                nodePoolSpec: nodePoolSpec,
-                ec2NodeClassSpec: nodeClassSpec,
+                nodePoolSpec: this.nodePoolSpec,
+                ec2NodeClassSpec: this.nodeClassSpec,
                 interruptionHandling: true,
             }),
             new blueprints.addons.SecretsStoreAddOn(),
@@ -86,148 +49,14 @@ export default class BlueprintIPV6Construct {
             hostedZoneResources: [ blueprints.GlobalResources.HostedZone ]
         });
 
-        const clusterProvider = new blueprints.GenericClusterProvider({
-            version: KubernetesVersion.V1_29,
-            tags: {
-                "Name": "blueprints-example-cluster",
-                "Type": "generic-cluster"
-            },
-            mastersRole: blueprints.getResource(context => {
-                return new iam.Role(context.scope, 'AdminRole', { assumedBy: new iam.AccountRootPrincipal() });
-            }),
-            managedNodeGroups: [
-                addGenericNodeGroup(),
-                addCustomNodeGroup(),
-                addWindowsNodeGroup(), //  commented out to check the impact on e2e
-                addGpuNodeGroup()
-            ]
-        });
-
         blueprints.EksBlueprint.builder()
             .addOns(...addOns)
             .resourceProvider(blueprints.GlobalResources.Vpc, new blueprints.VpcProvider(undefined))
             .resourceProvider("node-role", nodeRole)
-            .withBlueprintProps({
-                ipFamily: IpFamily.IP_V6,
-            })
-            .clusterProvider(clusterProvider)
-            .teams(...teams)
+            .ipFamily(IpFamily.IP_V6)
+            .clusterProvider(this.clusterProvider)
+            .teams(...this.teams)
             .build(scope, blueprintID, props);
-
     }
 }
 
-function addGenericNodeGroup(): blueprints.ManagedNodeGroup {
-
-    return {
-        id: "mng1",
-        amiType: NodegroupAmiType.AL2_X86_64,
-        instanceTypes: [new ec2.InstanceType('m5.4xlarge')],
-        desiredSize: 2,
-        maxSize: 3,
-        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
-        nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
-        launchTemplate: {
-            // You can pass Custom Tags to Launch Templates which gets Propogated to worker nodes.
-            tags: {
-                "Name": "Mng1",
-                "Type": "Managed-Node-Group",
-                "LaunchTemplate": "Custom",
-                "Instance": "ONDEMAND"
-            },
-            requireImdsv2: false
-        }
-    };
-}
-
-function addCustomNodeGroup(): blueprints.ManagedNodeGroup {
-
-    const userData = ec2.UserData.forLinux();
-    userData.addCommands(`/etc/eks/bootstrap.sh ${blueprintID}`);
-
-    return {
-        id: "mng2-customami",
-        amiType: NodegroupAmiType.AL2_X86_64,
-        instanceTypes: [new ec2.InstanceType('t3.large')],
-        nodeGroupCapacityType: CapacityType.SPOT,
-        desiredSize: 0,
-        minSize: 0,
-        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
-        launchTemplate: {
-            tags: {
-                "Name": "Mng2",
-                "Type": "Managed-Node-Group",
-                "LaunchTemplate": "Custom",
-                "Instance": "SPOT"
-            },
-            machineImage: ec2.MachineImage.genericLinux({
-                'eu-west-1': 'ami-00805477850d62b8c',
-                'us-east-1': 'ami-08e520f5673ee0894',
-                'us-west-2': 'ami-0403ff342ceb30967',
-                'us-east-2': 'ami-07109d69738d6e1ee',
-                'us-west-1': 'ami-07bda4b61dc470985',
-                'us-gov-west-1': 'ami-0e9ebbf0d3f263e9b',
-                'us-gov-east-1':'ami-033eb9bc6daf8bfb1'
-            }),
-            userData: userData,
-        }
-    };
-}
-
-function addWindowsNodeGroup(): blueprints.ManagedNodeGroup {
-
-    return {
-        id: "mng3-windowsami",
-        amiType: NodegroupAmiType.WINDOWS_CORE_2019_X86_64,
-        instanceTypes: [new ec2.InstanceType('m5.4xlarge')],
-        desiredSize: 0,
-        minSize: 0,
-        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
-        diskSize: 50,
-        tags: {
-            "Name": "Mng3",
-            "Type": "Managed-WindowsNode-Group",
-            "LaunchTemplate": "WindowsLT",
-            "kubernetes.io/cluster/blueprint-ipv6-construct-dev": "owned"
-        }
-    };
-}
-
-function addGpuNodeGroup(): blueprints.ManagedNodeGroup {
-
-    return {
-        id: "mng-linux-gpu",
-        amiType: NodegroupAmiType.AL2_X86_64_GPU,
-        instanceTypes: [new ec2.InstanceType('g5.xlarge')],
-        desiredSize: 0,
-        minSize: 0,
-        maxSize: 1,
-        nodeGroupSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
-        launchTemplate: {
-            tags: {
-                "Name": "Mng-linux-Gpu",
-                "Type": "Managed-linux-Gpu-Node-Group",
-                "LaunchTemplate": "Linux-Launch-Template",
-            },
-            requireImdsv2: false
-        }
-    };
-}
-
-export function addInferentiaNodeGroup(): blueprints.ManagedNodeGroup {
-
-    return {
-        id: "mng4-inferentia",
-        instanceTypes: [new ec2.InstanceType('inf1.2xlarge')],
-        desiredSize: 1,
-        minSize: 1,
-        nodeRole: blueprints.getNamedResource("node-role") as iam.Role,
-        diskSize: 50,
-        tags: {
-            "Name": "Mng4",
-            "Type": "Managed-InferentiaNode-Group",
-            "LaunchTemplate": "Inferentia",
-            "kubernetes.io/cluster/blueprint-ipv6-construct-dev": "owned"
-        }
-    };
-}

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -250,7 +250,7 @@ export class GenericClusterProvider implements ClusterProvider {
     /**
      * @override
      */
-    createCluster(scope: Construct, vpc: ec2.IVpc, secretsEncryptionKey?: IKey, kubernetesVersion?: eks.KubernetesVersion, clusterLogging?: eks.ClusterLoggingTypes[]) : ClusterInfo {
+    createCluster(scope: Construct, vpc: ec2.IVpc, secretsEncryptionKey?: IKey, kubernetesVersion?: eks.KubernetesVersion, clusterLogging?: eks.ClusterLoggingTypes[], ipFamily?: eks.IpFamily) : ClusterInfo {
         const id = scope.node.id;
 
         // Props for the cluster.
@@ -286,7 +286,7 @@ export class GenericClusterProvider implements ClusterProvider {
             defaultCapacity: 0 // we want to manage capacity ourselves
         };
 
-        const clusterOptions = { ...defaultOptions, ...this.props, version };
+        const clusterOptions = { ...defaultOptions, ...this.props, version , ipFamily };
         // Create an EKS Cluster
         const cluster = this.internalCreateCluster(scope, id, clusterOptions);
         cluster.node.addDependency(vpc);

--- a/lib/resource-providers/index.ts
+++ b/lib/resource-providers/index.ts
@@ -7,3 +7,5 @@ export * from './vpc';
 export * from './efs';
 export * from './s3';
 export * from './amp';
+export * from './ipv6-iam';
+export * from './ipv6-vpc';

--- a/lib/resource-providers/ipv6-iam.ts
+++ b/lib/resource-providers/ipv6-iam.ts
@@ -14,12 +14,19 @@ export class CreateIPv6NodeRoleProvider implements spi.ResourceProvider<iam.Role
      * @param assumedBy @example  new iam.ServicePrincipal('ec2.amazonaws.com')
      * @param policies
      */
-    constructor(private roleId: string, private assumedBy: iam.IPrincipal, private policies?: IManagedPolicy[]){}
+    constructor(private roleId: string, private policies?: IManagedPolicy[]){}
 
     provide(context: spi.ResourceContext): iam.Role {
+        const assumedBy = new iam.ServicePrincipal("ec2.amazonaws.com");
+        const defaultNodePolicies = [
+                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
+                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
+                iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore")
+        ];
+        const nodePolicies = this.policies ? defaultNodePolicies.concat(this.policies) : defaultNodePolicies;
         const role = new iam.Role(context.scope, this.roleId, {
-            assumedBy: this.assumedBy,
-            managedPolicies: this.policies
+            assumedBy: assumedBy,
+            managedPolicies: nodePolicies
         });
         const nodeIpv6Policy = new iam.Policy(context.scope, 'node-Ipv6-Policy', {
             document: getEKSNodeIpv6PolicyDocument() });

--- a/lib/resource-providers/ipv6-iam.ts
+++ b/lib/resource-providers/ipv6-iam.ts
@@ -1,0 +1,29 @@
+import * as spi from "../spi";
+import * as iam from "aws-cdk-lib/aws-iam";
+import {IManagedPolicy} from "aws-cdk-lib/aws-iam";
+import {getEKSNodeIpv6PolicyDocument} from '../../lib/utils/ipv6-utils';
+
+/**
+ * Resource provider that creates a new role with ipv6 permissions.
+ * Especially, Node management roles (requires ipv6 permissions).
+ */
+export class CreateIPv6NodeRoleProvider implements spi.ResourceProvider<iam.Role> {
+    /**
+     * Constructor to create role provider.
+     * @param roleId role id
+     * @param assumedBy @example  new iam.ServicePrincipal('ec2.amazonaws.com')
+     * @param policies
+     */
+    constructor(private roleId: string, private assumedBy: iam.IPrincipal, private policies?: IManagedPolicy[]){}
+
+    provide(context: spi.ResourceContext): iam.Role {
+        const role = new iam.Role(context.scope, this.roleId, {
+            assumedBy: this.assumedBy,
+            managedPolicies: this.policies
+        });
+        const nodeIpv6Policy = new iam.Policy(context.scope, 'node-Ipv6-Policy', {
+            document: getEKSNodeIpv6PolicyDocument() });
+        role.attachInlinePolicy(nodeIpv6Policy);
+        return role;
+    }
+}

--- a/lib/resource-providers/ipv6-vpc.ts
+++ b/lib/resource-providers/ipv6-vpc.ts
@@ -2,6 +2,7 @@ import {Fn} from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import {IpProtocol, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { ResourceContext, ResourceProvider } from "../spi";
+import {getVPCFromId} from "./vpc";
 
 /**
  * IPV6 VPC resource provider
@@ -15,7 +16,7 @@ export class Ipv6VpcProvider implements ResourceProvider<ec2.IVpc> {
 
     provide(context: ResourceContext): ec2.IVpc {
         const id = context.scope.node.id;
-        let vpc = this.getVPCFromId(context, id);
+        let vpc = getVPCFromId(context, id, this.vpcId);
         if (vpc == null) {
             // It will automatically divide the provided VPC CIDR range, and create public and private subnets per Availability Zone.
             // Network routing for the public subnets will be configured to allow outbound access directly via an Internet Gateway.
@@ -67,22 +68,4 @@ export class Ipv6VpcProvider implements ResourceProvider<ec2.IVpc> {
         cfnSubnet.assignIpv6AddressOnCreation = true;
     }
 
-    /*
-    ** This function will give return vpc based on the ResourceContext passed to the cluster.
-     */
-    getVPCFromId(context: ResourceContext, nodeId: string) {
-        let vpc = undefined;
-        const vpcId = this.vpcId;
-        if (vpcId) {
-            if (vpcId === "default") {
-                console.log(`looking up completely default VPC`);
-                vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { isDefault: true });
-            } else {
-                console.log(`looking up non-default ${vpcId} VPC`);
-                vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { vpcId: vpcId });
-                console.log(vpc);
-            }
-        }
-        return vpc;
-    }
 }

--- a/lib/resource-providers/ipv6-vpc.ts
+++ b/lib/resource-providers/ipv6-vpc.ts
@@ -1,0 +1,88 @@
+import {Fn} from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import {IpProtocol, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { ResourceContext, ResourceProvider } from "../spi";
+
+/**
+ * IPV6 VPC resource provider
+ */
+export class Ipv6VpcProvider implements ResourceProvider<ec2.IVpc> {
+    readonly vpcId?: string;
+
+    constructor(vpcId?: string) {
+        this.vpcId = vpcId;
+    }
+
+    provide(context: ResourceContext): ec2.IVpc {
+        const id = context.scope.node.id;
+        let vpc = this.getVPCFromId(context, id);
+        if (vpc == null) {
+            // It will automatically divide the provided VPC CIDR range, and create public and private subnets per Availability Zone.
+            // Network routing for the public subnets will be configured to allow outbound access directly via an Internet Gateway.
+            // Network routing for the private subnets will be configured to allow outbound access via a one NAT Gateway to reduce the cost.
+            // IPv6 does not require NAT for pod to pod communication. By default, we are creating one NAT for cluster communications outside endpoints if any.
+            return this.getIPv6VPC(context, id);
+        }
+        return vpc;
+    }
+
+    /*
+    ** AWS recommend to have dual stack vpc for ipv6 EKS clusters. This functions creates VPC required for IPV6 cluster.
+    ** For more info refer: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-migrate-ipv6-add.html
+     */
+    getIPv6VPC(context: ResourceContext, id: string):ec2.IVpc {
+        // Create VPC with dual stack mode
+        // Setting natGateways lower than the number of Availability Zones in VPC in order to save on NAT cost.
+        const vpc = new ec2.Vpc(context.scope, id+"-vpc", { natGateways: 1,
+            ipProtocol: IpProtocol.DUAL_STACK, restrictDefaultSecurityGroup: false });
+
+        // Create and associate IPV6 CIDR blocks
+        const ipv6Cidr = new ec2.CfnVPCCidrBlock(context.scope, id+"-CIDR6", {
+            vpcId: vpc.vpcId,
+            amazonProvidedIpv6CidrBlock: true,
+        });
+        let subnetCount = 0;
+        let subnets = [...vpc.publicSubnets, ...vpc.privateSubnets];
+
+        // associate an IPv6 CIDR block with a subnet
+        for ( let subnet of subnets) {
+            // Wait for the ipv6 cidr to complete
+            subnet.node.addDependency(ipv6Cidr);
+            this.associateSubnetsWithIpv6CIDR(subnetCount, subnet, vpc);
+            subnetCount++;
+        }
+        return vpc;
+    }
+
+    /*
+    ** For IPV6 vpc we need to attach subnets with available ipv6Cidr blocks in the vpc.
+    ** Refer steps in here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+     */
+    associateSubnetsWithIpv6CIDR(count: number, subnet: ec2.ISubnet, vpc: Vpc) {
+        const cfnSubnet = subnet.node.defaultChild as ec2.CfnSubnet;
+        // The VPC is associated with /56 for amazonProvidedIpv6CidrBlock. So value of 64 subnet mask. so 256 cidr blocks are available.
+        // Having 64 as subnet mask will give 2^64 IP's for each subnet. Which high enough for any kind of workload.
+        const ipv6CIDRSubnetMask = "64";
+        cfnSubnet.ipv6CidrBlock = Fn.select(count, Fn.cidr(Fn.select(0, vpc.vpcIpv6CidrBlocks), 256, ipv6CIDRSubnetMask));
+        cfnSubnet.assignIpv6AddressOnCreation = true;
+    }
+
+    /*
+    ** This function will give return vpc based on the ResourceContext passed to the cluster.
+     */
+    getVPCFromId(context: ResourceContext, nodeId: string) {
+        let vpc = undefined;
+        const vpcId = this.vpcId;
+        if (vpcId) {
+            if (vpcId === "default") {
+                console.log(`looking up completely default VPC`);
+                vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { isDefault: true });
+            } else {
+                console.log(`looking up non-default ${vpcId} VPC`);
+                vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { vpcId: vpcId });
+                console.log(vpc);
+            }
+        }
+        return vpc;
+    }
+}

--- a/lib/stacks/eks-blueprint-construct.ts
+++ b/lib/stacks/eks-blueprint-construct.ts
@@ -82,18 +82,15 @@ export class EksBlueprintProps {
     readonly enableGitOpsMode?: spi.GitOpsMode;
 
     /**
-<<<<<<< HEAD
      * When set to true, will not use extra nesting for blueprint resources and attach them directly to the stack.
      */
     readonly compatibilityMode?: boolean;
 
     /**
-     * Adding ipFamily to support IPv6 clusters. By default it uses IPv4 as the value.
-=======
-     *
->>>>>>> cfbe78ce (IPV6 EKS cluster code.)
+     * ipFamily to support IPv6 clusters. By default, it uses IPv4 as the value.
      */
     readonly ipFamily?: eks.IpFamily;
+
 }
 
 export class BlueprintPropsConstraints implements constraints.ConstraintsType<EksBlueprintProps> {
@@ -148,6 +145,14 @@ export class BlueprintConstructBuilder {
 
     public version(version: "auto" | KubernetesVersion): this {
         this.props = { ...this.props, ...{ version: version } };
+        return this;
+    }
+
+    /**
+     * Adding ipFamily method to support IPv6 clusters. By default, it uses IPv4 as the value.
+     */
+    public ipFamily(ipFamily:  eks.IpFamily = eks.IpFamily.IP_V4): this {
+        this.props = { ...this.props, ...{ ipFamily: ipFamily } };
         return this;
     }
 

--- a/lib/stacks/eks-blueprint-construct.ts
+++ b/lib/stacks/eks-blueprint-construct.ts
@@ -12,6 +12,7 @@ import { IKey } from "aws-cdk-lib/aws-kms";
 import {CreateKmsKeyProvider} from "../resource-providers/kms-key";
 import { ArgoGitOpsFactory } from "../addons/argocd/argo-gitops-factory";
 
+import * as eks from "aws-cdk-lib/aws-eks";
 /* Default K8s version of EKS Blueprints */
 export const DEFAULT_VERSION = KubernetesVersion.V1_29;
 
@@ -81,9 +82,18 @@ export class EksBlueprintProps {
     readonly enableGitOpsMode?: spi.GitOpsMode;
 
     /**
+<<<<<<< HEAD
      * When set to true, will not use extra nesting for blueprint resources and attach them directly to the stack.
      */
     readonly compatibilityMode?: boolean;
+
+    /**
+     * Adding ipFamily to support IPv6 clusters. By default it uses IPv4 as the value.
+=======
+     *
+>>>>>>> cfbe78ce (IPV6 EKS cluster code.)
+     */
+    readonly ipFamily?: eks.IpFamily;
 }
 
 export class BlueprintPropsConstraints implements constraints.ConstraintsType<EksBlueprintProps> {
@@ -240,7 +250,7 @@ export class EksBlueprintConstruct extends Construct {
             version
         });
 
-        this.clusterInfo = clusterProvider.createCluster(scope, vpcResource!, kmsKeyResource, version, blueprintProps.enableControlPlaneLogTypes);
+        this.clusterInfo = clusterProvider.createCluster(scope, vpcResource!, kmsKeyResource, version, blueprintProps.enableControlPlaneLogTypes, blueprintProps.ipFamily);
         this.clusterInfo.setResourceContext(resourceContext);
 
         if (blueprintProps.enableGitOpsMode == spi.GitOpsMode.APPLICATION) {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -15,3 +15,4 @@ export * from './string-utils';
 export * from './usage-utils';
 export * from './vpc-utils';
 export * from './yaml-utils';
+export * from './ipv6-utils';

--- a/lib/utils/ipv6-utils.ts
+++ b/lib/utils/ipv6-utils.ts
@@ -6,7 +6,7 @@
  */
 import {PolicyDocument} from "aws-cdk-lib/aws-iam";
 
-export function getEKSNodeIpv6PolicyDocument(){
+export function getEKSNodeIpv6PolicyDocument(): PolicyDocument {
     return PolicyDocument.fromJson({
         "Version": "2012-10-17",
         "Statement": [

--- a/lib/utils/ipv6-utils.ts
+++ b/lib/utils/ipv6-utils.ts
@@ -1,0 +1,35 @@
+
+/*
+** This policy is required for all the roles which are manging/creating the nodes in the cluster.
+** So, we need it for both cluster node role and karpenter node role.
+** Refer to: https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-role
+ */
+import {PolicyDocument} from "aws-cdk-lib/aws-iam";
+
+export function getEKSNodeIpv6PolicyDocument(){
+    return PolicyDocument.fromJson({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:AssignIpv6Addresses",
+                    "ec2:DescribeInstances",
+                    "ec2:DescribeTags",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeInstanceTypes"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:CreateTags"
+                ],
+                "Resource": [
+                    "arn:aws:ec2:*:*:network-interface/*"
+                ]
+            }
+        ]
+    });
+}

--- a/test/resource-providers/ipv6-iam.test.ts
+++ b/test/resource-providers/ipv6-iam.test.ts
@@ -1,0 +1,63 @@
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as blueprints from "../../lib";
+import {EksBlueprintConstruct, GlobalResources} from "../../lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+
+describe("CreateIPv6NodeRoleProvider", () => {
+    test("Stack is created with a new IAM role", () => {
+        // Given
+        const app = new App();
+        const stack = blueprints.EksBlueprint.builder()
+            .resourceProvider(GlobalResources.Vpc, new blueprints.VpcProvider())
+            .resourceProvider(
+                "blueprint-node-role",
+                new blueprints.CreateIPv6NodeRoleProvider("blueprint-ipv6-node-role",  new iam.ServicePrincipal("ec2.amazonaws.com"),
+                    [
+                        iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
+                        iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
+                        iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore")
+                    ]
+                )
+            )
+            .account("123456789012")
+            .region("us-east-1")
+            .version("auto")
+            .build(app, "east-test-1");
+
+
+        // When
+        const template = Template.fromStack(stack);
+
+        // Then
+        const iamRoles = template.findResources("AWS::IAM::Policy");
+        const nodeRolePolicy = Object.values(iamRoles).filter(policy => {
+            if (policy?.Properties?.PolicyName) {
+                const nodeIpv6Policy = policy?.Properties?.PolicyName;
+                if (nodeIpv6Policy && nodeIpv6Policy.includes("nodeIpv6Policy")) {
+                    return true;
+                }
+            }
+            return false;
+        });
+        expect(nodeRolePolicy).toBeDefined();
+        expect(nodeRolePolicy.length).toEqual(1);
+        expect(nodeRolePolicy[0].Properties.Roles[0].Ref).toContain('blueprintipv6noderole');
+    });
+
+    test("Stack is created with an existing node role", () => {
+        // Given
+        const app = new App();
+        const nodeRole = new blueprints.LookupRoleProvider("node-ipv6-role");
+        const stack = blueprints.EksBlueprint.builder()
+            .resourceProvider(GlobalResources.Vpc, new blueprints.VpcProvider())
+            .resourceProvider("node-role", nodeRole)
+            .account("123456789012")
+            .region("us-east-1")
+            .version("auto")
+            .build(app, "east-test-1");
+        const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
+        const role = <iam.Role>eksBlueprintConstruct.node.tryFindChild('node-ipv6-role-iam-provider');
+        expect(role.roleName == 'node-ipv6-role');
+    });
+});

--- a/test/resource-providers/ipv6-iam.test.ts
+++ b/test/resource-providers/ipv6-iam.test.ts
@@ -1,7 +1,7 @@
 import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as blueprints from "../../lib";
-import {EksBlueprintConstruct, GlobalResources} from "../../lib";
+import { GlobalResources } from "../../lib";
 import * as iam from "aws-cdk-lib/aws-iam";
 
 describe("CreateIPv6NodeRoleProvider", () => {
@@ -12,13 +12,7 @@ describe("CreateIPv6NodeRoleProvider", () => {
             .resourceProvider(GlobalResources.Vpc, new blueprints.VpcProvider())
             .resourceProvider(
                 "blueprint-node-role",
-                new blueprints.CreateIPv6NodeRoleProvider("blueprint-ipv6-node-role",  new iam.ServicePrincipal("ec2.amazonaws.com"),
-                    [
-                        iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
-                        iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
-                        iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore")
-                    ]
-                )
+                new blueprints.CreateIPv6NodeRoleProvider("blueprint-ipv6-node-role")
             )
             .account("123456789012")
             .region("us-east-1")
@@ -56,8 +50,7 @@ describe("CreateIPv6NodeRoleProvider", () => {
             .region("us-east-1")
             .version("auto")
             .build(app, "east-test-1");
-        const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
-        const role = <iam.Role>eksBlueprintConstruct.node.tryFindChild('node-ipv6-role-iam-provider');
+        const role = <iam.Role>stack.node.tryFindChild('node-ipv6-role-iam-provider');
         expect(role.roleName == 'node-ipv6-role');
     });
 });

--- a/test/resource-providers/ipv6-vpc.test.ts
+++ b/test/resource-providers/ipv6-vpc.test.ts
@@ -1,0 +1,99 @@
+import { App } from "aws-cdk-lib";
+import * as blueprints from "../../lib";
+import {
+    EksBlueprintConstruct,
+    GlobalResources,
+} from "../../lib";
+import {IpFamily} from "aws-cdk-lib/aws-eks";
+import {CfnSubnet, IpProtocol, Vpc} from 'aws-cdk-lib/aws-ec2';
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+
+describe("CreateIpv6VpcProvider", () => {
+    test("Stack is created with a new VPC for IPv6", () => {
+        // Given
+        const app = new App();
+        const stack = blueprints.EksBlueprint.builder()
+            .resourceProvider(GlobalResources.Vpc, new blueprints.Ipv6VpcProvider())
+            .withBlueprintProps({
+                ipFamily: IpFamily.IP_V6,
+            })
+            .account("123456789012")
+            .region("us-east-1")
+            .version("auto")
+            .build(app, "east-test-1");
+        const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
+        const vpc = <Vpc>eksBlueprintConstruct.node.tryFindChild('east-test-1-vpc');
+        expect(vpc.vpcIpv6CidrBlocks);
+    });
+
+    test("getIPv6VPC in Ipv6VpcProvider will provide ipv6 vpc", () => {
+        // Given
+        const app = new App();
+        const stack = blueprints.EksBlueprint.builder()
+            .resourceProvider(GlobalResources.Vpc, new blueprints.Ipv6VpcProvider())
+            .withBlueprintProps({
+                ipFamily: IpFamily.IP_V6,
+            })
+            .account("123456789012")
+            .region("us-east-1")
+            .version("auto")
+            .build(app, "east-test-1");
+        const context = stack.getClusterInfo().getResourceContext();
+        const ipv6VpcProvider = new blueprints.Ipv6VpcProvider();
+
+        // When
+        const vpc = ipv6VpcProvider.getIPv6VPC(context, 'ipv6');
+
+        //Then
+        expect(vpc.node.id).toEqual('ipv6-vpc');
+        expect(vpc.node.tryFindChild('ipv6cidr'));
+        expect(vpc.node.tryFindChild('PublicSubnet1'));
+        expect(vpc.node.tryFindChild('PrivateSubnet1'));
+        expect(vpc.node.tryFindChild('IGW'));
+        expect(vpc.node.tryFindChild('EIGW6'));
+    });
+
+    test("associateSubnetsWithIpv6CIDR will provide vpc subnet with ipv6 cidr", () => {
+        // Given
+        const app = new App();
+        const ipv6VpcProvider = new blueprints.Ipv6VpcProvider();
+        const stack = blueprints.EksBlueprint.builder()
+            .resourceProvider(GlobalResources.Vpc, ipv6VpcProvider)
+            .withBlueprintProps({
+                ipFamily: IpFamily.IP_V6,
+            })
+            .account("123456789012")
+            .region("us-east-1")
+            .version("auto")
+            .build(app, "east-test-1");
+        const context = stack.getClusterInfo().getResourceContext();
+
+        const vpc = new ec2.Vpc(context.scope, "test-vpc", { natGateways: 1,
+            ipProtocol: IpProtocol.DUAL_STACK, restrictDefaultSecurityGroup: false });
+
+        // When
+        ipv6VpcProvider.associateSubnetsWithIpv6CIDR(0, vpc.publicSubnets[0], vpc);
+        const cfnSubnet = <CfnSubnet>vpc.publicSubnets[0].node.defaultChild;
+
+        // Then
+        expect(cfnSubnet.assignIpv6AddressOnCreation).toEqual(true);
+        expect(cfnSubnet.ipv6CidrBlock);
+    });
+
+    test("getIPv6VPC will provide ipv6 vpc when created through VpcProvider", () => {
+        // Given
+        const app = new App();
+        const stack = blueprints.EksBlueprint.builder()
+            .resourceProvider(GlobalResources.Vpc, new blueprints.VpcProvider())
+            .withBlueprintProps({
+                ipFamily: IpFamily.IP_V6,
+            })
+            .account("123456789012")
+            .region("us-east-1")
+            .version("auto")
+            .build(app, "east-test-1");
+        const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
+        const vpc = <Vpc>eksBlueprintConstruct.node.tryFindChild('east-test-1-vpc');
+        expect(vpc.vpcIpv6CidrBlocks);
+    });
+});

--- a/test/resource-providers/ipv6-vpc.test.ts
+++ b/test/resource-providers/ipv6-vpc.test.ts
@@ -1,7 +1,6 @@
 import { App } from "aws-cdk-lib";
 import * as blueprints from "../../lib";
 import {
-    EksBlueprintConstruct,
     GlobalResources,
 } from "../../lib";
 import {IpFamily} from "aws-cdk-lib/aws-eks";
@@ -21,8 +20,8 @@ describe("CreateIpv6VpcProvider", () => {
             .region("us-east-1")
             .version("auto")
             .build(app, "east-test-1");
-        const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
-        const vpc = <Vpc>eksBlueprintConstruct.node.tryFindChild('east-test-1-vpc');
+
+        const vpc = <Vpc>stack.node.tryFindChild('east-test-1-vpc');
         expect(vpc.vpcIpv6CidrBlocks);
     });
 
@@ -92,8 +91,7 @@ describe("CreateIpv6VpcProvider", () => {
             .region("us-east-1")
             .version("auto")
             .build(app, "east-test-1");
-        const eksBlueprintConstruct = <EksBlueprintConstruct>stack.node.tryFindChild("east-test-1");
-        const vpc = <Vpc>eksBlueprintConstruct.node.tryFindChild('east-test-1-vpc');
+        const vpc = <Vpc>stack.node.tryFindChild('east-test-1-vpc');
         expect(vpc.vpcIpv6CidrBlocks);
     });
 });


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Supporting IPv6 cluster with EKS blueprints.

For IPv6 cluster, we haven't tested with all the addons except for the below mentioned addons.
const addOns: Array<blueprints.ClusterAddOn> = [
    new blueprints.addons.VpcCniAddOn(),
    new blueprints.addons.KarpenterAddOn(),
    new blueprints.addons.SecretsStoreAddOn()
];



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

