### PR TITLE
S3 CSI Addon - Support multiple buckets

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -271,7 +271,7 @@ export default class BlueprintConstruct {
       new addons.OpaGatekeeperAddOn(),
       new addons.PrometheusNodeExporterAddOn(),
       new addons.S3CSIDriverAddOn({
-        s3BucketName: "s3-csi-driver-for-blueprints-xbucket",
+        bucketNames: ["s3-csi-driver-for-blueprints-xbucket"],
       }),
       new addons.SecretsStoreAddOn(),
       new addons.SSMAgentAddOn(),

--- a/lib/addons/s3-csi-driver/iam-policy.ts
+++ b/lib/addons/s3-csi-driver/iam-policy.ts
@@ -3,14 +3,14 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 export function getS3DriverPolicyStatements(bucketNames: string[]): iam.PolicyStatement[] {
     // new IAM policy to grand access to S3 bucket
     // https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#iam-permissions
-    const s3BucketArns = bucketNames.map((name) => `arn:aws:s3:::${name}`);
+    const arns = bucketNames.map((name) => `arn:aws:s3:::${name}`);
     return [
         new iam.PolicyStatement({
             sid: 'S3MountpointFullBucketAccess',
             actions: [
                 "s3:ListBucket"
             ],
-            resources: s3BucketArns
+            resources: arns
         }),
         new iam.PolicyStatement({
             sid: 'S3MountpointFullObjectAccess',
@@ -20,6 +20,6 @@ export function getS3DriverPolicyStatements(bucketNames: string[]): iam.PolicySt
                 "s3:AbortMultipartUpload",
                 "s3:DeleteObject"
             ],
-            resources: s3BucketArns.map((arn) => `${arn}/*`)
+            resources: arns.map((arn) => `${arn}/*`)
         })];
 }

--- a/lib/addons/s3-csi-driver/iam-policy.ts
+++ b/lib/addons/s3-csi-driver/iam-policy.ts
@@ -1,16 +1,16 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
 
-export function getS3DriverPolicyStatements(s3BucketName: string): iam.PolicyStatement[] {
+export function getS3DriverPolicyStatements(s3BucketNames: string[]): iam.PolicyStatement[] {
     // new IAM policy to grand access to S3 bucket
     // https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#iam-permissions
-    const s3BucketArn = `arn:aws:s3:::${s3BucketName}`;
+    const s3BucketArns = s3BucketNames.map((name) => `arn:aws:s3:::${name}`);
     return [
         new iam.PolicyStatement({
             sid: 'S3MountpointFullBucketAccess',
             actions: [
                 "s3:ListBucket"
             ],
-            resources: [s3BucketArn]
+            resources: s3BucketArns
         }),
         new iam.PolicyStatement({
             sid: 'S3MountpointFullObjectAccess',
@@ -20,6 +20,6 @@ export function getS3DriverPolicyStatements(s3BucketName: string): iam.PolicySta
                 "s3:AbortMultipartUpload",
                 "s3:DeleteObject"
             ],
-            resources: [`${s3BucketArn}/*`]
+            resources: s3BucketArns.map((arn) => `${arn}/*`)
         })];
 }

--- a/lib/addons/s3-csi-driver/iam-policy.ts
+++ b/lib/addons/s3-csi-driver/iam-policy.ts
@@ -1,9 +1,9 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
 
-export function getS3DriverPolicyStatements(s3BucketNames: string[]): iam.PolicyStatement[] {
+export function getS3DriverPolicyStatements(bucketNames: string[]): iam.PolicyStatement[] {
     // new IAM policy to grand access to S3 bucket
     // https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#iam-permissions
-    const s3BucketArns = s3BucketNames.map((name) => `arn:aws:s3:::${name}`);
+    const s3BucketArns = bucketNames.map((name) => `arn:aws:s3:::${name}`);
     return [
         new iam.PolicyStatement({
             sid: 'S3MountpointFullBucketAccess',

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -18,7 +18,7 @@ export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
     /**
      * The names of the S3 buckets to be used by the driver
      */
-    s3BucketNames: string[];
+    bucketNames: string[];
     /**
      * Create Namespace with the provided one (will not if namespace is kube-system)
      */
@@ -36,7 +36,7 @@ const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
   version: "v1.11.0",
   repository: "https://awslabs.github.io/mountpoint-s3-csi-driver",
   createNamespace: false,
-  s3BucketNames: []
+  bucketNames: []
 };
 
 @supportsALL
@@ -59,7 +59,7 @@ export class S3CSIDriverAddOn extends HelmAddOn {
 
         const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {
             statements:
-                getS3DriverPolicyStatements(this.options.s3BucketNames)
+                getS3DriverPolicyStatements(this.options.bucketNames)
         });
         serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
         

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -16,9 +16,9 @@ const S3_DRIVER_POLICY = 's3-csi-driver-policy';
  */
 export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
     /**
-     * ARN of the S3 bucket to be used by the driver
+     * The ARNs of the S3 buckets to be used by the driver
      */
-    s3BucketName: string;
+    s3BucketArns: string[];
     /**
      * Create Namespace with the provided one (will not if namespace is kube-system)
      */
@@ -36,7 +36,7 @@ const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
   version: "v1.11.0",
   repository: "https://awslabs.github.io/mountpoint-s3-csi-driver",
   createNamespace: false,
-  s3BucketName: ""
+  s3BucketArns: []
 };
 
 @supportsALL
@@ -59,7 +59,7 @@ export class S3CSIDriverAddOn extends HelmAddOn {
 
         const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {
             statements:
-                getS3DriverPolicyStatements(this.options.s3BucketName)
+                getS3DriverPolicyStatements(this.options.s3BucketArns)
         });
         serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
         

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -16,9 +16,9 @@ const S3_DRIVER_POLICY = 's3-csi-driver-policy';
  */
 export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
     /**
-     * The ARNs of the S3 buckets to be used by the driver
+     * The names of the S3 buckets to be used by the driver
      */
-    s3BucketArns: string[];
+    s3BucketNames: string[];
     /**
      * Create Namespace with the provided one (will not if namespace is kube-system)
      */
@@ -36,7 +36,7 @@ const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
   version: "v1.11.0",
   repository: "https://awslabs.github.io/mountpoint-s3-csi-driver",
   createNamespace: false,
-  s3BucketArns: []
+  s3BucketNames: []
 };
 
 @supportsALL
@@ -59,7 +59,7 @@ export class S3CSIDriverAddOn extends HelmAddOn {
 
         const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {
             statements:
-                getS3DriverPolicyStatements(this.options.s3BucketArns)
+                getS3DriverPolicyStatements(this.options.s3BucketNames)
         });
         serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
         


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Tweak the new S3 CSI Addon so it supports multiple S3 buckets.  Looking at the CSI Driver itself, it does support multiple bucket; it's just the Service Account creation here which is currently constrained to a single bucket name.

One thing I'm not sure on is how this changes the Props object - it means consumers will have to change their usage.  I could instead make s3BucketNames a `string | string[]` to handle this, but I'm not sure if its worth the effort.  What are your thoughts?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
