### PR TITLE
Add S3 CSI Driver IAM policy as blueprints addon

### DIFF
--- a/docs/addons/s3-csi-driver.md
+++ b/docs/addons/s3-csi-driver.md
@@ -1,0 +1,71 @@
+# S3 CSI Driver Addon
+
+The S3 CSI Driver Addon integrates Amazon S3 with your Kubernetes cluster, allowing you to use S3 buckets as persistent storage for your applications.
+
+## Prerequisites
+
+- The S3 bucket must be created in AWS separately as the driver uses the S3 bucket for storage, but it does not create it.
+- The S3 bucket must have a bucket policy that allows the EKS cluster to access the bucket.
+
+## Usage
+
+```typescript
+import { S3CsiDriverAddon } from '@aws-quickstart/eks-blueprints';
+
+const addOns = [
+    new S3CsiDriverAddon({
+        s3BucketName: 'my-s3-bucket',
+    }),
+    // other addons
+];
+
+const blueprint = EksBlueprint.builder()
+    .addOns(...addOns)
+    .build(app, 'my-stack');
+```
+
+## Configuration
+
+You can customize the S3 CSI Driver Addon by passing configuration options:
+
+```typescript
+new S3CsiDriverAddon({
+    s3BucketName: 'my-s3-bucket',
+});
+```
+
+## Use in EKS Cluster
+
+Once installed, you can create PersistentVolume and PersistentVolumeClaim resources that use the S3 CSI Driver:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+    name: s3-pv
+spec:
+    capacity:
+        storage: 5Gi
+    accessModes:
+        - ReadWriteOnce
+    csi:
+        driver: s3.csi.aws.com
+        volumeHandle: my-s3-bucket
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: s3-pvc
+spec:
+    accessModes:
+        - ReadWriteOnce
+    resources:
+        requests:
+            storage: 5Gi
+    volumeName: s3-pv
+```
+
+## References
+
+- [Amazon S3 CSI Driver Documentation](https://github.com/kubernetes-sigs/aws-s3-csi-driver)
+- [Amazon EKS S3 CSI Driver Documentation](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html)

--- a/docs/addons/s3-csi-driver.md
+++ b/docs/addons/s3-csi-driver.md
@@ -67,5 +67,5 @@ spec:
 
 ## References
 
-- [Amazon S3 CSI Driver Documentation](https://github.com/kubernetes-sigs/aws-s3-csi-driver)
+- [Amazon S3 CSI Driver Source](https://github.com/awslabs/mountpoint-s3-csi-driver)
 - [Amazon EKS S3 CSI Driver Documentation](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html)

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -57,6 +57,7 @@ export * from './neuron';
 export * from './nginx';
 export * from './opa-gatekeeper';
 export * from './prometheus-node-exporter';
+export * from './s3-csi-driver';
 export * from './secrets-store';
 export * from './secrets-store/csi-driver-provider-aws-secrets';
 export * from './secrets-store/secret-provider';

--- a/lib/addons/s3-csi-driver/iam-policy.ts
+++ b/lib/addons/s3-csi-driver/iam-policy.ts
@@ -1,0 +1,24 @@
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export function getS3DriverPolicyStatements(s3BucketArn: string): iam.PolicyStatement[] {
+    // new IAM policy to grand access to S3 bucket
+    // https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#iam-permissions
+    return [
+        new iam.PolicyStatement({
+            sid: 'S3MountpointFullBucketAccess',
+            actions: [
+                "s3:ListBucket"
+            ],
+            resources: [s3BucketArn]
+        }),
+        new iam.PolicyStatement({
+            sid: 'S3MountpointFullObjectAccess',
+            actions: [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject"
+            ],
+            resources: [`${s3BucketArn}/*`]
+        })];
+}

--- a/lib/addons/s3-csi-driver/iam-policy.ts
+++ b/lib/addons/s3-csi-driver/iam-policy.ts
@@ -1,8 +1,9 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
 
-export function getS3DriverPolicyStatements(s3BucketArn: string): iam.PolicyStatement[] {
+export function getS3DriverPolicyStatements(s3BucketName: string): iam.PolicyStatement[] {
     // new IAM policy to grand access to S3 bucket
     // https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#iam-permissions
+    const s3BucketArn = `arn:aws:s3:::${s3BucketName}`;
     return [
         new iam.PolicyStatement({
             sid: 'S3MountpointFullBucketAccess',

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -17,7 +17,7 @@ export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
     /**
      * ARN of the S3 bucket to be used by the driver
      */
-    s3BucketArn: string;
+    s3BucketName: string;
     /**
      * Create Namespace with the provided one (will not if namespace is kube-system)
      */
@@ -34,7 +34,8 @@ const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
     release: S3_CSI_DRIVER_RELEASE,
     version: 'v1.9.0',
     repository: 'https://github.com/awslabs/mountpoint-s3-csi-driver',
-    s3BucketArn: ''
+    createNamespace: false,
+    s3BucketName: ''
 };
 
 @supportsALL
@@ -57,7 +58,7 @@ export class S3CSIDriverAddOn extends HelmAddOn {
 
         const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {
             statements:
-                getS3DriverPolicyStatements(this.options.s3BucketArn)
+                getS3DriverPolicyStatements(this.options.s3BucketName)
         });
         serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
         

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -1,0 +1,84 @@
+import { Construct } from "constructs";
+import { ClusterInfo } from "../../spi";
+import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { createNamespace, setPath, supportsALL } from "../../utils";
+import { getS3DriverPolicyStatements } from "./iam-policy";
+
+const S3_CSI_DRIVER_SA = 's3-csi-driver-sa';
+const S3_CSI_DRIVER = 's3-csi-driver';
+const S3_CSI_DRIVER_RELEASE = 's3-csi-driver-release';
+const S3_DRIVER_POLICY = 's3-csi-driver-policy';
+
+/**
+ * Configuration options for the add-on.
+ */
+export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
+    /**
+     * ARN of the S3 bucket to be used by the driver
+     */
+    s3BucketArn: string;
+    /**
+     * Create Namespace with the provided one (will not if namespace is kube-system)
+     */
+    createNamespace?: boolean
+}
+
+/**
+ * Defaults options for the add-on
+ */
+const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
+    chart: S3_CSI_DRIVER,
+    name: S3_CSI_DRIVER,
+    namespace: 'kube-system',
+    release: S3_CSI_DRIVER_RELEASE,
+    version: 'v1.9.0',
+    repository: 'https://github.com/awslabs/mountpoint-s3-csi-driver',
+    s3BucketArn: ''
+};
+
+@supportsALL
+export class S3CSIDriverAddOn extends HelmAddOn {
+
+    readonly options: S3CSIDriverAddOnProps;
+
+    constructor(props: S3CSIDriverAddOnProps) {
+        super({ ...defaultProps as any, ...props });
+        this.options = this.props as S3CSIDriverAddOnProps;
+    }
+
+    deploy(clusterInfo: ClusterInfo): Promise<Construct> {
+        // Create service account and policy
+        const cluster = clusterInfo.cluster;
+        const serviceAccount = cluster.addServiceAccount(S3_CSI_DRIVER_SA, {
+            name: S3_CSI_DRIVER_SA,
+            namespace: this.options.namespace,
+        });
+
+        const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {
+            statements:
+                getS3DriverPolicyStatements(this.options.s3BucketArn)
+        });
+        serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
+        
+        // Create namespace
+        if (this.options.createNamespace) {
+            const ns = createNamespace(this.options.namespace!, cluster, true);
+            serviceAccount.node.addDependency(ns);
+        }
+
+        // setup value for helm chart
+        const chartValues = populateValues(this.options);
+
+        const s3CsiDriverChart = this.addHelmChart(clusterInfo, chartValues, true, true);
+        s3CsiDriverChart.node.addDependency(serviceAccount);
+        return Promise.resolve(s3CsiDriverChart);
+    }
+}
+
+function populateValues(helmOptions: S3CSIDriverAddOnProps): any {
+    const values = helmOptions.values ?? {};
+    setPath(values, 'node.serviceAccount.create', false);
+    setPath(values, 'node.tolerateAllTaints', true);
+    return values;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - Pixie: 'addons/pixie.md'
     - Prometheus Node Exporter: 'addons/prometheus-node-exporter.md'
     - Rafay: 'addons/rafay.md'
+    - S3 CSI Driver: 'addons/s3-csi-driver.md'
     - Secrets Store: 'addons/secrets-store.md'
     - Snyk: 'https://github.com/snyk-partners/snyk-monitor-eks-blueprints-addon'
     - SSM Agent: 'addons/ssm-agent.md'


### PR DESCRIPTION
S3 CSI Driver 
*Description of changes:*
This commit adds a new file `iam-policy.ts` that contains the IAM policy statements for the S3 CSI driver. It also adds a new file `index.ts` that implements the S3 CSI driver addon. The addon creates a service account, attaches the IAM policy to the service account's role, and deploys the addon to the cluster. The commit also includes some helper functions and default options for the addon.

