### PR TITLE
Adding dependency on instance role

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -790,6 +790,7 @@ export class KarpenterAddOn extends HelmAddOn {
             instanceProfileName: `KarpenterNodeInstanceProfile-${instanceProfileName}`,
             path: '/'
         });
+        karpenterInstanceProfile.node.addDependency(karpenterNodeRole);
 
         const clusterId = Names.uniqueId(cluster);
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The instance profile created has a dependency on the instance role, but this is not captured by the level 1 construct `CfnInstanceProfile`. Explicitly adding the dependency so that the addon can be reliably destroyed in CloudFormation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
