### PR TITLE
Added new scraping jobs for KSH and KCM metrics

### DIFF
--- a/lib/addons/amp/collector-config-amp-daemonset.ytpl
+++ b/lib/addons/amp/collector-config-amp-daemonset.ytpl
@@ -49,6 +49,40 @@ spec:
               ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
               insecure_skip_verify: true
 
+          - job_name: ksh-metrics
+            scheme: https
+            metrics_path: /apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+              action: keep
+              regex: default;kubernetes;https
+
+          - job_name: kcm-metrics
+            scheme: https
+            metrics_path: /apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+              action: keep
+              regex: default;kubernetes;https
+
           - job_name: kubernetes-nodes
             bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             kubernetes_sd_configs:
@@ -348,6 +382,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metrics.eks.amazonaws.com
+  resources:
+  - kcm/metrics
+  - ksh/metrics
+  verbs:
+  - get
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/lib/addons/amp/collector-config-amp.ytpl
+++ b/lib/addons/amp/collector-config-amp.ytpl
@@ -43,6 +43,38 @@ spec:
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 insecure_skip_verify: true
+            - job_name: ksh-metrics
+              scheme: https
+              metrics_path: /apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: endpoints
+              relabel_configs:
+              - source_labels:
+                - __meta_kubernetes_namespace
+                - __meta_kubernetes_service_name
+                - __meta_kubernetes_endpoint_port_name
+                action: keep
+                regex: default;kubernetes;https
+            - job_name: kcm-metrics
+              scheme: https
+              metrics_path: /apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: endpoints
+              relabel_configs:
+              - source_labels:
+                - __meta_kubernetes_namespace
+                - __meta_kubernetes_service_name
+                - __meta_kubernetes_endpoint_port_name
+                action: keep
+                regex: default;kubernetes;https
             - job_name: kubernetes-nodes
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               kubernetes_sd_configs:
@@ -1934,6 +1966,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metrics.eks.amazonaws.com
+  resources:
+  - kcm/metrics
+  - ksh/metrics
+  verbs:
+  - get
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/lib/addons/cloud-watch-insights/index.ts
+++ b/lib/addons/cloud-watch-insights/index.ts
@@ -10,11 +10,11 @@ import {KubernetesVersion} from "aws-cdk-lib/aws-eks";
 // aws eks describe-addon-versions --kubernetes-version <kubernetes-version> --addon-name amazon-cloudwatch-observability \
 //     --query 'addons[].addonVersions[].{Version: addonVersion, Defaultversion: compatibilities[0].defaultVersion}' --output table
 const versionMap: Map<KubernetesVersion, string> = new Map([
-    [KubernetesVersion.V1_31, "v2.1.3-eksbuild.1"],
-    [KubernetesVersion.V1_30, "v2.1.3-eksbuild.1"],
-    [KubernetesVersion.V1_29, "v2.1.3-eksbuild.1"],
-    [KubernetesVersion.V1_28, "v2.1.3-eksbuild.1"],
-    [KubernetesVersion.V1_27, "v2.1.3-eksbuild.1"]
+    [KubernetesVersion.V1_31, "v2.3.0-eksbuild.1"],
+    [KubernetesVersion.V1_30, "v2.3.0-eksbuild.1"],
+    [KubernetesVersion.V1_29, "v2.3.0-eksbuild.1"],
+    [KubernetesVersion.V1_28, "v2.3.0-eksbuild.1"],
+    [KubernetesVersion.V1_27, "v2.3.0-eksbuild.1"]
 ]);
 
 

--- a/lib/addons/cloudwatch-adot-addon/collector-config-cloudwatch.ytpl
+++ b/lib/addons/cloudwatch-adot-addon/collector-config-cloudwatch.ytpl
@@ -45,6 +45,40 @@ spec:
               ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
               insecure_skip_verify: true
 
+          - job_name: ksh-metrics
+            scheme: https
+            metrics_path: /apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+              action: keep
+              regex: default;kubernetes;https
+
+          - job_name: kcm-metrics
+            scheme: https
+            metrics_path: /apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+              action: keep
+              regex: default;kubernetes;https
+
           - job_name: kubernetes-nodes
             bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             kubernetes_sd_configs:
@@ -409,6 +443,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
   - nonResourceURLs:
       - /metrics
     verbs:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added new jobs to scrape kube-scheduler and kube-controller-manager metrics from EKS. This will be released on 11/18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
