### PR TITLE
Pin aws/secrets-store-csi-driver-provider-aws YAML installer to a git version

### DIFF
--- a/lib/addons/secrets-store/index.ts
+++ b/lib/addons/secrets-store/index.ts
@@ -42,7 +42,7 @@ export interface SecretsStoreAddOnProps extends HelmAddOnUserProps {
  * Defaults options for the add-on
  */
 const defaultProps: SecretsStoreAddOnProps = {
-    ascpUrl: 'https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml',
+    ascpUrl: 'https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/secrets-store-csi-driver-provider-aws-0.3.11/deployment/aws-provider-installer.yaml',
     chart: 'secrets-store-csi-driver',
     name: 'secrets-store-csi-driver',
     namespace: 'kube-system',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The main branch of aws/secrets-store-csi-driver-provider-aws is a constant work in progress. The only authoritative things we release are:
- container images and their associated tags
- helm chart versions
- git version tags

We recommend you please pin the URL for the provider installation yaml instead of pointing to the tip of main. This recently broke a customer [here](https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/457).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
