### PR TITLE
Remove console.log when looking up non-default VPCs

### DIFF
--- a/lib/resource-providers/vpc.ts
+++ b/lib/resource-providers/vpc.ts
@@ -107,7 +107,6 @@ export function getVPCFromId(context: ResourceContext, nodeId: string, vpcId?: s
         } else {
             console.log(`looking up non-default ${vpcId} VPC`);
             vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { vpcId: vpcId });
-            console.log(vpc);
         }
     }
     return vpc;


### PR DESCRIPTION
*Description of changes:*

A debug `console.log()` seems to have been left in place that causes LookedUpVpc objects to be logged out when using imported (non-default) VPC/Subnets. This change removes that.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
