### PR TITLE
add EKS Kubernetes 1.35 support

### DIFF
--- a/examples/eks-1-35.ts
+++ b/examples/eks-1-35.ts
@@ -1,0 +1,17 @@
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
+import * as blueprints from '../lib';
+
+const app = new cdk.App();
+
+const account = process.env.CDK_DEFAULT_ACCOUNT;
+const region = process.env.CDK_DEFAULT_REGION;
+
+const stack = blueprints.EksBlueprint.builder()
+    .account(account)
+    .region(region)
+    .version(KubernetesVersion.V1_35)
+    .build(app, 'eks-1-35-debug-stack');
+
+void stack;

--- a/lib/addons/aws-network-flow-monitor/index.ts
+++ b/lib/addons/aws-network-flow-monitor/index.ts
@@ -16,6 +16,7 @@ export interface AwsNetworkFlowMonitorAddOnProps {
 
 /* VersioMap showing the default version for supported Kubernetes versions */
 const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_35, "v1.1.3-eksbuild.3"],
   [KubernetesVersion.V1_34, "v1.1.3-eksbuild.2"],
   [KubernetesVersion.V1_33, "v1.1.3-eksbuild.2"],
   [KubernetesVersion.V1_32, "v1.1.3-eksbuild.2"],

--- a/lib/addons/cloud-watch-insights/index.ts
+++ b/lib/addons/cloud-watch-insights/index.ts
@@ -11,6 +11,7 @@ import {KubernetesVersion} from "aws-cdk-lib/aws-eks";
 //     --query 'addons[].addonVersions[].{Version: addonVersion, Defaultversion: compatibilities[0].defaultVersion}' --output table
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_35, "v5.3.1-eksbuild.1"],
     [KubernetesVersion.V1_34, "v4.10.1-eksbuild.1"],
     [KubernetesVersion.V1_33, "v4.10.1-eksbuild.1"],
     [KubernetesVersion.V1_32, "v4.10.1-eksbuild.1"],

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -7,6 +7,7 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_35, "v1.13.2-eksbuild.3"],
     [KubernetesVersion.V1_34, "v1.12.3-eksbuild.1"],
     [KubernetesVersion.V1_33, "v1.12.1-eksbuild.2"],
     [KubernetesVersion.V1_32, "v1.11.4-eksbuild.2"],

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -10,6 +10,7 @@ import { KubernetesManifest, KubernetesPatch } from "aws-cdk-lib/aws-eks";
 
 /* VersioMap showing the default version for 4 supported Kubernetes versions */
 const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_35, "v1.57.1-eksbuild.1"],
   [KubernetesVersion.V1_34, "v1.56.0-eksbuild.1"],
   [KubernetesVersion.V1_33, "v1.56.0-eksbuild.1"],
   [KubernetesVersion.V1_32, "v1.56.0-eksbuild.1"],

--- a/lib/addons/eks-pod-identity-agent/index.ts
+++ b/lib/addons/eks-pod-identity-agent/index.ts
@@ -5,6 +5,7 @@ import { Cluster, KubernetesVersion } from "aws-cdk-lib/aws-eks";
 import * as utils from "../../utils";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+    [KubernetesVersion.V1_35, "v1.3.10-eksbuild.2"],
     [KubernetesVersion.V1_34, "v1.3.10-eksbuild.2"],
     [KubernetesVersion.V1_33, "v1.3.10-eksbuild.2"],
     [KubernetesVersion.V1_32, "v1.3.10-eksbuild.2"],

--- a/lib/addons/kube-proxy/index.ts
+++ b/lib/addons/kube-proxy/index.ts
@@ -5,6 +5,7 @@ import { ClusterInfo } from "../../spi/types";
 import { Construct } from "constructs";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_35, "v1.35.0-eksbuild.2"],
   [KubernetesVersion.V1_34, "v1.34.0-eksbuild.2"],
   [KubernetesVersion.V1_33, "v1.33.3-eksbuild.4"],
   [KubernetesVersion.V1_32, "v1.32.6-eksbuild.12"],
@@ -17,7 +18,7 @@ const versionMap: Map<KubernetesVersion, string> = new Map([
 ]);
 
 /**
- * Configuration options for the coredns add-on.
+ * Configuration options for the kube-proxy add-on.
  */
 export type kubeProxyAddOnProps = Omit<CoreAddOnProps, "saName" | "addOnName" | "version" >;
 

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -9,6 +9,7 @@ import { KubectlProvider, ManifestDeployment } from "../helm-addon/kubectl-provi
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_35, "v1.21.1-eksbuild.1"],
   [KubernetesVersion.V1_34, "v1.20.4-eksbuild.2"],
   [KubernetesVersion.V1_33, "v1.20.4-eksbuild.2"],
   [KubernetesVersion.V1_32, "v1.20.4-eksbuild.2"],

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -4,6 +4,7 @@ import { KubectlV31Layer } from "@aws-cdk/lambda-layer-kubectl-v31";
 import { KubectlV32Layer } from "@aws-cdk/lambda-layer-kubectl-v32";
 import { KubectlV33Layer } from "@aws-cdk/lambda-layer-kubectl-v33";
 import { KubectlV34Layer } from "@aws-cdk/lambda-layer-kubectl-v34";
+import { KubectlV35Layer } from "@aws-cdk/lambda-layer-kubectl-v35";
 
 import { Tags } from "aws-cdk-lib";
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
@@ -44,13 +45,15 @@ export function selectKubectlLayer(scope: Construct, version: eks.KubernetesVers
             return new KubectlV33Layer(scope, "kubectllayer33");
         case "1.34":
             return new KubectlV34Layer(scope, "kubectllayer34");
+        case "1.35":
+            return new KubectlV35Layer(scope, "kubectllayer35");
 
     }
 
     const minor = version.version.split('.')[1];
 
-    if(minor && parseInt(minor, 10) > 34) {
-        return new KubectlV34Layer(scope, "kubectllayer34"); // for all versions above 1.34 use 1.34 kubectl (unless explicitly supported in CDK)
+    if(minor && parseInt(minor, 10) > 35) {
+        return new KubectlV35Layer(scope, "kubectllayer35"); // for all versions above 1.35 use 1.35 kubectl (unless explicitly supported in CDK)
     }
     return undefined;
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@aws-cdk/lambda-layer-kubectl-v32": "^2.0.0",
     "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0",
     "@aws-cdk/lambda-layer-kubectl-v34": "^2.0.0",
+    "@aws-cdk/lambda-layer-kubectl-v35": "^2.0.0",
     "@aws-sdk/client-eks": "^3.844.0",
     "@aws-sdk/client-secrets-manager": "^3.844.0",
     "@types/assert": "^1.5.10",

--- a/test/clusterprovider.test.ts
+++ b/test/clusterprovider.test.ts
@@ -251,6 +251,7 @@ test("Asg cluster provider correctly initializes self-managed node group", () =>
 });
 
 test.each([
+  [KubernetesVersion.V1_35, "1.35"],
   [KubernetesVersion.V1_30, "1.30"],
   [KubernetesVersion.V1_31, "1.31"],
   [KubernetesVersion.V1_32, "1.32"],


### PR DESCRIPTION
- add Kubernetes 1.35 support
- added 1.35 version mappings for managed EKS add-ons
  - managed add-on versions for Kubernetes 1.35 were checked against `aws eks describe-addon-versions` and updated to the current AWS recommended default versions (e.g. `aws eks describe-addon-versions --addon-name adot --kubernetes-version 1.35 --query 'addons[0].addonVersions[?compatibilities[0].defaultVersion==`true`].addonVersion' --output text --region us-east-1`)
- updated cluster provider kubectl layer selection to use the v1.35 kubectl layer for Kubernetes 1.35
