### PR TITLE
Allow volume expansion on ebs csi driver

### DIFF
--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -33,7 +33,7 @@ export type EbsCsiDriverAddOnProps = Omit<CoreAddOnProps, "policyDocumentProvide
    */
   storageClass?: string;
   /**
-   * Determines whether the storage class should allow volume expansion or not.
+   * Determines whether the default storage class created by the addon should allow volume expansion or not.
    * @default false
    */
   allowVolumeExpansion?: boolean;


### PR DESCRIPTION
*Issue #, if available:*
I recently deployed the EBS CSI Driver addon on my EKS cluster using the provided add-on.
I needed to expand the volumes created by the CSI, but I noticed that the Storage Class that gets created by the add-on has the [allowVolumeExpansion ](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) parameter set to the default value, which is false.
However, I didn't find any way to change that if not manually from the Storage Class manifest itself.

*Description of changes:*
- Add allowVolumeExpansion property to EbsCsiDriverAddOnProps
- Set allowVolumeExpansion to false on defaultProps
- Set allowVolumeExpansion on the Storage Class manifest to the corresponding value inside ebsProps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
