### PR TITLE
docs: Fix rendering of helm values for cluster-autoscaler

### DIFF
--- a/docs/addons/cluster-autoscaler.md
+++ b/docs/addons/cluster-autoscaler.md
@@ -31,11 +31,12 @@ const blueprint = blueprints.EksBlueprint.builder()
 5. Supports [standard helm configuration options](./index.md#standard-helm-add-on-configuration-options).
 
 The add-on automatically sets the following Helm Chart [values](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler#values), and it is **highly recommended** not to pass these values in (as it will result in a failed deployment):
-- cloudProvider
-- autoDiscovery.clusterName
-- awsRegion
-- rbac.serviceAccount.create
-- rbac.serviceAccount.name
+
+- `cloudProvider`
+- `autoDiscovery.clusterName`
+- `awsRegion`
+- `rbac.serviceAccount.create`
+- `rbac.serviceAccount.name`
 
 ## Testing the scaling functionality
 


### PR DESCRIPTION
*Issue #, if available:*

The rendering of the helm values in the website is messed up.

<img width="687" alt="Screenshot 2024-08-30 at 9 11 54 AM" src="https://github.com/user-attachments/assets/4ecfcfb1-4994-4216-92b5-6fee05edbdf4">

*Description of changes:*

Added a newline which I think should fix the rendering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
