### PR TITLE
Update helm chart location for gpu-operator addon

### DIFF
--- a/lib/addons/gpu-operator/index.ts
+++ b/lib/addons/gpu-operator/index.ts
@@ -25,7 +25,7 @@ const defaultProps: HelmAddOnProps & GpuOperatorAddonProps = {
     chart: "gpu-operator",
     version: "v24.3.0",
     release: "nvidia-gpu-operator",
-    repository:  "https://helm.ngc.nvidia.com/nvidia",
+    repository:  "https://nvidia.github.io/gpu-operator",
     createNamespace: true,
     values: {}
 };


### PR DESCRIPTION
Fixes #1063

Follows the recommended changes in that ticket, which links to https://github.com/NVIDIA/gpu-operator/issues/538

Note that I haven't tested it as I haven't got the means to do so.  Let me know if theres anything further I should do!