### PR TITLE
Feature/amp collector configurable resource limits

### DIFF
--- a/lib/addons/amp/collector-config-amp.ytpl
+++ b/lib/addons/amp/collector-config-amp.ytpl
@@ -12,8 +12,8 @@ spec:
   image: public.ecr.aws/aws-observability/aws-otel-collector:v0.41.1
   resources:
     limits:
-      cpu: "1"
-      memory: "2Gi"
+      cpu: "{{cpuLimit}}"
+      memory: "{{memoryLimit}}"
     requests:
       cpu: "1"
       memory: "2Gi"  

--- a/lib/addons/amp/index.ts
+++ b/lib/addons/amp/index.ts
@@ -80,6 +80,18 @@ export interface AmpAddOnProps {
      * If not provided, the default will be used.
      */
     openTelemetryCollector?: OpenTelemetryCollector;
+
+    /**
+     * Memory limit for the ADOT Collector for AMP.
+     * @default 2Gi
+     */
+    memoryLimit?: any;
+
+    /**
+     * CPU limit for the ADOT Collector for AMP.
+     * @default 1
+     */
+    cpuLimit?: any;
 }
 
 export const enum DeploymentMode {
@@ -96,7 +108,9 @@ const defaultProps = {
     deploymentMode: DeploymentMode.DEPLOYMENT,
     name: 'adot-collector-amp',
     namespace: 'default',
-    enableAPIserverJob: false
+    enableAPIserverJob: false,
+    memoryLimit: '2Gi',
+    cpuLimit: '1'
 };
 
 /**
@@ -145,6 +159,8 @@ export class AmpAddOn implements ClusterAddOn {
             remoteWriteEndpoint: attrPrometheusEndpoint,
             awsRegion: cluster.stack.region,
             deploymentMode: this.ampAddOnProps.deploymentMode,
+            cpuLimit: this.ampAddOnProps.cpuLimit,
+            memoryLimit: this.ampAddOnProps.memoryLimit,
             namespace: this.ampAddOnProps.namespace,
             clusterName: cluster.clusterName,
             ...this.ampAddOnProps.openTelemetryCollector?.manifestParameterMap

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "copyfiles": "^2.4.1",
-    "eslint": "^8.56.0",
+    "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "json-schema-to-typescript": "^15.0.2",
     "lint": "^1.1.2",

--- a/test/amp.test.ts
+++ b/test/amp.test.ts
@@ -55,3 +55,29 @@ test("Stack creation fails due to ruleFilePaths.length == 0", async () => {
     }
     fail("Expected exception wasnt thrown for AMP Addon-on Rule Path test.");
 });
+    
+test("Stack creation succeeds with resource limits", async () => {
+    const app = new cdk.App();
+
+    const blueprint = blueprints.EksBlueprint.builder();
+
+    const stack = await blueprint.account("123567891").region('us-west-1').version("auto")
+    .addOns(new blueprints.addons.AwsLoadBalancerControllerAddOn())
+    .addOns(new blueprints.addons.CertManagerAddOn())
+    .addOns(new blueprints.addons.AdotCollectorAddOn())
+    .addOns(
+        new blueprints.addons.AmpAddOn({
+            ampPrometheusEndpoint: "test",
+            memoryLimit: "4Gi",
+            cpuLimit: "2",
+            ampRules: {
+                ampWorkspaceArn: "test",
+                ruleFilePaths: [
+                    __dirname + "/resources/recording-rules-test.yml",
+                ]
+            }
+        })
+    )
+    .buildAsync(app, 'amp-addon-stack-succeeds');
+    expect(stack).toBeDefined();
+});


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-quickstart/cdk-eks-blueprints/issues/1116

*Description of changes:*
Made resource limit configurable on AMP collector. This will support running AMP collector on larger EKS clusters. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
