### PR TITLE
Bugfix/s3mountpoint fails rbac

### DIFF
--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -3,7 +3,6 @@ import { ClusterInfo } from "../../spi";
 import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { createNamespace, setPath, supportsALL } from "../../utils";
-import { ReplaceServiceAccount } from "../../utils/sa-utils";
 import { getS3DriverPolicyStatements } from "./iam-policy";
 
 const S3_CSI_DRIVER_SA = 's3-csi-driver-sa';
@@ -68,10 +67,10 @@ export class S3CSIDriverAddOn extends HelmAddOn {
         const s3CsiDriverChart = this.addHelmChart(clusterInfo, chartValues, true, true);
 
         // Overwrite the Helm-created SA with IRSA annotation (fires after chart)
-        const serviceAccount = new ReplaceServiceAccount(cluster, S3_CSI_DRIVER_SA, {
-            cluster,
+        const serviceAccount = cluster.addServiceAccount(S3_CSI_DRIVER_SA, {
             name: S3_CSI_DRIVER_SA,
             namespace: this.options.namespace,
+            overwriteServiceAccount: true
         });
 
         const s3BucketPolicy = new iam.Policy(cluster, S3_DRIVER_POLICY, {

--- a/lib/addons/s3-csi-driver/index.ts
+++ b/lib/addons/s3-csi-driver/index.ts
@@ -3,6 +3,7 @@ import { ClusterInfo } from "../../spi";
 import { HelmAddOn, HelmAddOnUserProps } from "../helm-addon";
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { createNamespace, setPath, supportsALL } from "../../utils";
+import { ReplaceServiceAccount } from "../../utils/sa-utils";
 import { getS3DriverPolicyStatements } from "./iam-policy";
 
 const S3_CSI_DRIVER_SA = 's3-csi-driver-sa';
@@ -37,7 +38,7 @@ const defaultProps: HelmAddOnUserProps & S3CSIDriverAddOnProps = {
   name: S3_CSI_DRIVER,
   namespace: "kube-system",
   release: S3_CSI_DRIVER_RELEASE,
-  version: "2.4.0",
+  version: "2.4.1",
   repository: "https://awslabs.github.io/mountpoint-s3-csi-driver",
   createNamespace: false,
   bucketNames: [],
@@ -55,9 +56,20 @@ export class S3CSIDriverAddOn extends HelmAddOn {
     }
 
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
-        // Create service account and policy
         const cluster = clusterInfo.cluster;
-        const serviceAccount = cluster.addServiceAccount(S3_CSI_DRIVER_SA, {
+
+        // Create namespace
+        if (this.options.createNamespace) {
+            createNamespace(this.options.namespace!, cluster, true);
+        }
+
+        // Let Helm create the node SA with RBAC bindings
+        const chartValues = populateValues(this.options);
+        const s3CsiDriverChart = this.addHelmChart(clusterInfo, chartValues, true, true);
+
+        // Overwrite the Helm-created SA with IRSA annotation (fires after chart)
+        const serviceAccount = new ReplaceServiceAccount(cluster, S3_CSI_DRIVER_SA, {
+            cluster,
             name: S3_CSI_DRIVER_SA,
             namespace: this.options.namespace,
         });
@@ -67,28 +79,15 @@ export class S3CSIDriverAddOn extends HelmAddOn {
                 getS3DriverPolicyStatements(this.options.bucketNames, this.options.kmsArns ?? [])
         });
         serviceAccount.role.attachInlinePolicy(s3BucketPolicy);
-        
-        // Create namespace
-        if (this.options.createNamespace) {
-            const ns = createNamespace(this.options.namespace!, cluster, true);
-            serviceAccount.node.addDependency(ns);
-        }
 
-        // setup value for helm chart
-        const chartValues = populateValues(this.options, serviceAccount.serviceAccountName);
-
-        const s3CsiDriverChart = this.addHelmChart(clusterInfo, chartValues, true, true);
-        s3CsiDriverChart.node.addDependency(serviceAccount);
+        serviceAccount.node.addDependency(s3CsiDriverChart);
         return Promise.resolve(s3CsiDriverChart);
     }
 }
 
-function populateValues(helmOptions: S3CSIDriverAddOnProps, serviceAccountName: string): any {
+function populateValues(helmOptions: S3CSIDriverAddOnProps): any {
     const values = helmOptions.values ?? {};
-    // Only configure the node service account (which needs S3 access)
-    setPath(values, 'node.serviceAccount.create', false);
-    setPath(values, 'node.serviceAccount.name', serviceAccountName);
-    // Let Helm create the controller service account (no S3 access needed)
+    setPath(values, 'node.serviceAccount.create', true);
     setPath(values, 'controller.serviceAccount.create', true);
     setPath(values, 'node.tolerateAllTaints', true);
     return values;

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -3,7 +3,7 @@ import * as eks from "aws-cdk-lib/aws-eks";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from 'constructs';
 import { ClusterInfo, Values } from "../../spi";
-import { loadYaml, readYamlDocument, ReplaceServiceAccount, supportsALL, conflictsWithAutoMode, AutoModeConflictType} from "../../utils";
+import { loadYaml, readYamlDocument, supportsALL, conflictsWithAutoMode, AutoModeConflictType} from "../../utils";
 import { CoreAddOn, CoreAddOnProps } from "../core-addon";
 import { KubectlProvider, ManifestDeployment } from "../helm-addon/kubectl-provider";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
@@ -426,14 +426,14 @@ export class VpcCniAddOn extends CoreAddOn {
    * @returns 
    */
   createServiceAccount(clusterInfo: ClusterInfo, saNamespace: string, policies: iam.IManagedPolicy[]): eks.ServiceAccount {
-    const sa = new ReplaceServiceAccount(clusterInfo.cluster, `${this.coreAddOnProps.saName}-sa`, {
-      cluster: clusterInfo.cluster,
+    const sa = clusterInfo.cluster.addServiceAccount(`${this.coreAddOnProps.saName}-sa`, {
       name: this.coreAddOnProps.saName,
-      namespace: saNamespace
+      namespace: saNamespace,
+      overwriteServiceAccount: true
     });
 
     policies.forEach(p => sa.role.addManagedPolicy(p));
-    return sa as any as eks.ServiceAccount;
+    return sa;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-quickstart/eks-blueprints",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixed S3 CSI driver issue - pod failing with no RBAC entries after helm added one more service account for the controller. Also move for 2.4.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
