### PR TITLE
S3 CSI Driver - add support for Customer Managed KMS Keys

### DIFF
--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -22,11 +22,11 @@ export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
     /**
      * The ARNs of KMS Keys to be used by the driver.  Required if you are using Customer Managed Keys for S3
      */
-    kmsArns?: string[]
+    kmsArns?: string[];
     /**
      * Create Namespace with the provided one (will not if namespace is kube-system)
      */
-    createNamespace?: boolean
+    createNamespace?: boolean;
 }
 
 /**

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -20,6 +20,10 @@ export interface S3CSIDriverAddOnProps extends HelmAddOnUserProps {
      */
     bucketNames: string[];
     /**
+     * The ARNs of KMS Keys to be used by the driver.  Required if you are using Customer Managed Keys for S3
+     */
+    kmsArns?: string[]
+    /**
      * Create Namespace with the provided one (will not if namespace is kube-system)
      */
     createNamespace?: boolean
@@ -36,7 +40,8 @@ const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
   version: "v1.11.0",
   repository: "https://awslabs.github.io/mountpoint-s3-csi-driver",
   createNamespace: false,
-  bucketNames: []
+  bucketNames: [],
+  kmsArns: []
 };
 
 @supportsALL
@@ -59,7 +64,7 @@ export class S3CSIDriverAddOn extends HelmAddOn {
 
         const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {
             statements:
-                getS3DriverPolicyStatements(this.options.bucketNames)
+                getS3DriverPolicyStatements(this.options.bucketNames, this.options.kmsArns ?? [])
         });
         serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
         


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
The IAM policy for the S3 CSI Driver is missing permissions for customer managed KMS keys (when used).  This PR adds support for specifying KMS Keys by ARN.  The new props property is optional as I suspect this isn't going be needed most of the time!

Note: the kms permissions detailed in the Policy are enough to get it all working for me; I struggled to find any documentation to confirm that this includes all permissions we may need.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
