### PR TITLE
IngressNginxAddon: set helm.wait=true

### DIFF
--- a/lib/addons/ingress-nginx/index.ts
+++ b/lib/addons/ingress-nginx/index.ts
@@ -245,7 +245,7 @@ export class IngressNginxAddOn extends HelmAddOn {
 
         // Merge user-defined values with defaults for the Helm chart deployment
         const mergedValues = merge(values, this.props.values ?? {});
-        const nginxHelmChart = this.addHelmChart(clusterInfo, mergedValues);
+        const nginxHelmChart = this.addHelmChart(clusterInfo, mergedValues, undefined, true);
 
         return Promise.resolve(nginxHelmChart);
     }


### PR DESCRIPTION
*Description of changes:*

I'm not sure if this is the correct wait to go about this - but because this addon doesn't have `wait: true` set, it's not actually possible to `@depends` on this for installing things into the cluster. It kind of feels like all provided addons should have this set, so that things aren't potentially deploying out of order.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
