### PR TITLE
Correct Kube-proxy mapping version for EKS v1.31

### DIFF
--- a/lib/addons/kube-proxy/index.ts
+++ b/lib/addons/kube-proxy/index.ts
@@ -1,9 +1,9 @@
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
-import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { supportsALL } from "../../utils";
+import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_31, "1.31.0-eksbuild.5"],
+    [KubernetesVersion.V1_31, "v1.31.0-eksbuild.5"],
     [KubernetesVersion.V1_30, "v1.30.0-eksbuild.3"],
     [KubernetesVersion.V1_29, "v1.29.0-eksbuild.1"],
     [KubernetesVersion.V1_28, "v1.28.2-eksbuild.2"],


### PR DESCRIPTION
*Issue:*
```
22:09:53 | UPDATE_FAILED        | AWS::EKS::Addon                       | kubeproxyaddOn
Resource handler returned message: "Addon version specified is not supported (Service: Eks, Status Code: 400, Request ID: 5011efa8-0c30-4b51-9838-9a16e11518bd)" (RequestToken: 3efef0f1-7248-45a3-4665-f
a656c3f88f9, HandlerErrorCode: InvalidRequest)
```

*Description of changes:*
Correct version: `v1.31.0-eksbuild.5`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
