### PR TITLE
(Docs) ingress-nginx: Fix incorrect ingressClassName default comment

### DIFF
--- a/lib/addons/ingress-nginx/index.ts
+++ b/lib/addons/ingress-nginx/index.ts
@@ -84,7 +84,7 @@ export interface IngressNginxAddOnProps extends HelmAddOnUserProps {
 
     /**
      * Specifies the class of the ingress controller. Used to differentiate between multiple ingress controllers.
-     * @default 'nginx'
+     * @default 'ingress-nginx'
      */
     ingressClassName?: string;
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

A small fix to update the `@default` value in the ingressClassName (for the new ingress-nginx addon) so it properly reflects the actual default.
I just ran into this when deploying the add-on and my helm charts are all wrong :-).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
