### PR TITLE
[cluster-provider] Add option httpPutResponseHopLimit to nodeGroup.launchTemplate

### DIFF
--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -47,6 +47,7 @@ const mng = builder()
 
         launchTemplate: {
             requireImdsv2: true, 
+            httpPutResponseHopLimit: 2,
             tags: {
                 "cost-center": "2122", 
                 "old-cost-center": "2322",

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -418,6 +418,7 @@ export class GenericClusterProvider implements ClusterProvider {
                 securityGroup: nodeGroup.launchTemplate.securityGroup,
                 userData: nodeGroup.launchTemplate?.userData,
                 requireImdsv2: nodeGroup.launchTemplate?.requireImdsv2,
+                httpPutResponseHopLimit: nodeGroup.launchTemplate?.httpPutResponseHopLimit,
             });
             utils.setPath(nodegroupOptions, "launchTemplateSpec", {
                 id: lt.launchTemplateId!,

--- a/lib/cluster-providers/types.ts
+++ b/lib/cluster-providers/types.ts
@@ -36,6 +36,15 @@ export interface LaunchTemplateProps {
      * Security group to assign to instances created with the launch template.
      */
     securityGroup?: ec2.ISecurityGroup;
+
+    /**
+     * The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel.
+     *
+     * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-httpputresponsehoplimit
+     *
+     * @default 1
+     */
+    readonly httpPutResponseHopLimit?: number;
 }
 
 
@@ -44,7 +53,7 @@ export interface ManagedNodeGroup extends Omit<eks.NodegroupOptions, "launchTemp
     /**
      * Id of this node group. Expected to be unique in cluster scope.
      */
-    id: string, 
+    id: string,
 
     /**
      * Min size of the node group
@@ -113,7 +122,7 @@ export interface AutoscalingNodeGroup extends Omit<AutoScalingGroupCapacityOptio
     /**
      * Id of this node group. Expected to be unique in cluster scope.
      */
-    id: string, 
+    id: string,
 
     /**
      * Min size of the node group

--- a/test/resource-providers/resource-proxy.test.ts
+++ b/test/resource-providers/resource-proxy.test.ts
@@ -128,6 +128,7 @@ describe("ResourceProxy",() => {
                 id: "mng1",
                 launchTemplate: {
                     requireImdsv2: true,
+                    httpPutResponseHopLimit: 2,
                 },
             }],
         });


### PR DESCRIPTION
*Issue #, if available:* #1128

*Description of changes:*
Add option `httpPutResponseHopLimit` to `nodeGroup.launchTemplate`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
