### PR TITLE
fix: use global SPN which is now supported in all regions

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -564,7 +564,7 @@ export class KarpenterAddOn extends HelmAddOn {
     private setUpNodeRole(cluster: Cluster, stackName: string, region: string): [iam.Role, iam.CfnInstanceProfile] {
         // Set up Node Role
         const karpenterNodeRole = new iam.Role(cluster, 'karpenter-node-role', {
-            assumedBy: new iam.ServicePrincipal(`ec2.${cluster.stack.urlSuffix}`),
+            assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
             managedPolicies: [
                 iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
                 iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKS_CNI_Policy"),

--- a/lib/addons/karpenter/karpenter-v1.ts
+++ b/lib/addons/karpenter/karpenter-v1.ts
@@ -360,7 +360,7 @@ export class KarpenterV1AddOn extends HelmAddOn {
     ): [iam.Role, iam.CfnInstanceProfile] {
         // Set up Node Role
         const karpenterNodeRole = new iam.Role(cluster, "karpenter-node-role", {
-            assumedBy: new iam.ServicePrincipal(`ec2.${cluster.stack.urlSuffix}`),
+            assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
             managedPolicies: [
                 iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKSWorkerNodePolicy"),
                 iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonEKS_CNI_Policy"),


### PR DESCRIPTION
SPN construction using `service + urlSuffix` is not valid in all partitions, including EUSC. 

See comment [here](https://github.com/aws/aws-cdk/blob/c68f2f5961b24fba3f4a4b769e355b00d91fd6a1/packages/aws-cdk-lib/region-info/lib/default.ts#L27):
> Service principals are now globally `<SERVICE>.amazonaws.com`, use iam.ServicePrincipal instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
