### PR TITLE
Add adot version map for EKS 1.35

### DIFF
--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -8,6 +8,7 @@ import { getAdotCollectorPolicyDocument } from "./iam-policy";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_35, "v0.151.0-eksbuild.1"],
   [KubernetesVersion.V1_34, "v0.141.0-eksbuild.1"],
   [KubernetesVersion.V1_33, "v0.141.0-eksbuild.1"],
   [KubernetesVersion.V1_32, "v0.141.0-eksbuild.1"],


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds version mapping for ADOT addon in EKS v1.35.  Uses the default version output from:
`aws eks describe-addon-versions --addon-name adot --kubernetes-version 1.35`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
