### PR TITLE
fix: aws-load-balancer-controller service account missing IAM permissions

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/iam-policy.ts
+++ b/lib/addons/aws-loadbalancer-controller/iam-policy.ts
@@ -37,7 +37,9 @@ export const AwsLoadbalancerControllerIamPolicy = (partition: string) => {
                     "elasticloadbalancing:DescribeTargetGroups",
                     "elasticloadbalancing:DescribeTargetGroupAttributes",
                     "elasticloadbalancing:DescribeTargetHealth",
-                    "elasticloadbalancing:DescribeTags"
+                    "elasticloadbalancing:DescribeTags",
+                    "elasticloadbalancing:DescribeTrustStores",
+                    "elasticloadbalancing:DescribeListenerAttributes"
                 ],
                 "Resource": "*"
             },
@@ -186,7 +188,8 @@ export const AwsLoadbalancerControllerIamPolicy = (partition: string) => {
                     "elasticloadbalancing:DeleteLoadBalancer",
                     "elasticloadbalancing:ModifyTargetGroup",
                     "elasticloadbalancing:ModifyTargetGroupAttributes",
-                    "elasticloadbalancing:DeleteTargetGroup"
+                    "elasticloadbalancing:DeleteTargetGroup",
+                    "elasticloadbalancing:ModifyListenerAttributes"
                 ],
                 "Resource": "*",
                 "Condition": {


### PR DESCRIPTION
*Issue #1096*

*Description of changes:*
Expands the IAM permissions of the `aws-load-balancer-controller` role to what is recommended by the addon:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
