### PR TITLE
Karpenter: split controller IAM policy, add missing permissions, fix example AMI

### DIFF
--- a/examples/blueprint-construct/index.ts
+++ b/examples/blueprint-construct/index.ts
@@ -84,7 +84,11 @@ export default class BlueprintConstruct {
     this.nodeClassSpec = {
       amiFamily: "Bottlerocket",
       amiSelectorTerms: [
-        { alias: "bottlerocket@v1.34.0" },
+        // Use the `@latest` alias so the AMI resolves to the newest Bottlerocket build for the
+        // cluster's Kubernetes version. A pinned version (e.g. bottlerocket@v1.34.0) refers to a
+        // Bottlerocket OS release, not the K8s version, and can fail to resolve ("failed to discover
+        // any AMIs for alias") — which also breaks as the default cluster version advances.
+        { alias: "bottlerocket@latest" },
       ],
       subnetSelectorTerms: [
         { tags: { Name: `${blueprintID}/${blueprintID}-vpc/PrivateSubnet*` } },

--- a/lib/addons/karpenter/iam.ts
+++ b/lib/addons/karpenter/iam.ts
@@ -33,8 +33,20 @@ export const KarpenterControllerPolicy = {
     ]
 };
 
-// IAM Policy for Beta CRD Karpenter addons
-export const KarpenterControllerPolicyBeta = (cluster: Cluster, partition: string, region: string) => {
+/**
+ * Builds the full (combined) scoped Karpenter controller policy document.
+ *
+ * This scoped policy is shared by the legacy v1beta1-generation addon and the stable-v1 addon
+ * (`KarpenterV1AddOn`): the controller IAM permissions did not materially change between the
+ * v1beta1 and stable-v1 CRD generations, so a single definition serves both.
+ *
+ * The document embeds the cluster name repeatedly in its tag-scoped conditions, so for clusters with
+ * long names a single combined managed policy can exceed the IAM managed-policy size quota
+ * (6,144 chars). To stay under the limit, callers can attach it as several scoped managed policies
+ * via {@link KarpenterControllerPolicyV1Groups}, mirroring upstream Karpenter
+ * (aws/karpenter-provider-aws#8690).
+ */
+const buildScopedKarpenterControllerPolicyDocument = (cluster: Cluster, partition: string, region: string) => {
     const condition1 = new CfnJson(cluster.stack, 'condition-owned-request-tag', {
         value: {
             [`aws:RequestTag/kubernetes.io/cluster/${cluster.clusterName}`]: "owned"
@@ -176,11 +188,14 @@ export const KarpenterControllerPolicyBeta = (cluster: Cluster, partition: strin
                 "Resource": "*",
                 "Action": [
                     "ec2:DescribeAvailabilityZones",
+                    "ec2:DescribeCapacityReservations",
                     "ec2:DescribeImages",
                     "ec2:DescribeInstances",
+                    "ec2:DescribeInstanceStatus",
                     "ec2:DescribeInstanceTypeOfferings",
                     "ec2:DescribeInstanceTypes",
                     "ec2:DescribeLaunchTemplates",
+                    "ec2:DescribePlacementGroups",
                     "ec2:DescribeSecurityGroups",
                     "ec2:DescribeSpotPriceHistory",
                     "ec2:DescribeSubnets"
@@ -262,9 +277,91 @@ export const KarpenterControllerPolicyBeta = (cluster: Cluster, partition: strin
                 "Effect": "Allow",
                 "Resource": `${cluster.clusterArn}`,
                 "Action": "eks:DescribeCluster"
-            }    
+            },
+            {
+                "Sid": "AllowZonalShiftStatusReadOnly",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                    "arc-zonal-shift:GetManagedResource"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "arc-zonal-shift:ResourceIdentifier": `${cluster.clusterArn}`
+                    }
+                }
+            }
         ]
     };
 };
 
+/**
+ * Sids that make up each named controller policy, mirroring the policy split upstream Karpenter uses
+ * (aws/karpenter-provider-aws#8690). The interruption-queue permissions are not listed here; the
+ * addon adds them separately as their own policy, and only when interruption handling is enabled.
+ */
+const KARPENTER_CONTROLLER_POLICY_SIDS = {
+    nodeLifecycle: [
+        "AllowScopedEC2InstanceActions",
+        "AllowScopedEC2InstanceActionsWithTags",
+        "AllowScopedResourceCreationTagging",
+        "AllowScopedResourceTagging",
+        "AllowScopedDeletion",
+    ],
+    iamIntegration: [
+        "AllowScopedInstanceProfileCreationActions",
+        "AllowScopedInstanceProfileTagActions",
+        "AllowScopedInstanceProfileActions",
+        "AllowInstanceProfileReadActions",
+    ],
+    eksIntegration: [
+        "AllowAPIServerEndpointDiscovery",
+    ],
+    resourceDiscovery: [
+        "AllowRegionalReadActions",
+        "AllowSSMReadActions",
+        "AllowPricingReadActions",
+    ],
+    zonalShift: [
+        "AllowZonalShiftStatusReadOnly",
+    ],
+} as const;
+
+/** Names of the scoped Karpenter controller policies (mirrors upstream's policy names). */
+export type KarpenterControllerPolicyName = keyof typeof KARPENTER_CONTROLLER_POLICY_SIDS;
+
+/**
+ * Scoped Karpenter controller policy as a single combined document. Introduced for the v1beta1 CRD
+ * generation (hence the historical `Beta` name) and still used by the legacy `KarpenterAddOn`.
+ */
+export const KarpenterControllerPolicyBeta = (cluster: Cluster, partition: string, region: string) =>
+    buildScopedKarpenterControllerPolicyDocument(cluster, partition, region);
+
+/**
+ * The same scoped controller policy, split into separate named documents — `nodeLifecycle`,
+ * `iamIntegration`, `eksIntegration`, `resourceDiscovery`, and `zonalShift` — each meant to be
+ * attached as its own managed policy. This keeps every managed policy under the IAM managed-policy
+ * size quota even for clusters with long names (the cluster name is embedded repeatedly in the
+ * tag-scoped conditions), mirroring upstream Karpenter (aws/karpenter-provider-aws#8690).
+ */
+export const KarpenterControllerPolicyV1Groups = (cluster: Cluster, partition: string, region: string): Record<KarpenterControllerPolicyName, object> => {
+    const statements = buildScopedKarpenterControllerPolicyDocument(cluster, partition, region).Statement as any[];
+    const documentFor = (sids: readonly string[]) => ({
+        "Version": "2012-10-17",
+        "Statement": statements.filter((statement) => sids.includes(statement.Sid)),
+    });
+    return {
+        nodeLifecycle: documentFor(KARPENTER_CONTROLLER_POLICY_SIDS.nodeLifecycle),
+        iamIntegration: documentFor(KARPENTER_CONTROLLER_POLICY_SIDS.iamIntegration),
+        eksIntegration: documentFor(KARPENTER_CONTROLLER_POLICY_SIDS.eksIntegration),
+        resourceDiscovery: documentFor(KARPENTER_CONTROLLER_POLICY_SIDS.resourceDiscovery),
+        zonalShift: documentFor(KARPENTER_CONTROLLER_POLICY_SIDS.zonalShift),
+    };
+};
+
+/**
+ * Alias retained for backward compatibility. The controller IAM permissions are shared between the
+ * v1beta1 and stable-v1 CRD generations. Prefer {@link KarpenterControllerPolicyV1Groups} for the
+ * stable-v1 addon so the permissions are attached as multiple size-bounded managed policies.
+ */
 export const KarpenterControllerPolicyV1 = KarpenterControllerPolicyBeta;

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -21,6 +21,7 @@ export * from './karpenter-v1';
 
 class versionMap {
     private static readonly versionMap: Map<string, string> = new Map([
+        [KubernetesVersion.V1_35.version, "1.6.0"],
         [KubernetesVersion.V1_34.version, "1.6.0"],
         [KubernetesVersion.V1_33.version, '1.5.0'],
         [KubernetesVersion.V1_32.version, '1.2.0'],

--- a/lib/addons/karpenter/karpenter-v1.ts
+++ b/lib/addons/karpenter/karpenter-v1.ts
@@ -11,7 +11,7 @@ import { ClusterInfo } from "../../spi";
 import * as semver from "semver";
 import * as assert from "assert";
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from "../helm-addon";
-import { KarpenterControllerPolicyV1 } from "./iam";
+import { KarpenterControllerPolicyV1Groups } from "./iam";
 import { Ec2NodeClassV1Spec, NodePoolV1Spec, KARPENTER, RELEASE } from "./types";
 import { Cluster as Clusterv2, AccessEntryType } from 'aws-cdk-lib/aws-eks-v2';
 import * as md5 from "ts-md5";
@@ -161,14 +161,16 @@ export class KarpenterV1AddOn extends HelmAddOn {
         // Set up the node role and instance profile
         const [karpenterNodeRole] = this.setUpNodeRole(cluster, stackName, region, clusterInfo.clusterv2 as Clusterv2);
 
-        // Create the controller policy
-        let karpenterPolicyDocument;
+        // Create the controller policies. Mirroring upstream Karpenter (aws/karpenter-provider-aws#8690),
+        // the controller permissions are attached as several small, purpose-named managed policies
+        // instead of one combined policy. The cluster name is embedded repeatedly in the tag-scoped
+        // conditions, so a single managed policy can exceed the IAM managed-policy size quota
+        // (6,144 chars) for clusters with long names; splitting keeps each policy under the limit.
+        const controllerPolicyDocuments = KarpenterControllerPolicyV1Groups(cluster, partition, region);
 
-        karpenterPolicyDocument = iam.PolicyDocument.fromJson(
-            KarpenterControllerPolicyV1(cluster, partition, region)
-        );
-
-        karpenterPolicyDocument.addStatements(
+        // iam:PassRole for the node role belongs with the IAM-integration policy.
+        const iamIntegrationDocument = iam.PolicyDocument.fromJson(controllerPolicyDocuments.iamIntegration);
+        iamIntegrationDocument.addStatements(
             new iam.PolicyStatement({
                 effect: iam.Effect.ALLOW,
                 actions: ["iam:PassRole"],
@@ -176,11 +178,38 @@ export class KarpenterV1AddOn extends HelmAddOn {
             })
         );
 
-        // Support for Native spot interruption
+        const nodeLifecyclePolicy = new iam.ManagedPolicy(cluster, `${RELEASE}-node-lifecycle-policy`, {
+            document: iam.PolicyDocument.fromJson(controllerPolicyDocuments.nodeLifecycle),
+        });
+        const iamIntegrationPolicy = new iam.ManagedPolicy(cluster, `${RELEASE}-iam-integration-policy`, {
+            document: iamIntegrationDocument,
+        });
+        const eksIntegrationPolicy = new iam.ManagedPolicy(cluster, `${RELEASE}-eks-integration-policy`, {
+            document: iam.PolicyDocument.fromJson(controllerPolicyDocuments.eksIntegration),
+        });
+        const resourceDiscoveryPolicy = new iam.ManagedPolicy(cluster, `${RELEASE}-resource-discovery-policy`, {
+            document: iam.PolicyDocument.fromJson(controllerPolicyDocuments.resourceDiscovery),
+        });
+        const zonalShiftPolicy = new iam.ManagedPolicy(cluster, `${RELEASE}-zonal-shift-policy`, {
+            document: iam.PolicyDocument.fromJson(controllerPolicyDocuments.zonalShift),
+        });
+
+        const controllerManagedPolicies: iam.IManagedPolicy[] = [
+            nodeLifecyclePolicy,
+            iamIntegrationPolicy,
+            eksIntegrationPolicy,
+            resourceDiscoveryPolicy,
+            zonalShiftPolicy,
+        ];
+
+        // Support for Native spot interruption: attach the interruption-queue permissions as their
+        // own managed policy (mirrors upstream's InterruptionPolicy), only when enabled.
         if (interruption) {
-            // Add policy to the node role to allow access to the Interruption Queue
             const interruptionQueueStatement = this.createInterruptionQueue(cluster, stackName);
-            karpenterPolicyDocument.addStatements(interruptionQueueStatement);
+            const interruptionPolicy = new iam.ManagedPolicy(cluster, `${RELEASE}-interruption-policy`, {
+                document: new iam.PolicyDocument({ statements: [interruptionQueueStatement] }),
+            });
+            controllerManagedPolicies.push(interruptionPolicy);
         }
 
         // Create Namespace
@@ -189,19 +218,22 @@ export class KarpenterV1AddOn extends HelmAddOn {
         let sa: any;
         let saAnnotation: any;
         if (podIdentity) {
-            sa = utils.podIdentityAssociation(
+            sa = utils.podIdentityAssociationWithPolicies(
                 cluster,
                 RELEASE,
                 this.options.namespace!,
-                karpenterPolicyDocument
+                ...controllerManagedPolicies
             );
             saAnnotation = {};
         } else {
-            sa = utils.createServiceAccount(
+            // identityType left as default (IRSA); the controller permissions are supplied as the
+            // named managed policies above.
+            sa = utils.createServiceAccountWithPolicy(
                 cluster,
                 RELEASE,
                 this.options.namespace!,
-                karpenterPolicyDocument
+                undefined,
+                ...controllerManagedPolicies
             );
             saAnnotation = { "eks.amazonaws.com/role-arn": sa.role.roleArn };
         }

--- a/lib/cluster-providers/generic-cluster-provider.ts
+++ b/lib/cluster-providers/generic-cluster-provider.ts
@@ -358,9 +358,12 @@ export class GenericClusterProvider implements ClusterProvider {
         const machineImageType = nodeGroup.machineImageType ?? eks.MachineImageType.AMAZON_LINUX_2;
         const instanceTypeContext = utils.valueFromContext(cluster, constants.INSTANCE_TYPE_KEY, constants.DEFAULT_INSTANCE_TYPE);
         const instanceType = nodeGroup.instanceType ?? (typeof instanceTypeContext === 'string' ? new ec2.InstanceType(instanceTypeContext) : instanceTypeContext);
-        const minSize = nodeGroup.minSize ?? utils.valueFromContext(cluster, constants.MIN_SIZE_KEY, constants.DEFAULT_NG_MINSIZE);
         const maxSize = nodeGroup.maxSize ?? utils.valueFromContext(cluster, constants.MAX_SIZE_KEY, constants.DEFAULT_NG_MAXSIZE);
-        const desiredSize = nodeGroup.desiredSize ?? utils.valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize);
+        // Clamp the defaulted min/desired sizes so they never exceed an explicitly smaller maxSize
+        // (e.g. a node group that only sets maxSize: 1). Explicitly-provided minSize/desiredSize are
+        // respected as-is, so genuine user misconfigurations still surface.
+        const minSize = nodeGroup.minSize ?? Math.min(utils.valueFromContext(cluster, constants.MIN_SIZE_KEY, constants.DEFAULT_NG_MINSIZE), maxSize);
+        const desiredSize = nodeGroup.desiredSize ?? Math.min(utils.valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize), maxSize);
         const updatePolicy = nodeGroup.updatePolicy ?? autoscaling.UpdatePolicy.rollingUpdate();
 
         // Create an autoscaling group
@@ -398,9 +401,12 @@ export class GenericClusterProvider implements ClusterProvider {
         const instanceTypeContext = utils.valueFromContext(cluster, constants.INSTANCE_TYPE_KEY, constants.DEFAULT_INSTANCE_TYPE);
         const instanceTypes = nodeGroup.instanceTypes ?? ([typeof instanceTypeContext === 'string' ? new ec2.InstanceType(instanceTypeContext) : instanceTypeContext]);
         const amiType = nodeGroup.amiType ?? constants.DEFAULT_AMI;
-        const minSize = nodeGroup.minSize ?? utils.valueFromContext(cluster, constants.MIN_SIZE_KEY, constants.DEFAULT_NG_MINSIZE);
         const maxSize = nodeGroup.maxSize ?? utils.valueFromContext(cluster, constants.MAX_SIZE_KEY, constants.DEFAULT_NG_MAXSIZE);
-        const desiredSize = nodeGroup.desiredSize ?? utils.valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize);
+        // Clamp the defaulted min/desired sizes so they never exceed an explicitly smaller maxSize
+        // (e.g. a node group that only sets maxSize: 1). Explicitly-provided minSize/desiredSize are
+        // respected as-is, so genuine user misconfigurations still surface.
+        const minSize = nodeGroup.minSize ?? Math.min(utils.valueFromContext(cluster, constants.MIN_SIZE_KEY, constants.DEFAULT_NG_MINSIZE), maxSize);
+        const desiredSize = nodeGroup.desiredSize ?? Math.min(utils.valueFromContext(cluster, constants.DESIRED_SIZE_KEY, minSize), maxSize);
 
         // Create a managed node group.
         const nodegroupOptions: utils.Writeable<eks.NodegroupOptions> = {

--- a/lib/utils/pod-identity-utils.ts
+++ b/lib/utils/pod-identity-utils.ts
@@ -19,7 +19,27 @@ export function podIdentityAssociation(
   const policy = new iam.ManagedPolicy(cluster, `${name}-managed-policy`, {
     document: policyDocument,
   });
+  return podIdentityAssociationWithPolicies(cluster, name, namespace, policy);
+}
 
+/**
+ * Same as {@link podIdentityAssociation}, but attaches one or more pre-built managed policies to the
+ * pod identity role. Useful when a permission set must be split across multiple managed policies to
+ * stay under the IAM managed-policy size quota (e.g. the Karpenter controller).
+ *
+ * @param cluster
+ * @param name
+ * @param namespace
+ * @param policies one or more managed policies to attach to the pod identity role
+ *
+ * @returns podIdentityAssociation
+ */
+export function podIdentityAssociationWithPolicies(
+  cluster: ICluster,
+  name: string,
+  namespace: string,
+  ...policies: iam.IManagedPolicy[]
+): CfnPodIdentityAssociation {
   const role = new iam.Role(cluster, `${name}-role`, {
     assumedBy: new iam.ServicePrincipal("pods.eks.amazonaws.com"),
   });
@@ -33,7 +53,7 @@ export function podIdentityAssociation(
       principals: [new iam.ServicePrincipal("pods.eks.amazonaws.com")],
     })
   );
-  role.addManagedPolicy(policy);
+  policies.forEach((policy) => role.addManagedPolicy(policy));
 
   const podIdentityAssociation = new CfnPodIdentityAssociation(cluster, `${name}-pod-identity-association`, {
     clusterName: cluster.clusterName,


### PR DESCRIPTION
## What this includes

**1. Split the Karpenter controller IAM policy into several smaller policies.**
Before, all Karpenter permissions were in one IAM managed policy. The cluster name is repeated many times inside it, so for clusters with long names it can go over the IAM policy size limit (6,144 characters) and fail. This splits it into smaller named policies (node lifecycle, IAM integration, EKS integration, resource discovery, zonal shift, interruption), the same way upstream Karpenter did (aws/karpenter-provider-aws#8690).

**2. Added permissions Karpenter needs that were missing.**
`ec2:DescribeCapacityReservations`, `ec2:DescribeInstanceStatus`, `ec2:DescribePlacementGroups`, and `arc-zonal-shift:GetManagedResource`. Without these, features like capacity reservations, placement groups, and zonal shift would fail.

**3. Fixed the example AMI in `blueprint-construct`.**
It pointed at `bottlerocket@v1.34.0`, which is not a real AMI and did not resolve. Changed to `bottlerocket@latest` so it always finds a valid AMI for the cluster's Kubernetes version.

**4. Two small test fixes** (needed after the 1.19.0 merge):
- Node groups that set only `maxSize` no longer fail because of the new default minimum size.
- Added EKS 1.35 to the Karpenter version map (1.35 is now the default).

## How it was tested

- Unit tests pass (41/41).
- Deployed to a live 1.35 cluster: the update was clean, the controller role now has the split policies, and the controller kept running.
- Confirmed Karpenter can still create a node (launched a node, ran a pod, then removed it).
- Confirmed `bottlerocket@latest` resolves to a valid AMI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.